### PR TITLE
feature/UIDS-251 update pill sizing

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -2381,6 +2381,23 @@ exports[`Storyshots Design System/Pill With Leading Icon 1`] = `
 </div>
 `;
 
+exports[`Storyshots Design System/Pill With Link 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <a
+    className="Pill Pill--blue"
+    href="https://www.userinterviews.com/"
+  >
+    Visit our site
+  </a>
+</div>
+`;
+
 exports[`Storyshots Design System/Popper Dark 1`] = `
 <div
   style={

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -2374,12 +2374,17 @@ exports[`Storyshots Design System/Pill With Link 1`] = `
     }
   }
 >
-  <a
+  <span
     className="Pill Pill--blue"
-    href="https://www.userinterviews.com/"
   >
-    Visit our site
-  </a>
+    <a
+      href="https://www.userinterviews.com/"
+      rel="noreferrer"
+      target="_blank"
+    >
+      Visit our site
+    </a>
+  </span>
 </div>
 `;
 
@@ -3240,23 +3245,20 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-70
-          </span>
+            text="font-type-70"
+          />
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-70--bold
-          </span>
+            text="font-type-70--bold"
+          />
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-70--light
-          </span>
+            text="font-type-70--light"
+          />
         </li>
       </ul>
     </div>
@@ -3315,23 +3317,20 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-60
-          </span>
+            text="font-type-60"
+          />
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-60--bold
-          </span>
+            text="font-type-60--bold"
+          />
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-60--light
-          </span>
+            text="font-type-60--light"
+          />
         </li>
       </ul>
     </div>
@@ -3390,23 +3389,20 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-50
-          </span>
+            text="font-type-50"
+          />
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-50--bold
-          </span>
+            text="font-type-50--bold"
+          />
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-50--light
-          </span>
+            text="font-type-50--light"
+          />
         </li>
       </ul>
     </div>
@@ -3465,23 +3461,20 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-40
-          </span>
+            text="font-type-40"
+          />
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-40--bold
-          </span>
+            text="font-type-40--bold"
+          />
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-40--light
-          </span>
+            text="font-type-40--light"
+          />
         </li>
       </ul>
     </div>
@@ -3540,23 +3533,20 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-30
-          </span>
+            text="font-type-30"
+          />
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-30--bold
-          </span>
+            text="font-type-30--bold"
+          />
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-30--light
-          </span>
+            text="font-type-30--light"
+          />
         </li>
       </ul>
     </div>
@@ -3615,23 +3605,20 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-20
-          </span>
+            text="font-type-20"
+          />
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-20--bold
-          </span>
+            text="font-type-20--bold"
+          />
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-20--light
-          </span>
+            text="font-type-20--light"
+          />
         </li>
       </ul>
     </div>
@@ -3698,23 +3685,20 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-10
-          </span>
+            text="font-type-10"
+          />
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-10--bold
-          </span>
+            text="font-type-10--bold"
+          />
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-          >
-            font-type-10--light
-          </span>
+            text="font-type-10--light"
+          />
         </li>
       </ul>
     </div>

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -3245,20 +3245,23 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-70"
-          />
+          >
+            font-type-70
+          </span>
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-70--bold"
-          />
+          >
+            font-type-70--bold
+          </span>
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-70--light"
-          />
+          >
+            font-type-70--light
+          </span>
         </li>
       </ul>
     </div>
@@ -3317,20 +3320,23 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-60"
-          />
+          >
+            font-type-60
+          </span>
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-60--bold"
-          />
+          >
+            font-type-60--bold
+          </span>
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-60--light"
-          />
+          >
+            font-type-60--light
+          </span>
         </li>
       </ul>
     </div>
@@ -3389,20 +3395,23 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-50"
-          />
+          >
+            font-type-50
+          </span>
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-50--bold"
-          />
+          >
+            font-type-50--bold
+          </span>
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-50--light"
-          />
+          >
+            font-type-50--light
+          </span>
         </li>
       </ul>
     </div>
@@ -3461,20 +3470,23 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-40"
-          />
+          >
+            font-type-40
+          </span>
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-40--bold"
-          />
+          >
+            font-type-40--bold
+          </span>
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-40--light"
-          />
+          >
+            font-type-40--light
+          </span>
         </li>
       </ul>
     </div>
@@ -3533,20 +3545,23 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-30"
-          />
+          >
+            font-type-30
+          </span>
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-30--bold"
-          />
+          >
+            font-type-30--bold
+          </span>
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-30--light"
-          />
+          >
+            font-type-30--light
+          </span>
         </li>
       </ul>
     </div>
@@ -3605,20 +3620,23 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-20"
-          />
+          >
+            font-type-20
+          </span>
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-20--bold"
-          />
+          >
+            font-type-20--bold
+          </span>
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-20--light"
-          />
+          >
+            font-type-20--light
+          </span>
         </li>
       </ul>
     </div>
@@ -3685,20 +3703,23 @@ exports[`Storyshots Design System/Styles Typography 1`] = `
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-10"
-          />
+          >
+            font-type-10
+          </span>
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-10--bold"
-          />
+          >
+            font-type-10--bold
+          </span>
         </li>
         <li>
           <span
             className="Pill Pill--blue"
-            text="font-type-10--light"
-          />
+          >
+            font-type-10--light
+          </span>
         </li>
       </ul>
     </div>

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -2274,21 +2274,6 @@ exports[`Storyshots Design System/Pill Default 1`] = `
         }
       }
     >
-      Large
-    </h4>
-    <span
-      className="Pill Pill--blue Pill--large"
-    >
-      Text
-    </span>
-    <h4
-      style={
-        Object {
-          "marginBottom": "2rem",
-          "marginTop": "2rem",
-        }
-      }
-    >
       Colors
     </h4>
     <span

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -2327,7 +2327,23 @@ exports[`Storyshots Design System/Pill With Close 1`] = `
       onClick={[Function]}
       type="button"
     >
-       ×
+      <svg
+        aria-hidden="true"
+        className="svg-inline--fa fa-times fa-w-11 "
+        data-icon="times"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        style={Object {}}
+        viewBox="0 0 352 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+          fill="currentColor"
+          style={Object {}}
+        />
+      </svg>
     </button>
   </span>
 </div>

--- a/src/Pill/Pill.jsx
+++ b/src/Pill/Pill.jsx
@@ -14,7 +14,6 @@ const Pill = ({
   href,
   icon,
   id,
-  large,
   onClose,
   text,
 }) => (
@@ -24,7 +23,6 @@ const Pill = ({
         classNames(
           'Pill',
           { [`Pill--${color}`]: !!color },
-          { [`Pill--large`]: !!large },
         )
       }
       href={href}
@@ -43,7 +41,6 @@ const Pill = ({
         classNames(
           'Pill',
           { [`Pill--${color}`]: !!color },
-          { [`Pill--large`]: !!large },
         )
       }
     >
@@ -63,7 +60,6 @@ Pill.propTypes = {
   href: PropTypes.string,
   icon: PropTypes.any,
   id: PropTypes.string,
-  large: PropTypes.bool,
   text: PropTypes.node.isRequired,
   onClose: PropTypes.func,
 };
@@ -73,7 +69,6 @@ Pill.defaultProps = {
   href: undefined,
   icon: undefined,
   id: undefined,
-  large: undefined,
   onClose: undefined,
 };
 

--- a/src/Pill/Pill.jsx
+++ b/src/Pill/Pill.jsx
@@ -9,33 +9,56 @@ const colors = ['blue', 'orange', 'yellow', 'green', 'gray', 'silver'];
 
 const Pill = ({
   color,
+  href,
   icon,
   id,
   large,
   onClose,
   text,
 }) => (
-  <span
-    className={
-      classNames(
-        'Pill',
-        { [`Pill--${color}`]: !!color },
-        { [`Pill--large`]: !!large },
-      )
-    }
-  >
-    { icon && (
-      <FontAwesomeIcon className="Pill__icon--lead" icon={icon} />
-    )}
-    {text}
-    { onClose && (
-    <button className="Pill__button--close" type="button" onClick={() => onClose(id)}> &times;</button>
+  href ? (
+    <a
+      className={
+        classNames(
+          'Pill',
+          { [`Pill--${color}`]: !!color },
+          { [`Pill--large`]: !!large },
+        )
+      }
+      href={href}
+    >
+      { icon && (
+        <FontAwesomeIcon className="Pill__icon--lead" icon={icon} />
       )}
-  </span>
+      { text }
+      { onClose && (
+      <button className="Pill__button--close" type="button" onClick={() => onClose(id)}> &times;</button>
+        )}
+    </a>
+  ) : (
+    <span
+      className={
+        classNames(
+          'Pill',
+          { [`Pill--${color}`]: !!color },
+          { [`Pill--large`]: !!large },
+        )
+      }
+    >
+      { icon && (
+        <FontAwesomeIcon className="Pill__icon--lead" icon={icon} />
+      )}
+      { text }
+      { onClose && (
+      <button className="Pill__button--close" type="button" onClick={() => onClose(id)}> &times;</button>
+        )}
+    </span>
+  )
 );
 
 Pill.propTypes = {
   color: PropTypes.oneOf(colors),
+  href: PropTypes.string,
   icon: PropTypes.any,
   id: PropTypes.string,
   large: PropTypes.bool,
@@ -45,6 +68,7 @@ Pill.propTypes = {
 
 Pill.defaultProps = {
   color: 'blue',
+  href: undefined,
   icon: undefined,
   id: undefined,
   large: undefined,

--- a/src/Pill/Pill.jsx
+++ b/src/Pill/Pill.jsx
@@ -5,7 +5,9 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import './Pill.scss';
 
-const colors = ['blue', 'orange', 'yellow', 'green', 'gray', 'silver'];
+export const PILL_COLORS = {
+ BLUE: 'blue', ORANGE: 'orange', YELLOW: 'yellow', GREEN: 'green', GRAY: 'gray', SILVER: 'silver',
+};
 
 const Pill = ({
   color,
@@ -57,7 +59,7 @@ const Pill = ({
 );
 
 Pill.propTypes = {
-  color: PropTypes.oneOf(colors),
+  color: PropTypes.oneOf(Object.values(PILL_COLORS)),
   href: PropTypes.string,
   icon: PropTypes.any,
   id: PropTypes.string,
@@ -67,7 +69,7 @@ Pill.propTypes = {
 };
 
 Pill.defaultProps = {
-  color: 'blue',
+  color: PILL_COLORS.BLUE,
   href: undefined,
   icon: undefined,
   id: undefined,

--- a/src/Pill/Pill.jsx
+++ b/src/Pill/Pill.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
 
 import './Pill.scss';
 
@@ -33,7 +34,9 @@ const Pill = ({
     { children }
     { text }
     { onClose && (
-      <button className="Pill__button--close" type="button" onClick={() => onClose(id)}> &times;</button>
+      <button className="Pill__button--close" type="button" onClick={() => onClose(id)}>
+        <FontAwesomeIcon icon={faTimes} />
+      </button>
         )}
   </span>
   );

--- a/src/Pill/Pill.jsx
+++ b/src/Pill/Pill.jsx
@@ -15,6 +15,7 @@ const Pill = ({
   icon,
   id,
   onClose,
+  text,
   ...props
 }) => (
   <span
@@ -30,6 +31,7 @@ const Pill = ({
     <FontAwesomeIcon className="Pill__icon--lead" icon={icon} />
       )}
     { children }
+    { text }
     { onClose && (
       <button className="Pill__button--close" type="button" onClick={() => onClose(id)}> &times;</button>
         )}
@@ -37,17 +39,20 @@ const Pill = ({
   );
 
 Pill.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   color: PropTypes.oneOf(Object.values(PILL_COLORS)),
   icon: PropTypes.any,
   id: PropTypes.string,
+  text: PropTypes.node,
   onClose: PropTypes.func,
 };
 
 Pill.defaultProps = {
+  children: undefined,
   color: PILL_COLORS.BLUE,
   icon: undefined,
   id: undefined,
+  text: undefined,
   onClose: undefined,
 };
 

--- a/src/Pill/Pill.jsx
+++ b/src/Pill/Pill.jsx
@@ -10,63 +10,42 @@ export const PILL_COLORS = {
 };
 
 const Pill = ({
+  children,
   color,
-  href,
   icon,
   id,
   onClose,
-  text,
+  ...props
 }) => (
-  href ? (
-    <a
-      className={
+  <span
+    className={
         classNames(
           'Pill',
           { [`Pill--${color}`]: !!color },
         )
       }
-      href={href}
-    >
-      { icon && (
-        <FontAwesomeIcon className="Pill__icon--lead" icon={icon} />
+    {...props}
+  >
+    { icon && (
+    <FontAwesomeIcon className="Pill__icon--lead" icon={icon} />
       )}
-      { text }
-      { onClose && (
+    { children }
+    { onClose && (
       <button className="Pill__button--close" type="button" onClick={() => onClose(id)}> &times;</button>
         )}
-    </a>
-  ) : (
-    <span
-      className={
-        classNames(
-          'Pill',
-          { [`Pill--${color}`]: !!color },
-        )
-      }
-    >
-      { icon && (
-        <FontAwesomeIcon className="Pill__icon--lead" icon={icon} />
-      )}
-      { text }
-      { onClose && (
-      <button className="Pill__button--close" type="button" onClick={() => onClose(id)}> &times;</button>
-        )}
-    </span>
-  )
-);
+  </span>
+  );
 
 Pill.propTypes = {
+  children: PropTypes.node.isRequired,
   color: PropTypes.oneOf(Object.values(PILL_COLORS)),
-  href: PropTypes.string,
   icon: PropTypes.any,
   id: PropTypes.string,
-  text: PropTypes.node.isRequired,
   onClose: PropTypes.func,
 };
 
 Pill.defaultProps = {
   color: PILL_COLORS.BLUE,
-  href: undefined,
   icon: undefined,
   id: undefined,
   onClose: undefined,

--- a/src/Pill/Pill.mdx
+++ b/src/Pill/Pill.mdx
@@ -2,7 +2,7 @@ import { ArgsTable, Story, Preview } from '@storybook/addon-docs/blocks';
 import { Pill } from './Pill';
 
 # Pill
-Represents an object that can be viewed with or without an icon
+Represents an object that can be viewed with or without an icon. Useful when describing or categorizing a property.
 
 <Preview>
   <Story id="design-system-pill--default" />
@@ -15,14 +15,20 @@ Represents an object that can be viewed with or without an icon
 - **Text: ** main descriptor of the pill
 - **Icon: ** relevant icon that makes it easier for users to identify (always placed left of the Text)
 - **Close: ** users have the option to clear the pill (provided by default with the presence of the `onClose` function)
+- **Link: ** an optional link to more information 
 
 ## Best practices 
 
-- TBD
+- Use to label, categorize, or organize items using keywords that describe them
+- Help users search for and find related content quickly and easily
+- Use to highlight an item's status for quick recognition 
+- Ideal to indicate meanings that users can learn and recognize across the app
 
 ## Stories
 
 ### Default
+- The default Pill and available colors
+- Use the `PILL_COLORS` constant when setting the `color` prop
 
 <Preview>
   <Story id="design-system-pill--default" />
@@ -43,7 +49,7 @@ Represents an object that can be viewed with or without an icon
 </Preview>
 
 ### With Link
-- For Pills that want to link to more information. An `<a>` tag will be rendered instead of a `<span>` if an `href` prop is provided. 
+- For Pills that link to more information. An `<a>` tag will be rendered instead of a `<span>` if an `href` prop is provided. 
 
 <Preview>
   <Story id="design-system-pill--with-link" />

--- a/src/Pill/Pill.mdx
+++ b/src/Pill/Pill.mdx
@@ -12,10 +12,9 @@ Represents an object that can be viewed with or without an icon. Useful when des
 
 ## Anatomy
 
-- **Text: ** main descriptor of the pill
-- **Icon: ** relevant icon that makes it easier for users to identify (always placed left of the Text)
+- **Content: ** main content area of the Pill. Can be provided plain text or a link (`<a>`) as `children`
+- **Icon: ** relevant icon that makes it easier for users to identify (always placed left of the Content)
 - **Close: ** users have the option to clear the pill (provided by default with the presence of the `onClose` function)
-- **Link: ** an optional link to more information 
 
 ## Best practices 
 
@@ -29,6 +28,7 @@ Represents an object that can be viewed with or without an icon. Useful when des
 ### Default
 - The default Pill and available colors
 - Use the `PILL_COLORS` constant when setting the `color` prop
+- If using plain text as the content, do not wrap in block-level elements (e.g. `<p>` or `div`) 
 
 <Preview>
   <Story id="design-system-pill--default" />
@@ -49,7 +49,8 @@ Represents an object that can be viewed with or without an icon. Useful when des
 </Preview>
 
 ### With Link
-- For Pills that link to more information. An `<a>` tag will be rendered instead of a `<span>` if an `href` prop is provided. 
+- For Pills that link to more information
+- The Pill accepts an `<a>` tag as a child
 
 <Preview>
   <Story id="design-system-pill--with-link" />

--- a/src/Pill/Pill.mdx
+++ b/src/Pill/Pill.mdx
@@ -41,3 +41,10 @@ Represents an object that can be viewed with or without an icon
 <Preview>
   <Story id="design-system-pill--with-close" />
 </Preview>
+
+### With Link
+- For Pills that want to link to more information. An `<a>` tag will be rendered instead of a `<span>` if an `href` prop is provided. 
+
+<Preview>
+  <Story id="design-system-pill--with-link" />
+</Preview>

--- a/src/Pill/Pill.mdx
+++ b/src/Pill/Pill.mdx
@@ -28,7 +28,8 @@ Represents an object that can be viewed with or without an icon. Useful when des
 ### Default
 - The default Pill and available colors
 - Use the `PILL_COLORS` constant when setting the `color` prop
-- If using plain text as the content, do not wrap in block-level elements (e.g. `<p>` or `div`) 
+- Can use either the `text` prop or provide an element via `children` for content. (Note: the `text` prop is planned to be retired in favor of `children` in a future release)
+- If using plain text or an element as the content via `children`, do not wrap in block-level elements (e.g. `<p>` or `div`) 
 
 <Preview>
   <Story id="design-system-pill--default" />

--- a/src/Pill/Pill.scss
+++ b/src/Pill/Pill.scss
@@ -129,10 +129,4 @@
       padding: 0;
     }
   }
-
-  &--large {
-    @include font-type-40;
-    border-radius: 0.5rem;
-    padding: $ux-spacing-10 $ux-spacing-20;
-  }
 }

--- a/src/Pill/Pill.scss
+++ b/src/Pill/Pill.scss
@@ -24,7 +24,7 @@
     .Pill__button--close {
       background-color: unset; 
       border: none;
-      color: $ux-blue;
+      color: $ux-blue-300;
       margin-left: $ux-spacing-20;
       margin-right: 0;
       padding: 0;

--- a/src/Pill/Pill.scss
+++ b/src/Pill/Pill.scss
@@ -2,14 +2,14 @@
 @import '../../scss/theme';
 
 .Pill {
-  @include font-type-30;
+  @include font-type-20;
   font-weight: $font-weight-normal;
   display: inline;
   background-color: $ux-blue-100;
   color: $ux-blue-700;
   border: 0.06rem solid $ux-blue-300;
   border-radius: $ux-border-radius;
-  padding: $ux-spacing-10 $ux-spacing-20;
+  padding: $ux-spacing-10 $ux-spacing-30;
 
   &--blue {
     background-color: $ux-blue-100;

--- a/src/Pill/Pill.stories.jsx
+++ b/src/Pill/Pill.stories.jsx
@@ -8,7 +8,7 @@ import {
 } from '@storybook/addon-knobs';
 import { faUsers } from '@fortawesome/free-solid-svg-icons';
 
-import Pill from 'src/Pill';
+import { Pill, PILL_COLORS } from 'src/Pill';
 import mdx from './Pill.mdx';
 
 export default {
@@ -22,8 +22,6 @@ export default {
   },
 };
 
-const colors = ['blue', 'orange', 'yellow', 'green', 'gray', 'silver'];
-
 const handleClose = (id) => {
   action('handle close')(id);
 };
@@ -32,7 +30,7 @@ export const Default = () => (
   <div>
     <h4 style={{ marginBottom: '2rem' }}>Test Pill</h4>
     <Pill
-      color={select('Color', colors, 'blue')}
+      color={select('Color', Object.values(PILL_COLORS), PILL_COLORS.BLUE)}
       id="1"
       large={boolean('Large', false)}
       text={text('Text', 'Text')}
@@ -73,7 +71,7 @@ export const Default = () => (
 
 export const WithLeadingIcon = () => (
   <Pill
-    color={select('Color', colors, 'blue')}
+    color={select('Color', Object.values(PILL_COLORS), PILL_COLORS.BLUE)}
     icon={faUsers}
     id="2"
     large={boolean('Large', false)}
@@ -83,7 +81,7 @@ export const WithLeadingIcon = () => (
 
 export const WithClose = () => (
   <Pill
-    color={select('Color', colors, 'blue')}
+    color={select('Color', Object.values(PILL_COLORS), PILL_COLORS.BLUE)}
     id="3"
     large={boolean('Large', false)}
     text={text('Text', 'Text')}
@@ -93,7 +91,7 @@ export const WithClose = () => (
 
 export const WithLink = () => (
   <Pill
-    color={select('Color', colors, 'blue')}
+    color={select('Color', Object.values(PILL_COLORS), PILL_COLORS.BLUE)}
     href="https://www.userinterviews.com/"
     id="3"
     large={boolean('Large', false)}

--- a/src/Pill/Pill.stories.jsx
+++ b/src/Pill/Pill.stories.jsx
@@ -90,3 +90,13 @@ export const WithClose = () => (
     onClose={handleClose}
   />
 );
+
+export const WithLink = () => (
+  <Pill
+    color={select('Color', colors, 'blue')}
+    href="https://www.userinterviews.com/"
+    id="3"
+    large={boolean('Large', false)}
+    text={text('Text', 'Visit our site')}
+  />
+);

--- a/src/Pill/Pill.stories.jsx
+++ b/src/Pill/Pill.stories.jsx
@@ -4,7 +4,6 @@ import {
   withKnobs,
   text,
   select,
-  boolean,
 } from '@storybook/addon-knobs';
 import { faUsers } from '@fortawesome/free-solid-svg-icons';
 
@@ -32,38 +31,31 @@ export const Default = () => (
     <Pill
       color={select('Color', Object.values(PILL_COLORS), PILL_COLORS.BLUE)}
       id="1"
-      large={boolean('Large', false)}
       text={text('Text', 'Text')}
-    />
-    <h4 style={{ marginBottom: '2rem', marginTop: '2rem' }}>Large</h4>
-    <Pill
-      color="blue"
-      large
-      text="Text"
     />
     <h4 style={{ marginBottom: '2rem', marginTop: '2rem' }}>Colors</h4>
     <Pill
-      color="blue"
+      color={PILL_COLORS.BLUE}
       text="blue"
     />
     <Pill
-      color="orange"
+      color={PILL_COLORS.ORANGE}
       text="orange"
     />
     <Pill
-      color="yellow"
+      color={PILL_COLORS.YELLOW}
       text="yellow"
     />
     <Pill
-      color="green"
+      color={PILL_COLORS.GREEN}
       text="green"
     />
     <Pill
-      color="gray"
+      color={PILL_COLORS.GRAY}
       text="gray"
     />
     <Pill
-      color="silver"
+      color={PILL_COLORS.SILVER}
       text="silver"
     />
   </div>
@@ -74,7 +66,6 @@ export const WithLeadingIcon = () => (
     color={select('Color', Object.values(PILL_COLORS), PILL_COLORS.BLUE)}
     icon={faUsers}
     id="2"
-    large={boolean('Large', false)}
     text={text('Text', 'Text')}
   />
 );
@@ -83,7 +74,6 @@ export const WithClose = () => (
   <Pill
     color={select('Color', Object.values(PILL_COLORS), PILL_COLORS.BLUE)}
     id="3"
-    large={boolean('Large', false)}
     text={text('Text', 'Text')}
     onClose={handleClose}
   />
@@ -94,7 +84,6 @@ export const WithLink = () => (
     color={select('Color', Object.values(PILL_COLORS), PILL_COLORS.BLUE)}
     href="https://www.userinterviews.com/"
     id="3"
-    large={boolean('Large', false)}
     text={text('Text', 'Visit our site')}
   />
 );

--- a/src/Pill/Pill.stories.jsx
+++ b/src/Pill/Pill.stories.jsx
@@ -31,33 +31,40 @@ export const Default = () => (
     <Pill
       color={select('Color', Object.values(PILL_COLORS), PILL_COLORS.BLUE)}
       id="1"
-      text={text('Text', 'Text')}
-    />
+    >
+      {text('Text', 'Text')}
+    </Pill>
     <h4 style={{ marginBottom: '2rem', marginTop: '2rem' }}>Colors</h4>
     <Pill
       color={PILL_COLORS.BLUE}
-      text="blue"
-    />
+    >
+      blue
+    </Pill>
     <Pill
       color={PILL_COLORS.ORANGE}
-      text="orange"
-    />
+    >
+      orange
+    </Pill>
     <Pill
       color={PILL_COLORS.YELLOW}
-      text="yellow"
-    />
+    >
+      yellow
+    </Pill>
     <Pill
       color={PILL_COLORS.GREEN}
-      text="green"
-    />
+    >
+      green
+    </Pill>
     <Pill
       color={PILL_COLORS.GRAY}
-      text="gray"
-    />
+    >
+      gray
+    </Pill>
     <Pill
       color={PILL_COLORS.SILVER}
-      text="silver"
-    />
+    >
+      silver
+    </Pill>
   </div>
 );
 
@@ -66,24 +73,26 @@ export const WithLeadingIcon = () => (
     color={select('Color', Object.values(PILL_COLORS), PILL_COLORS.BLUE)}
     icon={faUsers}
     id="2"
-    text={text('Text', 'Text')}
-  />
+  >
+    {text('Text', 'Text')}
+  </Pill>
 );
 
 export const WithClose = () => (
   <Pill
     color={select('Color', Object.values(PILL_COLORS), PILL_COLORS.BLUE)}
     id="3"
-    text={text('Text', 'Text')}
     onClose={handleClose}
-  />
+  >
+    {text('Text', 'Text')}
+  </Pill>
 );
 
 export const WithLink = () => (
   <Pill
     color={select('Color', Object.values(PILL_COLORS), PILL_COLORS.BLUE)}
-    href="https://www.userinterviews.com/"
     id="3"
-    text={text('Text', 'Visit our site')}
-  />
+  >
+    <a href="https://www.userinterviews.com/" rel="noreferrer" target="_blank">{text('Link text', 'Visit our site')}</a>
+  </Pill>
 );

--- a/src/Pill/index.js
+++ b/src/Pill/index.js
@@ -1,1 +1,6 @@
-export { default } from './Pill';
+import Pill, { PILL_COLORS } from './Pill';
+
+export {
+  Pill,
+  PILL_COLORS,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ import {
   ModalFooter,
   ModalHeader,
 } from 'src/Modal';
-import Pill from 'src/Pill';
+import { Pill, PILL_COLORS } from 'src/Pill';
 import Popper from 'src/Popper';
 import ProfileCell from 'src/ProfileCell';
 import RadioButton from 'src/RadioButton';
@@ -60,6 +60,7 @@ export {
   ModalFooter,
   ModalHeader,
   Pill,
+  PILL_COLORS,
   Popper,
   ProfileCell,
   RadioButton,

--- a/stories/Styles/Typography/Typography.stories.jsx
+++ b/stories/Styles/Typography/Typography.stories.jsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 
-import Pill from 'src/Pill';
+import { Pill, PILL_COLORS } from 'src/Pill';
 
 import './Typography.scss';
 import PropTypes from 'prop-types';
@@ -30,7 +30,7 @@ TypographyExample.propTypes = {
 const TypographyTokens = ({ tokens }) => (
   <ul>
     {
-      tokens.map((token) => <li key={token}><Pill color="blue" size="sm" text={token} /></li>)
+      tokens.map((token) => <li key={token}><Pill color={PILL_COLORS.BLUE} text={token} /></li>)
     }
   </ul>
 );


### PR DESCRIPTION
update default Pill size to `font-type-20`

added a Pill with link variant. If an `href` prop is provided, renders an `<a>` tag. Otherwise renders a `<span>`. Wasn't sure if it was better to render an `<a>` within the existing span to avoid code duplication and then add some scss hover pseudoclass or just do this for better semantics?

~~not sure what's been decided for the `large` variant. Keep it at `font-type-40`?~~
Decision was made to remove the `large` variant for now.
