### PR TITLE
Feature/UI ds 77 card component

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -2,7 +2,7 @@
   on:
     push:
       branches:
-        - master
+        - feature/UIDS-77-card-component
   jobs:
     gh-pages-deploy:
       name: Deploying to gh-pages

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -2,7 +2,7 @@
   on:
     push:
       branches:
-        - feature/UIDS-77-card-component
+        - master
   jobs:
     gh-pages-deploy:
       name: Deploying to gh-pages

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -60,11 +60,21 @@ exports[`Storyshots Design System/Card Default 1`] = `
   <section
     className="Card Card--lg"
   >
-    <h2
-      className="Card__title"
+    <div
+      className="Card__header"
     >
-      Large card with title
-    </h2>
+      <h2
+        className="Card__title"
+      >
+        Large card with title
+      </h2>
+      <span
+        className="Card__helper-text"
+      >
+         
+        (helper text)
+      </span>
+    </div>
     <h3
       className="Card__subtitle"
     >

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -60,16 +60,16 @@ exports[`Storyshots Design System/Card Default 1`] = `
   <section
     className="Card Card--lg"
   >
-    <div
+    <h2
       className="Card__title"
     >
       Large card with title
-    </div>
-    <div
+    </h2>
+    <h3
       className="Card__subtitle"
     >
       And a subtitle
-    </div>
+    </h3>
     <div>
       Use knobs to try out the different card sizes
     </div>

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -71,7 +71,6 @@ exports[`Storyshots Design System/Card Default 1`] = `
       <span
         className="Card__helper-text"
       >
-         
         (helper text)
       </span>
     </div>

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -49,6 +49,34 @@ exports[`Storyshots Design System/Alert Without Dismiss 1`] = `
 </div>
 `;
 
+exports[`Storyshots Design System/Card Default 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <section
+    className="Card Card--lg"
+  >
+    <div
+      className="Card__title"
+    >
+      Large card with title
+    </div>
+    <div
+      className="Card__subtitle"
+    >
+      And a subtitle
+    </div>
+    <div>
+      Use knobs to try out the different card sizes
+    </div>
+  </section>
+</div>
+`;
+
 exports[`Storyshots Design System/Copy To Clipboard Button Default 1`] = `
 <div
   style={
@@ -588,7 +616,7 @@ exports[`Storyshots Design System/Form Elements/Form Group Default 1`] = `
     className="FormGroup"
     id="default"
   >
-    
+
     <div
       className="Input input-group"
     >
@@ -1482,7 +1510,7 @@ exports[`Storyshots Design System/Selects/Async Default 1`] = `
                 }
               }
             >
-              
+
             </div>
           </div>
         </div>
@@ -1604,7 +1632,7 @@ exports[`Storyshots Design System/Selects/Async Labeled 1`] = `
                 }
               }
             >
-              
+
             </div>
           </div>
         </div>
@@ -1936,7 +1964,7 @@ exports[`Storyshots Design System/Selects/Single Searchable 1`] = `
                 }
               }
             >
-              
+
             </div>
           </div>
         </div>
@@ -2014,19 +2042,19 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
           </strong>
         </li>
         <li>
-          Type: 
+          Type:
           Lato, Arial, sans-serif
         </li>
         <li>
-          Size: 
+          Size:
           1.5rem
         </li>
         <li>
-          Line-height: 
+          Line-height:
           2rem
         </li>
         <li>
-          Weight: 
+          Weight:
           400 / Regular
         </li>
       </ul>
@@ -2089,19 +2117,19 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
           </strong>
         </li>
         <li>
-          Type: 
+          Type:
           Lato, Arial, sans-serif
         </li>
         <li>
-          Size: 
+          Size:
           1.25rem
         </li>
         <li>
-          Line-height: 
+          Line-height:
           1.625rem
         </li>
         <li>
-          Weight: 
+          Weight:
           400 / Regular
         </li>
       </ul>
@@ -2164,19 +2192,19 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
           </strong>
         </li>
         <li>
-          Type: 
+          Type:
           Lato, Arial, sans-serif
         </li>
         <li>
-          Size: 
+          Size:
           1.125rem
         </li>
         <li>
-          Line-height: 
+          Line-height:
           1.5rem
         </li>
         <li>
-          Weight: 
+          Weight:
           400 / Regular
         </li>
       </ul>
@@ -2239,19 +2267,19 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
           </strong>
         </li>
         <li>
-          Type: 
+          Type:
           Lato, Arial, sans-serif
         </li>
         <li>
-          Size: 
+          Size:
           1rem
         </li>
         <li>
-          Line-height: 
+          Line-height:
           1.375rem
         </li>
         <li>
-          Weight: 
+          Weight:
           400 / Regular
         </li>
       </ul>
@@ -2314,19 +2342,19 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
           </strong>
         </li>
         <li>
-          Type: 
+          Type:
           Lato, Arial, sans-serif
         </li>
         <li>
-          Size: 
+          Size:
           0.875rem
         </li>
         <li>
-          Line-height: 
+          Line-height:
           1.25rem
         </li>
         <li>
-          Weight: 
+          Weight:
           400 / Regular
         </li>
       </ul>
@@ -2389,19 +2417,19 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
           </strong>
         </li>
         <li>
-          Type: 
+          Type:
           Lato, Arial, sans-serif
         </li>
         <li>
-          Size: 
+          Size:
           0.75rem
         </li>
         <li>
-          Line-height: 
+          Line-height:
           1rem
         </li>
         <li>
-          Weight: 
+          Weight:
           400 / Regular
         </li>
       </ul>
@@ -2464,27 +2492,27 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
           </strong>
         </li>
         <li>
-          Type: 
+          Type:
           Lato, Arial, sans-serif
         </li>
         <li>
-          Size: 
+          Size:
           0.625rem
         </li>
         <li>
-          Line-height: 
+          Line-height:
           0.875rem
         </li>
         <li>
-          Weight: 
+          Weight:
           400 / Regular
         </li>
         <li>
-          Text-transform: 
+          Text-transform:
           Uppercase
         </li>
         <li>
-          Letter-spacing: 
+          Letter-spacing:
           0.0625rem
         </li>
       </ul>

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -616,7 +616,7 @@ exports[`Storyshots Design System/Form Elements/Form Group Default 1`] = `
     className="FormGroup"
     id="default"
   >
-
+    
     <div
       className="Input input-group"
     >
@@ -1510,7 +1510,7 @@ exports[`Storyshots Design System/Selects/Async Default 1`] = `
                 }
               }
             >
-
+              
             </div>
           </div>
         </div>
@@ -1632,7 +1632,7 @@ exports[`Storyshots Design System/Selects/Async Labeled 1`] = `
                 }
               }
             >
-
+              
             </div>
           </div>
         </div>
@@ -1964,7 +1964,7 @@ exports[`Storyshots Design System/Selects/Single Searchable 1`] = `
                 }
               }
             >
-
+              
             </div>
           </div>
         </div>
@@ -2042,19 +2042,19 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
           </strong>
         </li>
         <li>
-          Type:
+          Type: 
           Lato, Arial, sans-serif
         </li>
         <li>
-          Size:
+          Size: 
           1.5rem
         </li>
         <li>
-          Line-height:
+          Line-height: 
           2rem
         </li>
         <li>
-          Weight:
+          Weight: 
           400 / Regular
         </li>
       </ul>
@@ -2117,19 +2117,19 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
           </strong>
         </li>
         <li>
-          Type:
+          Type: 
           Lato, Arial, sans-serif
         </li>
         <li>
-          Size:
+          Size: 
           1.25rem
         </li>
         <li>
-          Line-height:
+          Line-height: 
           1.625rem
         </li>
         <li>
-          Weight:
+          Weight: 
           400 / Regular
         </li>
       </ul>
@@ -2192,19 +2192,19 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
           </strong>
         </li>
         <li>
-          Type:
+          Type: 
           Lato, Arial, sans-serif
         </li>
         <li>
-          Size:
+          Size: 
           1.125rem
         </li>
         <li>
-          Line-height:
+          Line-height: 
           1.5rem
         </li>
         <li>
-          Weight:
+          Weight: 
           400 / Regular
         </li>
       </ul>
@@ -2267,19 +2267,19 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
           </strong>
         </li>
         <li>
-          Type:
+          Type: 
           Lato, Arial, sans-serif
         </li>
         <li>
-          Size:
+          Size: 
           1rem
         </li>
         <li>
-          Line-height:
+          Line-height: 
           1.375rem
         </li>
         <li>
-          Weight:
+          Weight: 
           400 / Regular
         </li>
       </ul>
@@ -2342,19 +2342,19 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
           </strong>
         </li>
         <li>
-          Type:
+          Type: 
           Lato, Arial, sans-serif
         </li>
         <li>
-          Size:
+          Size: 
           0.875rem
         </li>
         <li>
-          Line-height:
+          Line-height: 
           1.25rem
         </li>
         <li>
-          Weight:
+          Weight: 
           400 / Regular
         </li>
       </ul>
@@ -2417,19 +2417,19 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
           </strong>
         </li>
         <li>
-          Type:
+          Type: 
           Lato, Arial, sans-serif
         </li>
         <li>
-          Size:
+          Size: 
           0.75rem
         </li>
         <li>
-          Line-height:
+          Line-height: 
           1rem
         </li>
         <li>
-          Weight:
+          Weight: 
           400 / Regular
         </li>
       </ul>
@@ -2492,27 +2492,27 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
           </strong>
         </li>
         <li>
-          Type:
+          Type: 
           Lato, Arial, sans-serif
         </li>
         <li>
-          Size:
+          Size: 
           0.625rem
         </li>
         <li>
-          Line-height:
+          Line-height: 
           0.875rem
         </li>
         <li>
-          Weight:
+          Weight: 
           400 / Regular
         </li>
         <li>
-          Text-transform:
+          Text-transform: 
           Uppercase
         </li>
         <li>
-          Letter-spacing:
+          Letter-spacing: 
           0.0625rem
         </li>
       </ul>

--- a/src/Card/Card.jsx
+++ b/src/Card/Card.jsx
@@ -12,7 +12,6 @@ export const CardSizes = {
 };
 
 const Card = ({
-  active,
   children,
   className,
   divided,
@@ -46,7 +45,6 @@ const Card = ({
         `Card--${size}`,
         className,
         {
-          'Card--active': active,
           'Card--divided': divided,
           'Card--no-padding': noPadding,
         },
@@ -57,7 +55,6 @@ const Card = ({
 };
 
 Card.propTypes = {
-  active: PropTypes.bool,
   className: PropTypes.string,
   divided: PropTypes.bool,
   elementType: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
@@ -69,7 +66,6 @@ Card.propTypes = {
 };
 
 Card.defaultProps = {
-  active: undefined,
   className: undefined,
   divided: false,
   elementType: 'section',

--- a/src/Card/Card.jsx
+++ b/src/Card/Card.jsx
@@ -25,7 +25,7 @@ const Card = ({
   const cardChildren = (
     <Fragment>
       { title && <h2 className="Card__title">{title}</h2> }
-      { subTitle && <h5 className="Card__subtitle">{subTitle}</h5> }
+      { subTitle && <h3 className="Card__subtitle">{subTitle}</h3> }
       { children }
     </Fragment>
   );

--- a/src/Card/Card.jsx
+++ b/src/Card/Card.jsx
@@ -15,10 +15,10 @@ const Card = ({
   active,
   children,
   className,
+  divided,
   elementType,
   helperText,
   noPadding,
-  ruled,
   size,
   subTitle,
   title,
@@ -28,10 +28,10 @@ const Card = ({
     <Fragment>
       <div className="Card__header">
         { title && <h2 className="Card__title">{title}</h2> }
-        { helperText && <span className="Card__helper-text">&nbsp;{helperText}</span>}
+        { helperText && <span className="Card__helper-text">{helperText}</span>}
       </div>
 
-      { ruled && <hr className="Card__rule" /> }
+      { divided && <hr className="Card__divider" /> }
       { subTitle && <h3 className="Card__subtitle">{subTitle}</h3> }
       { children }
     </Fragment>
@@ -47,8 +47,8 @@ const Card = ({
         className,
         {
           'Card--active': active,
+          'Card--divided': divided,
           'Card--no-padding': noPadding,
-          'Card--ruled': ruled,
         },
       ),
     },
@@ -59,10 +59,10 @@ const Card = ({
 Card.propTypes = {
   active: PropTypes.bool,
   className: PropTypes.string,
+  divided: PropTypes.bool,
   elementType: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   helperText: PropTypes.string,
   noPadding: PropTypes.bool,
-  ruled: PropTypes.bool,
   size: PropTypes.string,
   subTitle: PropTypes.string,
   title: PropTypes.string,
@@ -71,10 +71,10 @@ Card.propTypes = {
 Card.defaultProps = {
   active: undefined,
   className: undefined,
+  divided: false,
   elementType: 'section',
   helperText: undefined,
   noPadding: false,
-  ruled: false,
   size: CardSizes.LARGE,
   subTitle: undefined,
   title: undefined,

--- a/src/Card/Card.jsx
+++ b/src/Card/Card.jsx
@@ -31,8 +31,8 @@ const Card = ({
         { helperText && <span className="Card__helper-text">&nbsp;{helperText}</span>}
       </div>
 
-      { subTitle && <h3 className="Card__subtitle">{subTitle}</h3> }
       { ruled && <hr className="Card__rule" /> }
+      { subTitle && <h3 className="Card__subtitle">{subTitle}</h3> }
       { children }
     </Fragment>
   );

--- a/src/Card/Card.jsx
+++ b/src/Card/Card.jsx
@@ -17,6 +17,7 @@ const Card = ({
   className,
   elementType,
   noPadding,
+  ruled,
   size,
   subTitle,
   title,
@@ -26,6 +27,7 @@ const Card = ({
     <Fragment>
       { title && <h2 className="Card__title">{title}</h2> }
       { subTitle && <h3 className="Card__subtitle">{subTitle}</h3> }
+      { ruled && <hr className="Card__rule" /> }
       { children }
     </Fragment>
   );
@@ -38,8 +40,9 @@ const Card = ({
         `Card--${size}`,
         className,
         {
-          'Card--no-padding': noPadding,
           'Card--active': active,
+          'Card--no-padding': noPadding,
+          'Card--ruled': ruled,
         },
       ),
     },
@@ -52,6 +55,7 @@ Card.propTypes = {
   className: PropTypes.string,
   elementType: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   noPadding: PropTypes.bool,
+  ruled: PropTypes.bool,
   size: PropTypes.string,
   subTitle: PropTypes.string,
   title: PropTypes.string,
@@ -62,6 +66,7 @@ Card.defaultProps = {
   className: undefined,
   elementType: 'section',
   noPadding: false,
+  ruled: false,
   size: CardSizes.LARGE,
   subTitle: undefined,
   title: undefined,

--- a/src/Card/Card.jsx
+++ b/src/Card/Card.jsx
@@ -16,6 +16,7 @@ const Card = ({
   children,
   className,
   elementType,
+  helperText,
   noPadding,
   ruled,
   size,
@@ -25,12 +26,17 @@ const Card = ({
 }) => {
   const cardChildren = (
     <Fragment>
-      { title && <h2 className="Card__title">{title}</h2> }
+      <div className="Card__header">
+        { title && <h2 className="Card__title">{title}</h2> }
+        { helperText && <span className="Card__helper-text">&nbsp;{helperText}</span>}
+      </div>
+
       { subTitle && <h3 className="Card__subtitle">{subTitle}</h3> }
       { ruled && <hr className="Card__rule" /> }
       { children }
     </Fragment>
   );
+
   return createElement(
     elementType,
     {
@@ -54,6 +60,7 @@ Card.propTypes = {
   active: PropTypes.bool,
   className: PropTypes.string,
   elementType: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  helperText: PropTypes.string,
   noPadding: PropTypes.bool,
   ruled: PropTypes.bool,
   size: PropTypes.string,
@@ -65,6 +72,7 @@ Card.defaultProps = {
   active: undefined,
   className: undefined,
   elementType: 'section',
+  helperText: undefined,
   noPadding: false,
   ruled: false,
   size: CardSizes.LARGE,

--- a/src/Card/Card.jsx
+++ b/src/Card/Card.jsx
@@ -1,0 +1,70 @@
+import React, { createElement, Fragment } from 'react';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+
+import './Card.scss';
+
+export const CardSizes = {
+  EXTRA_SMALL: 'xs',
+  SMALL: 'sm',
+  MEDIUM: 'md',
+  LARGE: 'lg',
+};
+
+const Card = ({
+  active,
+  children,
+  className,
+  elementType,
+  noPadding,
+  size,
+  subTitle,
+  title,
+  ...props
+}) => {
+  const cardChildren = (
+    <Fragment>
+      { title && <h2 className="Card__title">{title}</h2> }
+      { subTitle && <h5 className="Card__subtitle">{subTitle}</h5> }
+      { children }
+    </Fragment>
+  );
+  return createElement(
+    elementType,
+    {
+      ...props,
+      className: classNames(
+        'Card',
+        `Card--${size}`,
+        className,
+        {
+          'Card--no-padding': noPadding,
+          'Card--active': active,
+        },
+      ),
+    },
+    cardChildren,
+  );
+};
+
+Card.propTypes = {
+  active: PropTypes.bool,
+  className: PropTypes.string,
+  elementType: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  noPadding: PropTypes.bool,
+  size: PropTypes.string,
+  subTitle: PropTypes.string,
+  title: PropTypes.string,
+};
+
+Card.defaultProps = {
+  active: undefined,
+  className: undefined,
+  elementType: 'section',
+  noPadding: false,
+  size: CardSizes.LARGE,
+  subTitle: undefined,
+  title: undefined,
+};
+
+export default Card;

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -5,6 +5,7 @@
 
 $card-xs-spacing: 1rem;
 $card-sm-spacing: 1.25rem;
+$card-spacing: 1.5rem;
 $card-width: 56rem;
 $card-width-md: 40rem;
 $card-width-sm: 32rem;
@@ -14,19 +15,14 @@ $card-width-xs: 15.625rem;
   background-color: $ux-white;
   border: none;
   box-shadow: 0 .125rem .25rem rgba(0,0,0,0.1);
-  margin: $card-xs-spacing auto;
+  margin: $card-spacing auto;
   outline-color: $ux-green-500;
-  padding: $card-xs-spacing;
+  padding: $card-spacing;
 
   width: calc(100% - #{$card-xs-spacing});
 
   @include media-breakpoint-up(sm) {
     width: calc(100% - 2rem);
-  }
-
-  @include media-breakpoint-up(sm) {
-    margin: $card-sm-spacing auto;
-    padding: $card-sm-spacing;
   }
 
   &__header {

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -36,6 +36,7 @@ $card-width-xs: 15.625rem;
 
   &__rule {
     border: 1px solid $ux-gray-400;
+    margin: 0.75rem auto;
   }
 
   &__subtitle {
@@ -53,6 +54,12 @@ $card-width-xs: 15.625rem;
 
   &--no-padding {
     padding: 0;
+  }
+
+  &--ruled {
+    .Card__title {
+      margin-bottom: 0;
+    }
   }
 
   &--md {

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -1,0 +1,66 @@
+@import '~bootstrap/scss/functions';
+@import '~bootstrap/scss/variables';
+@import '~bootstrap/scss/mixins/breakpoints';
+@import '../../scss/theme';
+
+$card-xs-spacing: 1rem;
+$card-sm-spacing: 1.25rem;
+$card-width: 56rem;
+$card-width-md: 40rem;
+$card-width-sm: 32rem;
+$card-width-xs: 15.625rem;
+
+.Card {
+  background-color: $ux-white;
+  border: none;
+  box-shadow: 0 .125rem .25rem rgba(0,0,0,0.1);
+  margin: $card-xs-spacing auto;
+  outline-color: $ux-green-500;
+  padding: $card-xs-spacing;
+
+  width: calc(100% - #{$card-xs-spacing});
+
+  @include media-breakpoint-up(sm) {
+    width: calc(100% - 2rem);
+  }
+
+  @include media-breakpoint-up(sm) {
+    margin: $card-sm-spacing auto;
+    padding: $card-sm-spacing;
+  }
+
+  &__title {
+    @include font-type-50;
+  }
+
+  &__subtitle {
+    @include font-type-30;
+    color: $ux-gray-700;
+  }
+
+  &--active {
+    outline: $ux-green-500 auto 5px;
+  }
+
+  &--no-padding {
+    padding: 0;
+  }
+
+  &--md {
+    @include media-breakpoint-up(sm) {
+      max-width: $card-width-md;
+    }
+  }
+
+  &--sm {
+    @include media-breakpoint-up(sm) {
+      max-width: $card-width-sm;
+    }
+  }
+
+  &--xs {
+    @include media-breakpoint-up(sm) {
+      max-width: $card-width-xs;
+    }
+  }
+}

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -29,6 +29,15 @@ $card-width-xs: 15.625rem;
     padding: $card-sm-spacing;
   }
 
+  &__header {
+    display: flex;
+  }
+
+  &__helper-text {
+    @include font-type-50--light;
+    color: $ux-gray-900;
+  }
+
   &__rule {
     border: 1px solid $ux-gray-400;
   }

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -14,6 +14,7 @@ $card-width-xs: 15rem;
 .Card {
   background-color: $ux-white;
   border: none;
+  border-radius: 0.25rem;
   box-shadow: 0 .125rem .25rem rgba(0,0,0,0.1);
   margin: $card-spacing auto;
   outline-color: $ux-green-500;
@@ -26,7 +27,7 @@ $card-width-xs: 15rem;
   }
 
   &__divider {
-    border: 1px solid $ux-gray-400;
+    border-top: 1px solid rgba(0,0,0,.1);
 
     margin-bottom: 0.5rem;
     margin-top: 0.25rem;
@@ -44,8 +45,8 @@ $card-width-xs: 15rem;
   }
 
   &__subtitle {
-    @include font-type-30;
-    color: $ux-gray-700;
+    @include font-type-30--light;
+    color: $ux-gray-800;
   }
 
   &__title {

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -49,10 +49,6 @@ $card-width-xs: 15.625rem;
     @include font-type-50--bold;
   }
 
-  &--active {
-    outline: $ux-green-500 auto 5px;
-  }
-
   &--divided {
     .Card__title {
       margin-bottom: 0;

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -25,6 +25,11 @@ $card-width-xs: 15.625rem;
     width: calc(100% - 2rem);
   }
 
+  &__divider {
+    border: 1px solid $ux-gray-400;
+    margin: 0.75rem auto;
+  }
+
   &__header {
     display: flex;
   }
@@ -32,11 +37,7 @@ $card-width-xs: 15.625rem;
   &__helper-text {
     @include font-type-50--light;
     color: $ux-gray-900;
-  }
-
-  &__rule {
-    border: 1px solid $ux-gray-400;
-    margin: 0.75rem auto;
+    margin-left: 0.25rem;
   }
 
   &__subtitle {
@@ -52,14 +53,14 @@ $card-width-xs: 15.625rem;
     outline: $ux-green-500 auto 5px;
   }
 
-  &--no-padding {
-    padding: 0;
-  }
-
-  &--ruled {
+  &--divided {
     .Card__title {
       margin-bottom: 0;
     }
+  }
+
+  &--no-padding {
+    padding: 0;
   }
 
   &--md {

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -44,7 +44,7 @@ $card-width-xs: 15.625rem;
   }
 
   &__title {
-    @include font-type-50;
+    @include font-type-50--bold;
   }
 
   &--active {

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -9,7 +9,7 @@ $card-spacing: 1.5rem;
 $card-width: 56rem;
 $card-width-md: 40rem;
 $card-width-sm: 32rem;
-$card-width-xs: 15.625rem;
+$card-width-xs: 15rem;
 
 .Card {
   background-color: $ux-white;
@@ -27,11 +27,14 @@ $card-width-xs: 15.625rem;
 
   &__divider {
     border: 1px solid $ux-gray-400;
-    margin: 0.75rem auto;
+
+    margin-bottom: 0.5rem;
+    margin-top: 0.25rem;
   }
 
   &__header {
     display: flex;
+    flex-wrap: wrap;
   }
 
   &__helper-text {
@@ -47,6 +50,7 @@ $card-width-xs: 15.625rem;
 
   &__title {
     @include font-type-50--bold;
+    margin-bottom: 0.25rem;
   }
 
   &--divided {
@@ -74,6 +78,11 @@ $card-width-xs: 15.625rem;
   &--xs {
     @include media-breakpoint-up(sm) {
       max-width: $card-width-xs;
+    }
+
+    .Card__helper-text {
+      margin-left: 0;
+      margin-bottom: 0.5rem;
     }
   }
 }

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -29,13 +29,17 @@ $card-width-xs: 15.625rem;
     padding: $card-sm-spacing;
   }
 
-  &__title {
-    @include font-type-50;
+  &__rule {
+    border: 1px solid $ux-gray-400;
   }
 
   &__subtitle {
     @include font-type-30;
     color: $ux-gray-700;
+  }
+
+  &__title {
+    @include font-type-50;
   }
 
   &--active {

--- a/src/Card/index.js
+++ b/src/Card/index.js
@@ -1,0 +1,1 @@
+export { default, CardSizes } from './Card';

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import Card, { CardSizes } from 'src/Card';
 import CheckboxButton from 'src/CheckboxButton';
 import CheckboxButtonGroup from 'src/CheckboxButtonGroup';
 import CopyToClipboard from 'src/CopyToClipboard';
@@ -31,6 +32,8 @@ import TrackedButton from 'src/TrackedButton';
 export {
   AlertMessage,
   AsyncSelect,
+  Card,
+  CardSizes,
   CheckboxButton,
   CheckboxButtonGroup,
   CopyToClipboard,

--- a/stories/Card.stories.jsx
+++ b/stories/Card.stories.jsx
@@ -14,9 +14,9 @@ export default {
 export const Default = () => (
   <Card
     active={boolean('Is active', false)}
+    divided={boolean('With divider', false)}
     helperText={text('Helper text', '(helper text)')}
     noPadding={boolean('Without padding', false)}
-    ruled={boolean('With horizontal rule', false)}
     size={radios('Message Type', CardSizes, CardSizes.LARGE)}
     subTitle={text('Subtitle', 'And a subtitle')}
     title={text('Title', 'Large card with title')}

--- a/stories/Card.stories.jsx
+++ b/stories/Card.stories.jsx
@@ -14,6 +14,7 @@ export default {
 export const Default = () => (
   <Card
     active={boolean('Is active', false)}
+    helperText={text('Helper text', '(helper text)')}
     noPadding={boolean('Without padding', false)}
     ruled={boolean('With horizontal rule', false)}
     size={radios('Message Type', CardSizes, CardSizes.LARGE)}

--- a/stories/Card.stories.jsx
+++ b/stories/Card.stories.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {
+  withKnobs, text, radios, boolean,
+} from '@storybook/addon-knobs';
+
+import Card, { CardSizes } from 'src/Card';
+
+export default {
+  title: 'Design System/Card',
+  component: Card,
+  decorators: [withKnobs({ escapeHTML: false })],
+};
+
+export const Default = () => (
+  <Card
+    active={boolean('Is active', false)}
+    noPadding={boolean('Without padding', false)}
+    size={radios('Message Type', CardSizes, CardSizes.LARGE)}
+    subTitle={text('Subtitle', 'And a subtitle')}
+    title={text('Title', 'Large card with title')}
+  >
+    <div>
+      Use knobs to try out the different card sizes
+    </div>
+  </Card>
+);

--- a/stories/Card.stories.jsx
+++ b/stories/Card.stories.jsx
@@ -13,7 +13,6 @@ export default {
 
 export const Default = () => (
   <Card
-    active={boolean('Is active', false)}
     divided={boolean('With divider', false)}
     helperText={text('Helper text', '(helper text)')}
     noPadding={boolean('Without padding', false)}

--- a/stories/Card.stories.jsx
+++ b/stories/Card.stories.jsx
@@ -15,6 +15,7 @@ export const Default = () => (
   <Card
     active={boolean('Is active', false)}
     noPadding={boolean('Without padding', false)}
+    ruled={boolean('With horizontal rule', false)}
     size={radios('Message Type', CardSizes, CardSizes.LARGE)}
     subTitle={text('Subtitle', 'And a subtitle')}
     title={text('Title', 'Large card with title')}


### PR DESCRIPTION
Closes #77 
Figma link: https://www.figma.com/file/471iS3QrpPtXZpS1xbsJ20/Components?node-id=1252%3A792

Adds Card component with variants no padding, active, and ruled.

Examples:
<img width="551" alt="Screen Shot 2020-12-28 at 1 19 27 PM" src="https://user-images.githubusercontent.com/35879359/103243651-61423c80-490f-11eb-8fb9-e06b3b19c792.png">

<img width="1227" alt="Screen Shot 2020-12-28 at 1 19 15 PM" src="https://user-images.githubusercontent.com/35879359/103243658-6901e100-490f-11eb-9619-596df9dc4a0d.png">

