### PR TITLE
CHORE Update to disabled radio styles, tooltip font weight

### DIFF
--- a/scss/forms/form_control_label.scss
+++ b/scss/forms/form_control_label.scss
@@ -39,4 +39,19 @@
     padding: 1rem;
     cursor: pointer;
   }
+
+  &--disabled {
+    background-color: $ux-gray-100;
+    cursor: not-allowed;
+    color: $ux-gray-400;
+
+    .FormControlLabel__children {
+      color: $ux-gray-400;
+    }
+  }
+
+  input[type='checkbox'], input[type='radio'] {
+    min-height: 1rem;
+    min-width: 1rem;
+  }
 }

--- a/src/FormControlLabel/FormControlLabel.jsx
+++ b/src/FormControlLabel/FormControlLabel.jsx
@@ -10,6 +10,7 @@ const FormControlLabel = React.forwardRef(({
   children,
   className,
   Control,
+  disabled,
   id,
   text,
   ...controlProps
@@ -22,6 +23,7 @@ const FormControlLabel = React.forwardRef(({
         'FormControlLabel--bordered': bordered,
         'FormControlLabel--active': checked,
         'FormControlLabel--with-children': !!children,
+        'FormControlLabel--disabled': bordered && disabled,
       },
     )}
     htmlFor={id}
@@ -30,6 +32,7 @@ const FormControlLabel = React.forwardRef(({
       <Control
         checked={checked}
         className="FormControlLabel__control"
+        disabled={disabled}
         id={id}
         ref={ref}
         {...controlProps}
@@ -49,6 +52,7 @@ FormControlLabel.propTypes = {
   checked: PropTypes.bool,
   className: PropTypes.string,
   Control: PropTypes.oneOfType([PropTypes.func, PropTypes.object]).isRequired,
+  disabled: PropTypes.bool,
   id: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
 };
@@ -57,6 +61,7 @@ FormControlLabel.defaultProps = {
   bordered: false,
   checked: undefined,
   className: undefined,
+  disabled: undefined,
 };
 
 FormControlLabel.displayName = 'FormControlLabel';

--- a/src/Popper/Popper.scss
+++ b/src/Popper/Popper.scss
@@ -12,6 +12,7 @@
   z-index: $z-index-flash;
 
   &__header {
+    font-weight: $font-weight-bold;
     border-bottom: 1px solid $ux-gray-300;
     margin-bottom: 0.5rem;
   }
@@ -19,6 +20,5 @@
   &--dark {
     background-color: $ux-gray-800;
     color: $ux-gray-100;
-    font-weight: $font-weight-bold;
   }
 }

--- a/src/RadioButtonGroup/RadioButtonGroup.scss
+++ b/src/RadioButtonGroup/RadioButtonGroup.scss
@@ -5,6 +5,7 @@
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
+    margin-right: -0.5rem;
 
     &--full-width {
       width: 100%;
@@ -19,10 +20,6 @@
       margin-right: 0.5rem;
       min-width: 16rem;
       display: block;
-    }
-
-    .FormControlLabel:last-child {
-      margin-right: 0;
     }
   }
 }

--- a/src/Tooltip/Tooltip.scss
+++ b/src/Tooltip/Tooltip.scss
@@ -6,6 +6,7 @@
     cursor: pointer;
     margin-left: 0.5rem;
     margin-right: 0.5rem;
+    vertical-align: middle;
 
     &--gray {
       color: $ux-gray-800;

--- a/stories/Form Elements/FormControlLabel.stories.jsx
+++ b/stories/Form Elements/FormControlLabel.stories.jsx
@@ -32,6 +32,7 @@ export const Checkbox = () => (
   <FormControlLabelControlComponent
     bordered={boolean('Bordered button', false)}
     Control={CheckboxButton}
+    disabled={boolean('Disabled', false)}
     id="checkbox"
     name="checkbox"
     text="Labeled checkbox"


### PR DESCRIPTION
Design feedback from https://github.com/user-interviews/rails-server/pull/5218
[ ] Fix checkbox shrinking on mobile
[ ] Give Tooltip messages font-weight 400
[ ] Vertically center tooltip icon
[ ] Fullwidth Radio buttons have extra right margin on mobile when they wrap to vertical column
