### PR TITLE
CHORE Update radio button row layout to stretch full width

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -2759,7 +2759,7 @@ exports[`Storyshots Design System/Styles/Color Palette Gray 1`] = `
     <div
       style={
         Object {
-          "backgroundColor": "#222222",
+          "backgroundColor": "#101010",
           "flexBasis": "11%",
           "height": "100%",
         }

--- a/src/RadioButton/RadioButton.scss
+++ b/src/RadioButton/RadioButton.scss
@@ -7,6 +7,9 @@
   padding: 0.5rem;
   border: 1px solid transparent;
   flex-wrap: wrap;
+  flex: 1 1 0;
+  cursor: pointer;
+  min-width: 16rem;
 
   &--bordered {
     border: 1px solid $ux-gray-400;


### PR DESCRIPTION
Small tweak to the RadioButton row layout to stretch the full width of the container:
<img width="773" alt="Screen Shot 2020-12-09 at 9 51 47 AM" src="https://user-images.githubusercontent.com/4008333/101667416-2b8eef80-3a04-11eb-8365-cc8eb9dc5fb4.png">
