### PR TITLE
UIDS Add palette colors

### DIFF
--- a/scss/palette.scss
+++ b/scss/palette.scss
@@ -1,3 +1,67 @@
+$ux-black: #000000;
 $ux-blue: #337ab7;
+$ux-dark-blue: #639BB8;
 $ux-green: #6DBD63;
+$ux-light-blue: #7CCBF2;
+$ux-light-purple: #8B008B;
+$ux-orange: #F59C27;
+$ux-purple: #420039;
+$ux-red: #FF4E00;
 $ux-white: #FFFFFF;
+$ux-yellow: #F6D810;
+
+$brand-color-facebook: #4C67A1;
+$brand-color-google: #DB3236;
+$brand-color-linkedin: #0077B5;
+$brand-color-office365: #2372BA;
+$brand-color-twitter: #1B95E0;
+
+$ux-blue-100: #EBF6FF;
+$ux-blue-200: #C9E5FC;
+$ux-blue-300: #92CBFC;
+$ux-blue-400: #5AA4E5;
+$ux-blue-500: $ux-blue;
+$ux-blue-600: #155B99;
+$ux-blue-700: #0D4473;
+$ux-blue-800: #083054;
+$ux-blue-900: #032847;
+
+$ux-gray-100: #F9F9F9;
+$ux-gray-200: #F1F1F1;
+$ux-gray-300: #E1E1E1;
+$ux-gray-400: #D1D1D1;
+$ux-gray-500: #A1A1A1;
+$ux-gray-600: #818181;
+$ux-gray-700: #616161;
+$ux-gray-800: #444444;
+$ux-gray-900: #222222;
+
+$ux-green-100: #F3FFF2;
+$ux-green-200: #E3FDE0;
+$ux-green-300: #BFFEB8;
+$ux-green-400: #85DC7A;
+$ux-green-500: $ux-green;
+$ux-green-600: #47A13B;
+$ux-green-700: #297021;
+$ux-green-800: #1A5313;
+$ux-green-900: #0E4207;
+
+$ux-orange-100: #FDEAD2;
+$ux-orange-200: #FCDFB9;
+$ux-orange-300: #FAC988;
+$ux-orange-400: #F7B258;
+$ux-orange-500: $ux-orange;
+$ux-orange-600: #E18C28;
+$ux-orange-700: #AE6608;
+$ux-orange-800: #7D4A06;
+$ux-orange-900: #653B05;
+
+$ux-red-100: #F0D9D9;
+$ux-red-200: #E8C5CB;
+$ux-red-300: #EB7A7A;
+$ux-red-400: #E44E4E;
+$ux-red-500: $ux-red;
+$ux-red-600: #C71F1F;
+$ux-red-700: #B11B1B;
+$ux-red-800: #9B1818;
+$ux-red-900: #851414;


### PR DESCRIPTION
Closes #2 

These are all taken from [here](https://github.com/user-interviews/rails-server/blob/master/app/assets/stylesheets/pipeline_shared/_ux_theme.scss) in the main app. We should audit these to make sure we want them all and we like the current naming/terminology.

The rest of the styles in that file seemed app-specific and we want to keep this as general as possible I think. That being said, if there's an argument to moving any of the others that didn't make the cut I'd like to hear it.