### PR TITLE
UIDS-87 Part one: allow FormControlLabel to accept children

### DIFF
--- a/scss/forms/form_control_label.scss
+++ b/scss/forms/form_control_label.scss
@@ -6,9 +6,29 @@
   align-items: center;
   display: flex;
 
+  &--with-children {
+    align-items: flex-start;
+    flex-direction: column;
+    display: flex;
+  }
+
+  &__label {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+  }
+
   &__control {
     display: flex;
-    margin-right: .25rem;
+    margin-right: .5rem;
+  }
+
+  &__children {
+    @include font-type-30;
+
+    color: $ux-gray-800;
+    margin-top: 0.5rem;
+    width: 100%;
   }
 
   &--bordered {
@@ -16,16 +36,7 @@
 
     border: 1px solid $ux-gray-400;
     border-radius: $ux-border-radius;
+    padding: 1rem;
     cursor: pointer;
-    padding: 0.3125rem 0.625rem;
-    margin-right: 0.5rem;
-  }
-
-  &--active {
-    @include font-type-30--bold;
-
-    background-color: $ux-blue-100;
-    color: $ux-blue-700;
-    border-color: $ux-blue-200;
   }
 }

--- a/src/CheckboxButtonGroup/CheckboxButtonGroup.scss
+++ b/src/CheckboxButtonGroup/CheckboxButtonGroup.scss
@@ -9,4 +9,18 @@
   label {
     margin-bottom: 0.5rem;
   }
+
+  .FormControlLabel--bordered {
+    padding: 0.3125rem 0.625rem;
+    margin-right: 0.5rem;
+  }
+
+  .FormControlLabel--active {
+    background-color: $ux-blue-100;
+    border-color: $ux-blue-200;
+
+    &__label {
+      color: $ux-blue-700;
+    }
+  }
 }

--- a/src/FormControlLabel/FormControlLabel.jsx
+++ b/src/FormControlLabel/FormControlLabel.jsx
@@ -7,6 +7,7 @@ import 'scss/forms/form_control_label.scss';
 const FormControlLabel = React.forwardRef(({
   bordered,
   checked,
+  children,
   className,
   Control,
   id,
@@ -15,19 +16,33 @@ const FormControlLabel = React.forwardRef(({
 }, ref) => (
   <label
     className={classnames(
-        'FormControlLabel',
-        className,
-        {
-          'FormControlLabel--bordered': bordered,
-          'FormControlLabel--active': bordered && checked,
-        },
-      )}
+      'FormControlLabel',
+      className,
+      {
+        'FormControlLabel--bordered': bordered,
+        'FormControlLabel--active': checked,
+        'FormControlLabel--with-children': !!children,
+      },
+    )}
     htmlFor={id}
   >
-    <Control checked={checked} className="FormControlLabel__control" id={id} ref={ref} {...controlProps} />
-    {text}
+    <div className="FormControlLabel__label">
+      <Control
+        checked={checked}
+        className="FormControlLabel__control"
+        id={id}
+        ref={ref}
+        {...controlProps}
+      />
+      {text}
+    </div>
+    {children && (
+      <div className="FormControlLabel__children">
+        {children}
+      </div>
+    )}
   </label>
-  ));
+));
 
 FormControlLabel.propTypes = {
   bordered: PropTypes.bool,

--- a/src/RadioButton/RadioButton.scss
+++ b/src/RadioButton/RadioButton.scss
@@ -18,11 +18,18 @@
 
   &__label {
     flex-grow: 1;
-    margin-left: 0.5rem;
+    vertical-align: middle;
+  }
+
+  &__input {
+    margin-right: 0.5rem;
+    vertical-align: middle;
   }
 
   &__children {
+    @include font-type-30;
     margin-top: 0.5rem;
     width: 100%;
+    color: $ux-gray-800;
   }
 }

--- a/src/RadioButtonGroup/RadioButtonGroup.scss
+++ b/src/RadioButtonGroup/RadioButtonGroup.scss
@@ -10,12 +10,16 @@
       margin-right: 0.5rem;
       display: block;
     }
+
+    .RadioButton:last-child {
+      margin-right: 0;
+    }
    }
 
-  .RadioButton {
+  .RadioButton--bordered {
     padding: 1rem;
 
-    &__label {
+    .RadioButton__label {
       @include font-type-30--bold;
     }
   }

--- a/stories/Form Elements/FormControlLabel.stories.jsx
+++ b/stories/Form Elements/FormControlLabel.stories.jsx
@@ -38,3 +38,17 @@ export const Checkbox = () => (
     value="1"
   />
 );
+
+export const CheckboxWithChildren = () => (
+  <FormControlLabelCheckboxComponent
+    bordered
+    Control={CheckboxButton}
+    id="checkbox"
+    name="checkbox"
+    text="Labeled checkbox"
+    type="checkbox"
+    value="1"
+  >
+    <div>This checkbox has some helper text too!</div>
+  </FormControlLabelCheckboxComponent>
+);

--- a/stories/Form Elements/RadioButton.stories.jsx
+++ b/stories/Form Elements/RadioButton.stories.jsx
@@ -49,14 +49,14 @@ export const WithRadioButtonGroup = () => (
       id="radio-1"
       label={text('First Label', 'First option with child')}
     >
-      <span style={{ color: colors.uxGray800 }}>Some descriptive text for the option above</span>
+      <span>Some descriptive text for the option above</span>
     </RadioButton>
     <RadioButton
       bordered
       id="radio-2"
       label={text('Second Label', 'Second option with child')}
     >
-      <span style={{ color: colors.uxGray800 }}>And another option to choose from</span>
+      <span>And another option to choose from</span>
     </RadioButton>
   </RadioButtonGroup>
 );


### PR DESCRIPTION
This doesn't completely finish this issue b/c we still have the refactor of `RadioButton` component, but I am not touching that for now b/c it will require a decent amount of changes in the app. But this branch enables `FormControlLabel` to accept children, so we can use that for helper text associated with checkboxes, like the Double screening checkbox:

Bordered checkbox not in a CheckboxButtonGroup
- Grey border
- No blue active state
- More padding (1rem)
- Children are ux-gray-800 and font-type-30 and fill the width

<img width="666" alt="Screen Shot 2020-12-09 at 12 27 20 PM" src="https://user-images.githubusercontent.com/4008333/101683551-ed042f80-3a19-11eb-815e-c3e0492b608b.png">


Bordered checkbox in a CheckboxButtonGroup
- Grey border
- Active state is highlighted blue
- Padding is tighter

<img width="552" alt="Screen Shot 2020-12-09 at 12 27 11 PM" src="https://user-images.githubusercontent.com/4008333/101683558-f1304d00-3a19-11eb-8709-5c39f9ea0d88.png">

