### PR TITLE
CHORE Add forwardRef to RadioButton and some styling tweaks

### DIFF
--- a/src/CheckboxButton/CheckboxButton.jsx
+++ b/src/CheckboxButton/CheckboxButton.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const CheckboxButton = ({
+const CheckboxButton = React.forwardRef(({
   checked,
   className,
   disabled,
@@ -11,7 +11,7 @@ const CheckboxButton = ({
   value,
   onChange,
   ...rest
-}) => (
+}, ref) => (
   <input
     checked={checked}
     className={className}
@@ -19,12 +19,13 @@ const CheckboxButton = ({
     id={id}
     indeterminate={indeterminate}
     name={name}
+    ref={ref}
     type="checkbox"
     value={value}
     onChange={onChange}
     {...rest}
   />
-);
+));
 
 CheckboxButton.propTypes = {
   checked: PropTypes.bool,
@@ -36,6 +37,7 @@ CheckboxButton.propTypes = {
   value: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,
+    PropTypes.bool,
   ]),
   onChange: PropTypes.func,
 };
@@ -49,5 +51,7 @@ CheckboxButton.defaultProps = {
   value: undefined,
   onChange: undefined,
 };
+
+CheckboxButton.displayName = 'CheckboxButton';
 
 export default CheckboxButton;

--- a/src/FormControlLabel/FormControlLabel.jsx
+++ b/src/FormControlLabel/FormControlLabel.jsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 
 import 'scss/forms/form_control_label.scss';
 
-export default function FormControlLabel({
+const FormControlLabel = React.forwardRef(({
   bordered,
   checked,
   className,
@@ -12,10 +12,9 @@ export default function FormControlLabel({
   id,
   text,
   ...controlProps
-}) {
-  return (
-    <label
-      className={classnames(
+}, ref) => (
+  <label
+    className={classnames(
         'FormControlLabel',
         className,
         {
@@ -23,19 +22,18 @@ export default function FormControlLabel({
           'FormControlLabel--active': bordered && checked,
         },
       )}
-      htmlFor={id}
-    >
-      <Control checked={checked} className="FormControlLabel__control" id={id} {...controlProps} />
-      {text}
-    </label>
-  );
-}
+    htmlFor={id}
+  >
+    <Control checked={checked} className="FormControlLabel__control" id={id} ref={ref} {...controlProps} />
+    {text}
+  </label>
+  ));
 
 FormControlLabel.propTypes = {
   bordered: PropTypes.bool,
   checked: PropTypes.bool,
   className: PropTypes.string,
-  Control: PropTypes.func.isRequired,
+  Control: PropTypes.oneOfType([PropTypes.func, PropTypes.object]).isRequired,
   id: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
 };
@@ -45,3 +43,7 @@ FormControlLabel.defaultProps = {
   checked: undefined,
   className: undefined,
 };
+
+FormControlLabel.displayName = 'FormControlLabel';
+
+export default FormControlLabel;

--- a/src/Input/Input.jsx
+++ b/src/Input/Input.jsx
@@ -80,4 +80,6 @@ Input.defaultProps = {
   onChange: undefined,
 };
 
+Input.displayName = 'Input';
+
 export default Input;

--- a/src/RadioButton/RadioButton.jsx
+++ b/src/RadioButton/RadioButton.jsx
@@ -12,12 +12,15 @@ const RadioButton = React.forwardRef((props, ref) => {
   return (
     <label className={classNames}>
       <input
+        checked={props.checked}
         className="RadioButton__input"
         disabled={props.disabled}
         id={props.id}
         name={props.name}
         ref={ref}
         type="radio"
+        value={props.value}
+        onChange={props.onChange}
         {...props.radioButtonProps}
       />
 
@@ -36,20 +39,32 @@ const RadioButton = React.forwardRef((props, ref) => {
 
 RadioButton.propTypes = {
   bordered: PropTypes.bool,
+  checked: PropTypes.bool,
   children: PropTypes.node,
   disabled: PropTypes.bool,
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   name: PropTypes.string,
   radioButtonProps: PropTypes.object,
+  value: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+    PropTypes.bool,
+  ]),
+  onChange: PropTypes.func,
 };
 
 RadioButton.defaultProps = {
   bordered: false,
+  checked: undefined,
   children: null,
   disabled: false,
   name: '',
   radioButtonProps: {},
+  value: undefined,
+  onChange: undefined,
 };
+
+RadioButton.displayName = 'RadioButton';
 
 export default RadioButton;

--- a/src/RadioButtonGroup/RadioButtonGroup.scss
+++ b/src/RadioButtonGroup/RadioButtonGroup.scss
@@ -8,6 +8,7 @@
 
     .RadioButton {
       margin-right: 0.5rem;
+      display: block;
     }
    }
 


### PR DESCRIPTION
Added forwardRef for use with React Hook Form and a few styling tweaks:
- Radio buttons that are part of a RadioButtonGroup should have bold text
- Added row orientation to RadioButtonGroup
- Additional padding b/t buttons in RadioButtonGroup

Unclear if we may need more tweaks after the first radio goes through review but I think these are the most obvious ones. I paused the refactoring of RadioButton for now due to time constraints as it wasn't blocking yet.