### PR TITLE
CHORE update Input helper text color to be accessible

### DIFF
--- a/src/InputLabel/InputLabel.scss
+++ b/src/InputLabel/InputLabel.scss
@@ -6,6 +6,6 @@
 
   &__helper-text {
     @include font-type-30;
-    color: $ux-gray-600;
+    color: $ux-gray-800;
   }
 }


### PR DESCRIPTION
Before:
![Screen Shot 2020-11-25 at 2 35 27 PM](https://user-images.githubusercontent.com/4555430/100288408-77816500-2f2b-11eb-9aad-a11a11f0272a.png)



After:
![Screen Shot 2020-11-25 at 2 34 07 PM](https://user-images.githubusercontent.com/4555430/100288328-486af380-2f2b-11eb-8125-6c890601b591.png)
