### PR TITLE
UIDS-121 Add support for html form post to Form component

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -272,6 +272,7 @@ exports[`Storyshots Design System/Form Default 1`] = `
   <form
     className="Form"
     id="form"
+    method="POST"
     onSubmit={[Function]}
   >
     <div
@@ -456,6 +457,7 @@ exports[`Storyshots Design System/Form Elements/Form Control Label Checkbox 1`] 
       <input
         checked={false}
         className="FormControlLabel__control"
+        disabled={false}
         id="checkbox"
         name="checkbox"
         onChange={[Function]}
@@ -1241,6 +1243,7 @@ exports[`Storyshots Design System/Form Inline 1`] = `
   <form
     className="Form Form--inline"
     id="form"
+    method="POST"
     onSubmit={[Function]}
   >
     <div

--- a/src/CopyToClipboardButton/CopyToClipboardButton.jsx
+++ b/src/CopyToClipboardButton/CopyToClipboardButton.jsx
@@ -64,7 +64,7 @@ CopyToClipboardButton.propTypes = {
   copyText: PropTypes.string,
   displayText: PropTypes.string,
   trackingEvent: PropTypes.string.isRequired,
-  variant: PropTypes.oneOf(Object.keys(ButtonVariants)),
+  variant: PropTypes.oneOf(Object.values(ButtonVariants)),
 };
 
 CopyToClipboardButton.defaultProps = {

--- a/src/Form/Form.jsx
+++ b/src/Form/Form.jsx
@@ -1,32 +1,70 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import './Form.scss';
 
-export default function Form(props) {
+const Form = forwardRef(({
+  action,
+  children,
+  className,
+  CSRFParam,
+  CSRFToken,
+  id,
+  inline,
+  method,
+  multipart,
+  name,
+  onSubmit,
+}, ref) => {
+  const hasMethod = method != null;
+  const hasCSRF = CSRFParam && CSRFToken;
+
   return (
     <form
-      className={classNames('Form', props.className, { 'Form--inline': props.inline })}
-      id={props.id}
-      onSubmit={props.onSubmit}
+      action={action}
+      className={classNames('Form', className, { 'Form--inline': inline })}
+      id={id}
+      method="POST"
+      multipart={multipart}
+      name={name}
+      ref={ref}
+      onSubmit={onSubmit}
     >
-      {props.children}
+      { hasCSRF && <input name={CSRFParam} type="hidden" value={CSRFToken} /> }
+      { hasMethod && <input name="_method" type="hidden" value={method} /> }
+      {children}
     </form>
   );
-}
+});
+
+Form.displayName = 'Form';
 
 Form.propTypes = {
+  action: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,
+  CSRFParam: PropTypes.string,
+  CSRFToken: PropTypes.string,
   id: PropTypes.string.isRequired,
   inline: PropTypes.bool,
+  method: PropTypes.string,
+  multipart: PropTypes.string,
+  name: PropTypes.string,
   onSubmit: PropTypes.func,
 };
 
 Form.defaultProps = {
+  action: undefined,
   children: undefined,
   className: undefined,
+  CSRFParam: undefined,
+  CSRFToken: undefined,
   inline: false,
+  method: undefined,
+  multipart: undefined,
+  name: undefined,
   onSubmit: undefined,
 };
+
+export default Form;


### PR DESCRIPTION
Closes #121 

Reproduces the existing behavior of the common/form component, which accepts an action prop and can support an html form POST in addition to an ajax call. The code is mostly taken from the rails-server component except that it can accept a CSRFToken and CSRFParam.