### PR TITLE
CHORE Update label font size for radio and checkbox, ensure wrapping on mobile

### DIFF
--- a/scss/forms/form_group.scss
+++ b/scss/forms/form_group.scss
@@ -15,11 +15,11 @@
     padding: 1rem;
 
     .InputLabel {
-      @include font-type-40--bold;
+      @include font-type-30--bold;
       margin-bottom: 0.5rem;
 
       &__helper-text {
-        @include font-type-40--light;
+        @include font-type-30--light;
         color: $ux-gray-900;
       }
     }

--- a/scss/forms/input_label.scss
+++ b/scss/forms/input_label.scss
@@ -4,6 +4,7 @@
 .InputLabel {
   @include font-type-30--bold;
   display: flex;
+  flex-wrap: wrap;
   margin-bottom: 0.375rem;
 
   &__helper-text {

--- a/spec/Flash/__snapshots__/withFlash.test.jsx.snap
+++ b/spec/Flash/__snapshots__/withFlash.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`test withFlash it can create a new flash message 1`] = `
 Array [
   <div
-    className="alert alert-success AlertMessage AlertMessage-success"
+    className="AlertMessage AlertMessage-success"
   >
     <button
       className="close"

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -9,7 +9,7 @@ exports[`Storyshots Design System/Alert With Dismiss 1`] = `
   }
 >
   <div
-    className="alert alert-success AlertMessage AlertMessage-success"
+    className="AlertMessage AlertMessage-success"
   >
     <button
       className="close"
@@ -37,7 +37,7 @@ exports[`Storyshots Design System/Alert Without Dismiss 1`] = `
   }
 >
   <div
-    className="alert alert-success AlertMessage AlertMessage-success"
+    className="AlertMessage AlertMessage-success"
   >
     <p
       className="AlertMessage__title"


### PR DESCRIPTION
Fixes a few styling changes requested on radio buttons and checkboxes:
- Changes font-size to 30 for labels
- Makes label helper text wrap to a new line on mobile

