### PR TITLE
UIDS-149 Some css updates from the project builder design review

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -2,7 +2,7 @@
   on:
     push:
       branches:
-        - master
+        - feature/UIDS-149-builder-related-followons
   jobs:
     gh-pages-deploy:
       name: Deploying to gh-pages

--- a/scss/forms/control_button_group.scss
+++ b/scss/forms/control_button_group.scss
@@ -44,6 +44,8 @@
   }
 
   .FormControlLabel {
+    @include font-type-30;
+
     flex-wrap: wrap;
     margin-right: 0.5rem;
     display: block;

--- a/scss/forms/form_control_label.scss
+++ b/scss/forms/form_control_label.scss
@@ -3,17 +3,21 @@
 @import '../typography';
 
 .FormControlLabel {
+  @include font-type-30;
+
   align-items: center;
   display: flex;
 
   &--with-children {
+    @include font-type-30--bold;
+
     align-items: flex-start;
     flex-direction: column;
     display: flex;
   }
 
   &__label {
-    align-items: center;
+    align-items: flex-start;
     display: flex;
     flex-direction: row;
   }
@@ -32,8 +36,6 @@
   }
 
   &--bordered {
-    @include font-type-30;
-
     border: 1px solid $ux-gray-400;
     border-radius: $ux-border-radius;
     padding: 1rem;
@@ -53,5 +55,6 @@
   input[type='checkbox'], input[type='radio'] {
     min-height: 1rem;
     min-width: 1rem;
+    margin-top: 0.125rem;
   }
 }

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -1437,7 +1437,7 @@ exports[`Storyshots Design System/Selects/Async Default 1`] = `
         />
         <div
           aria-hidden="true"
-          className=" css-tlfecz-indicatorContainer"
+          className=" css-fric97-indicatorContainer"
           onMouseDown={[Function]}
           onTouchEnd={[Function]}
         >
@@ -1559,7 +1559,7 @@ exports[`Storyshots Design System/Selects/Async Labeled 1`] = `
         />
         <div
           aria-hidden="true"
-          className=" css-tlfecz-indicatorContainer"
+          className=" css-fric97-indicatorContainer"
           onMouseDown={[Function]}
           onTouchEnd={[Function]}
         >
@@ -1629,7 +1629,7 @@ exports[`Storyshots Design System/Selects/Single Default 1`] = `
         />
         <div
           aria-hidden="true"
-          className=" css-tlfecz-indicatorContainer"
+          className=" css-fric97-indicatorContainer"
           onMouseDown={[Function]}
           onTouchEnd={[Function]}
         >
@@ -1706,7 +1706,7 @@ exports[`Storyshots Design System/Selects/Single Labeled 1`] = `
         />
         <div
           aria-hidden="true"
-          className=" css-tlfecz-indicatorContainer"
+          className=" css-fric97-indicatorContainer"
           onMouseDown={[Function]}
           onTouchEnd={[Function]}
         >
@@ -1776,7 +1776,7 @@ exports[`Storyshots Design System/Selects/Single Loading 1`] = `
         />
         <div
           aria-hidden="true"
-          className=" css-tlfecz-indicatorContainer"
+          className=" css-fric97-indicatorContainer"
           onMouseDown={[Function]}
           onTouchEnd={[Function]}
         >
@@ -1891,7 +1891,7 @@ exports[`Storyshots Design System/Selects/Single Searchable 1`] = `
         />
         <div
           aria-hidden="true"
-          className=" css-tlfecz-indicatorContainer"
+          className=" css-fric97-indicatorContainer"
           onMouseDown={[Function]}
           onTouchEnd={[Function]}
         >

--- a/src/Select/styles.js
+++ b/src/Select/styles.js
@@ -1,4 +1,5 @@
 import systemColors from 'src/Styles/colors';
+import fontWeights from '../Styles/fontWeights';
 
 export const SELECT_SIZES = { SMALL: 'small' };
 
@@ -23,10 +24,12 @@ const defaultStyles = ({ size }) => ({
       backgroundColor: isDisabled ? systemColors.inputDisabledBg : styles.backgroundColor,
       borderColor: systemColors.inputBorderColor,
     }),
+    dropdownIndicator: (styles) => ({ ...styles, color: systemColors.uxGray600 }),
     indicatorSeparator: (styles) => ({ ...styles, display: 'none' }),
     singleValue: (styles, { data }) => ({
       ...styles,
-      color: (data.colors ? data.colors.text : systemColors.uxGray600) || systemColors.uxGray600,
+      color: (data.colors ? data.colors.text : systemColors.uxGray900) || systemColors.uxGray900,
+      fontWeight: fontWeights.light,
     }),
     option: (styles, {
       data,
@@ -40,6 +43,7 @@ const defaultStyles = ({ size }) => ({
         ...styles,
         backgroundColor: isSelected || isFocused ? colors.hover : styles.backgroundColor,
         color: colors.text,
+        fontWeight: fontWeights.light,
         cursor: 'pointer',
 
         ':active': {

--- a/src/Styles/fontWeights.js
+++ b/src/Styles/fontWeights.js
@@ -1,0 +1,5 @@
+export default {
+  light: 300,
+  regular: 400,
+  bold: 700,
+};


### PR DESCRIPTION
Closes #149 

See temporarily deployed here: https://docs.userinterviews.com/ui-design-system/?path=/story/design-system-selects-async--default

[ ] FormControlLabel (e.g. Zoom or Other location link labels) should be bolded when it has additional helper text and is not within the context of a ControlButtonGroup ([see design system Figma specs](https://www.figma.com/file/471iS3QrpPtXZpS1xbsJ20/Components?node-id=2145%3A396))
[ ] Update Select and AsyncSelect color to ux-gray-900 and font-weight: 300 when it is filled. (arrow icon should also always be ux-gray-600)
[ ] Align radio button icons to the top of each option on mobile (e.g. Incentive distribution)

Radios & Checkbox options with and without bolding:
<img width="322" alt="Screen Shot 2021-01-26 at 2 11 30 PM" src="https://user-images.githubusercontent.com/4008333/105912693-af1a9500-5fe0-11eb-9778-26a53a7f82d2.png">
<img width="361" alt="Screen Shot 2021-01-26 at 2 11 38 PM" src="https://user-images.githubusercontent.com/4008333/105912702-b346b280-5fe0-11eb-8bb1-80f0af570f14.png">
<img width="323" alt="Screen Shot 2021-01-26 at 2 11 46 PM" src="https://user-images.githubusercontent.com/4008333/105912708-b641a300-5fe0-11eb-81b8-333e15c109de.png">
<img width="532" alt="Screen Shot 2021-01-26 at 2 12 00 PM" src="https://user-images.githubusercontent.com/4008333/105912716-b9d52a00-5fe0-11eb-9787-070c4d41efd9.png">
<img width="489" alt="Screen Shot 2021-01-26 at 2 12 04 PM" src="https://user-images.githubusercontent.com/4008333/105912727-bd68b100-5fe0-11eb-8a39-2b60984c9dc7.png">
<img width="908" alt="Screen Shot 2021-01-26 at 2 12 26 PM" src="https://user-images.githubusercontent.com/4008333/105912735-c063a180-5fe0-11eb-81fd-10eb39403774.png">
<img width="613" alt="Screen Shot 2021-01-26 at 2 12 50 PM" src="https://user-images.githubusercontent.com/4008333/105912754-c6598280-5fe0-11eb-9525-7707acb5ab83.png">



Select font color and weight:

<img width="494" alt="Screen Shot 2021-01-26 at 2 01 16 PM" src="https://user-images.githubusercontent.com/4008333/105911414-03bd1080-5fdf-11eb-9882-1f148c8fc214.png">
