### PR TITLE
Feature/UI ds 244 release GitHub action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Create Release Branch
+on:
+  workflow_dispatch:
+    inputs:
+      releaseType:
+        description: 'Is this release: major, minor or patch?'
+        required: true
+jobs:
+  createrelease:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - run: yarn install
+      - run: yarn version ${{ github.event.inputs.releaseType }}
+      - run: yarn build
+      - run: npm pack
+      - run: npm publish --access public
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Extract Package Version
+        id: extract_version
+        uses: Saionaro/extract-package-version@v1.1.1
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.extract_version.outputs.version }}
+          release_name: Release v${{ steps.extract_version.outputs.version }}
+          body_path:
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./user-interviews-ui-design-system-${{ steps.extract_version.outputs.version }}.tgz
+          asset_name: user-interviews-ui-design-system-${{ steps.extract_version.outputs.version }}.tgz
+          asset_content_type: application/tar+gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Create Release Branch
+name: Create Release
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,21 +7,33 @@ on:
         required: true
         default: 'patch'
 jobs:
-  createrelease:
+  create-release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
       - run: yarn install
-      - run: yarn version ${{ github.event.inputs.releaseType }}
+
+      # Update package version
+      - run: git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - run: git config --local user.name "github-actions[bot]"
+      - run: yarn --new-version version ${{ github.event.inputs.releaseType }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+
+      # Build assets
       - run: yarn build
       - run: npm pack
-      - run: npm publish --access public
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Extract Package Version
         id: extract_version
         uses: Saionaro/extract-package-version@v1.1.1
+
+      # Create the release
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -33,13 +45,15 @@ jobs:
           body_path:
           draft: false
           prerelease: false
+
+      # Upload assets to the release
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./user-interviews-ui-design-system-${{ steps.extract_version.outputs.version }}.tgz
           asset_name: user-interviews-ui-design-system-${{ steps.extract_version.outputs.version }}.tgz
           asset_content_type: application/tar+gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
       releaseType:
         description: 'Is this release: major, minor or patch?'
         required: true
+        default: 'patch'
 jobs:
   createrelease:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
+      - uses: fregante/setup-git-user@v1
       - run: yarn install
 
       # Update package version
-      - run: git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      - run: git config --local user.name "github-actions[bot]"
       - run: yarn --new-version version ${{ github.event.inputs.releaseType }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #244 

There might be a better way to do this, I sort of put this together by following various tutorials I could find for the different pieces. The goal here is to automate the release process for the design system to make it easier/more streamlined and enable us to have more frequent releases. The workflow is as follows:

- This is a manually triggered github action, so it only runs when you manually request it. However, I haven't tested that part yet as the workflow_dispatch trigger is only supported on the main branch. So in testing I was triggering it on push, but may need a followup branch if there is any issue with the workflow_dispatch trigger once it is merged to main.
- Checkout the code, install the yarn dependencies, etc
- Auto increments the package version by either major, minor or patch (whichever is specified by an input parameter when you run the action). Pushes that update to main to increase the version in package.json.
- Builds the release .tgz
- Creates the github release and the new tag by extracting the updated version number
- Uploads the .tgz file to the release.

What is missing:
- Some kind of commit summary with the release. You can still go in and edit the release and add it manually, but I hope it could be possible to automate that part as well.
- Publishing to the npm repo (This should be possible but I need to figure out how to get the token set up properly. This part is not necessary for our uses for rails-server the way we have things setup currently and is more for if outside folks consume the design system)

I tested it on push as that is all that is supported on a feature branch and it successfully created the release (I deleted it since then) Successful run: https://github.com/user-interviews/ui-design-system/actions/runs/745760439