### PR TITLE
feature/UIDS-290-table-edits-part-2-multiple-sticky-columns

### DIFF
--- a/scss/box_shadow.scss
+++ b/scss/box_shadow.scss
@@ -5,7 +5,8 @@ $ux-box-shadow-light: 0 1px 1px $ux-navbar-shadow-color;
 
 $ux-box-shadow-card: 0 2px 4px rgba(0,0,0,0.1);
 
-$ux-box-shadow-table-sticky-column: 2px 0px 1px 0px rgba(0, 0, 0, 0.05);
+$ux-box-shadow-table-sticky-column-left: 2px 0px 1px 0px rgba(0, 0, 0, 0.05);
+$ux-box-shadow-table-sticky-column-right: -2px 0px 1px 0px rgba(0, 0, 0, 0.05);
 
 $ux-box-shadow-top: 0 -2px 5px $ux-navbar-shadow-color;
 $ux-box-shadow-top-light: 0 -1px 1px $ux-navbar-shadow-color;

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -9852,7 +9852,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
 </div>
 `;
 
-exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Columns And Header 1`] = `
+exports[`Storyshots Design System/Table Table With Multiple Select And Multiple Sticky Columns And Header 1`] = `
 <div
   style={
     Object {
@@ -10952,6 +10952,1404 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
                 style={Object {}}
               />
             </svg>
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And Header 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <table
+    className="Table"
+  >
+    <thead
+      className="TableHead"
+    >
+      <tr
+        className="TableRow"
+      >
+        <th
+          className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--left TableCell--sticky-row"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
+        >
+          Email
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--left TableCell--sticky-row"
+          style={
+            Object {
+              "left": "10rem",
+            }
+          }
+        >
+          First name 
+          <span
+            style={
+              Object {
+                "float": "right",
+              }
+            }
+          >
+            <button
+              onClick={[Function]}
+              style={
+                Object {
+                  "background": "none",
+                  "border": "none",
+                  "color": "#337AB7",
+                }
+              }
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-thumbtack fa-w-12 "
+                data-icon="thumbtack"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 384 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M298.028 214.267L285.793 96H328c13.255 0 24-10.745 24-24V24c0-13.255-10.745-24-24-24H56C42.745 0 32 10.745 32 24v48c0 13.255 10.745 24 24 24h42.207L85.972 214.267C37.465 236.82 0 277.261 0 328c0 13.255 10.745 24 24 24h136v104.007c0 1.242.289 2.467.845 3.578l24 48c2.941 5.882 11.364 5.893 14.311 0l24-48a8.008 8.008 0 0 0 .845-3.578V352h136c13.255 0 24-10.745 24-24-.001-51.183-37.983-91.42-85.973-113.733z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </button>
+          </span>
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
+        >
+          Last name
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
+        >
+          Phone number
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
+        >
+          Date added
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
+        >
+          Last invited
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
+        >
+          Last applied
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
+        >
+          Date
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
+        >
+          Boolean
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
+        >
+          Decimal
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-row"
+          style={null}
+        >
+          Pick any
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--right TableCell--sticky-row"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          Action
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      className="TableBody"
+    >
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          riley@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          Riley
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          Researcher
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          +18888888888
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          01/22/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          3 days ago
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          1 day ago
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
+          </button>
+        </td>
+      </tr>
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          basel123@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          Basel
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          Fakhoury
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          +467234460393409
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          04/08/2020
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
+          </button>
+        </td>
+      </tr>
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          bob456@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          Bob
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          Saris
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          01/26/2020
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          2 days ago
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
+          </button>
+        </td>
+      </tr>
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          dennis789@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          Dennis
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          Meng
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          12/21/2020
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          6 days ago
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          5 days ago
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
+          </button>
+        </td>
+      </tr>
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          erin007@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          Erin
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          May
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          +1499090234
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          09/21/2020
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          23 days ago
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
+          </button>
+        </td>
+      </tr>
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          jh247@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          John-Henry
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          Forster
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          +1888938488
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/14/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
+          </button>
+        </td>
+      </tr>
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          jason909085119@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          Jason
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          Basuil
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          01/01/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
+          </button>
+        </td>
+      </tr>
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          rachel777@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          Rachel
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          Rapollo
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          +40988881822329308
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          07/21/2019
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
+          </button>
+        </td>
+      </tr>
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          jojo330@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          JoJo
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          Lee
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          +1898374888
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          09/17/2020
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          1 day ago
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          2 days ago
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
+          </button>
+        </td>
+      </tr>
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          faus555@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          Faustino
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          Gaitan
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          +90918394789
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          06/13/2019
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
           </button>
         </td>
       </tr>
@@ -13071,1404 +14469,6 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
           style={Object {}}
         >
           5
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-`;
-
-exports[`Storyshots Design System/Table Table With Sticky Columns And Header 1`] = `
-<div
-  style={
-    Object {
-      "padding": "1rem",
-    }
-  }
->
-  <table
-    className="Table"
-  >
-    <thead
-      className="TableHead"
-    >
-      <tr
-        className="TableRow"
-      >
-        <th
-          className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--left TableCell--sticky-row"
-          style={
-            Object {
-              "left": "0rem",
-            }
-          }
-        >
-          Email
-        </th>
-        <th
-          className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--left TableCell--sticky-row"
-          style={
-            Object {
-              "left": "10rem",
-            }
-          }
-        >
-          First name 
-          <span
-            style={
-              Object {
-                "float": "right",
-              }
-            }
-          >
-            <button
-              onClick={[Function]}
-              style={
-                Object {
-                  "background": "none",
-                  "border": "none",
-                  "color": "#337AB7",
-                }
-              }
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                className="svg-inline--fa fa-thumbtack fa-w-12 "
-                data-icon="thumbtack"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                style={Object {}}
-                viewBox="0 0 384 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M298.028 214.267L285.793 96H328c13.255 0 24-10.745 24-24V24c0-13.255-10.745-24-24-24H56C42.745 0 32 10.745 32 24v48c0 13.255 10.745 24 24 24h42.207L85.972 214.267C37.465 236.82 0 277.261 0 328c0 13.255 10.745 24 24 24h136v104.007c0 1.242.289 2.467.845 3.578l24 48c2.941 5.882 11.364 5.893 14.311 0l24-48a8.008 8.008 0 0 0 .845-3.578V352h136c13.255 0 24-10.745 24-24-.001-51.183-37.983-91.42-85.973-113.733z"
-                  fill="currentColor"
-                  style={Object {}}
-                />
-              </svg>
-            </button>
-          </span>
-        </th>
-        <th
-          className="TableCell TableCell__header TableCell--sticky-row"
-          style={null}
-        >
-          Last name
-        </th>
-        <th
-          className="TableCell TableCell__header TableCell--sticky-row"
-          style={null}
-        >
-          Phone number
-        </th>
-        <th
-          className="TableCell TableCell__header TableCell--sticky-row"
-          style={null}
-        >
-          Date added
-        </th>
-        <th
-          className="TableCell TableCell__header TableCell--sticky-row"
-          style={null}
-        >
-          Last invited
-        </th>
-        <th
-          className="TableCell TableCell__header TableCell--sticky-row"
-          style={null}
-        >
-          Last applied
-        </th>
-        <th
-          className="TableCell TableCell__header TableCell--sticky-row"
-          style={null}
-        >
-          Date
-        </th>
-        <th
-          className="TableCell TableCell__header TableCell--sticky-row"
-          style={null}
-        >
-          Boolean
-        </th>
-        <th
-          className="TableCell TableCell__header TableCell--sticky-row"
-          style={null}
-        >
-          Decimal
-        </th>
-        <th
-          className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-row"
-          style={null}
-        >
-          Pick any
-        </th>
-        <th
-          className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--right TableCell--sticky-row"
-          style={
-            Object {
-              "right": "0rem",
-            }
-          }
-        >
-          Action
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      className="TableBody"
-    >
-      <tr
-        className="TableRow"
-      >
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "0rem",
-              "maxWidth": "10rem",
-            }
-          }
-        >
-          riley@userinterviews.com
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "10rem",
-              "minWidth": "10rem",
-            }
-          }
-        >
-          Riley
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          Researcher
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          +18888888888
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          01/22/2021
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          3 days ago
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          1 day ago
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          03/25/2021
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          True
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
-          style={
-            Object {
-              "right": "0rem",
-            }
-          }
-        >
-          <button
-            style={
-              Object {
-                "background": "none",
-                "border": "1px solid #337AB7",
-                "borderRadius": "4px",
-                "color": "#337AB7",
-                "fontWeight": "700",
-                "padding": "4px 8px",
-              }
-            }
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-file-alt fa-w-12 "
-              data-icon="file-alt"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={
-                Object {
-                  "marginRight": "10px",
-                }
-              }
-              viewBox="0 0 384 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-            Edit
-          </button>
-        </td>
-      </tr>
-      <tr
-        className="TableRow"
-      >
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "0rem",
-              "maxWidth": "10rem",
-            }
-          }
-        >
-          basel123@userinterviews.com
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "10rem",
-              "minWidth": "10rem",
-            }
-          }
-        >
-          Basel
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          Fakhoury
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          +467234460393409
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          04/08/2020
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          03/25/2021
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          True
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
-          style={
-            Object {
-              "right": "0rem",
-            }
-          }
-        >
-          <button
-            style={
-              Object {
-                "background": "none",
-                "border": "1px solid #337AB7",
-                "borderRadius": "4px",
-                "color": "#337AB7",
-                "fontWeight": "700",
-                "padding": "4px 8px",
-              }
-            }
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-file-alt fa-w-12 "
-              data-icon="file-alt"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={
-                Object {
-                  "marginRight": "10px",
-                }
-              }
-              viewBox="0 0 384 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-            Edit
-          </button>
-        </td>
-      </tr>
-      <tr
-        className="TableRow"
-      >
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "0rem",
-              "maxWidth": "10rem",
-            }
-          }
-        >
-          bob456@userinterviews.com
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "10rem",
-              "minWidth": "10rem",
-            }
-          }
-        >
-          Bob
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          Saris
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          01/26/2020
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          2 days ago
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          03/25/2021
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          True
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
-          style={
-            Object {
-              "right": "0rem",
-            }
-          }
-        >
-          <button
-            style={
-              Object {
-                "background": "none",
-                "border": "1px solid #337AB7",
-                "borderRadius": "4px",
-                "color": "#337AB7",
-                "fontWeight": "700",
-                "padding": "4px 8px",
-              }
-            }
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-file-alt fa-w-12 "
-              data-icon="file-alt"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={
-                Object {
-                  "marginRight": "10px",
-                }
-              }
-              viewBox="0 0 384 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-            Edit
-          </button>
-        </td>
-      </tr>
-      <tr
-        className="TableRow"
-      >
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "0rem",
-              "maxWidth": "10rem",
-            }
-          }
-        >
-          dennis789@userinterviews.com
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "10rem",
-              "minWidth": "10rem",
-            }
-          }
-        >
-          Dennis
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          Meng
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          12/21/2020
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          6 days ago
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          5 days ago
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          03/25/2021
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          True
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
-          style={
-            Object {
-              "right": "0rem",
-            }
-          }
-        >
-          <button
-            style={
-              Object {
-                "background": "none",
-                "border": "1px solid #337AB7",
-                "borderRadius": "4px",
-                "color": "#337AB7",
-                "fontWeight": "700",
-                "padding": "4px 8px",
-              }
-            }
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-file-alt fa-w-12 "
-              data-icon="file-alt"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={
-                Object {
-                  "marginRight": "10px",
-                }
-              }
-              viewBox="0 0 384 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-            Edit
-          </button>
-        </td>
-      </tr>
-      <tr
-        className="TableRow"
-      >
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "0rem",
-              "maxWidth": "10rem",
-            }
-          }
-        >
-          erin007@userinterviews.com
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "10rem",
-              "minWidth": "10rem",
-            }
-          }
-        >
-          Erin
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          May
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          +1499090234
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          09/21/2020
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          23 days ago
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          03/25/2021
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          True
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
-          style={
-            Object {
-              "right": "0rem",
-            }
-          }
-        >
-          <button
-            style={
-              Object {
-                "background": "none",
-                "border": "1px solid #337AB7",
-                "borderRadius": "4px",
-                "color": "#337AB7",
-                "fontWeight": "700",
-                "padding": "4px 8px",
-              }
-            }
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-file-alt fa-w-12 "
-              data-icon="file-alt"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={
-                Object {
-                  "marginRight": "10px",
-                }
-              }
-              viewBox="0 0 384 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-            Edit
-          </button>
-        </td>
-      </tr>
-      <tr
-        className="TableRow"
-      >
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "0rem",
-              "maxWidth": "10rem",
-            }
-          }
-        >
-          jh247@userinterviews.com
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "10rem",
-              "minWidth": "10rem",
-            }
-          }
-        >
-          John-Henry
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          Forster
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          +1888938488
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          03/14/2021
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          03/25/2021
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          True
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
-          style={
-            Object {
-              "right": "0rem",
-            }
-          }
-        >
-          <button
-            style={
-              Object {
-                "background": "none",
-                "border": "1px solid #337AB7",
-                "borderRadius": "4px",
-                "color": "#337AB7",
-                "fontWeight": "700",
-                "padding": "4px 8px",
-              }
-            }
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-file-alt fa-w-12 "
-              data-icon="file-alt"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={
-                Object {
-                  "marginRight": "10px",
-                }
-              }
-              viewBox="0 0 384 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-            Edit
-          </button>
-        </td>
-      </tr>
-      <tr
-        className="TableRow"
-      >
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "0rem",
-              "maxWidth": "10rem",
-            }
-          }
-        >
-          jason909085119@userinterviews.com
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "10rem",
-              "minWidth": "10rem",
-            }
-          }
-        >
-          Jason
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          Basuil
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          01/01/2021
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          03/25/2021
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          True
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
-          style={
-            Object {
-              "right": "0rem",
-            }
-          }
-        >
-          <button
-            style={
-              Object {
-                "background": "none",
-                "border": "1px solid #337AB7",
-                "borderRadius": "4px",
-                "color": "#337AB7",
-                "fontWeight": "700",
-                "padding": "4px 8px",
-              }
-            }
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-file-alt fa-w-12 "
-              data-icon="file-alt"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={
-                Object {
-                  "marginRight": "10px",
-                }
-              }
-              viewBox="0 0 384 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-            Edit
-          </button>
-        </td>
-      </tr>
-      <tr
-        className="TableRow"
-      >
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "0rem",
-              "maxWidth": "10rem",
-            }
-          }
-        >
-          rachel777@userinterviews.com
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "10rem",
-              "minWidth": "10rem",
-            }
-          }
-        >
-          Rachel
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          Rapollo
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          +40988881822329308
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          07/21/2019
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          03/25/2021
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          True
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
-          style={
-            Object {
-              "right": "0rem",
-            }
-          }
-        >
-          <button
-            style={
-              Object {
-                "background": "none",
-                "border": "1px solid #337AB7",
-                "borderRadius": "4px",
-                "color": "#337AB7",
-                "fontWeight": "700",
-                "padding": "4px 8px",
-              }
-            }
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-file-alt fa-w-12 "
-              data-icon="file-alt"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={
-                Object {
-                  "marginRight": "10px",
-                }
-              }
-              viewBox="0 0 384 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-            Edit
-          </button>
-        </td>
-      </tr>
-      <tr
-        className="TableRow"
-      >
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "0rem",
-              "maxWidth": "10rem",
-            }
-          }
-        >
-          jojo330@userinterviews.com
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "10rem",
-              "minWidth": "10rem",
-            }
-          }
-        >
-          JoJo
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          Lee
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          +1898374888
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          09/17/2020
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          1 day ago
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          2 days ago
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          03/25/2021
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          True
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
-          style={
-            Object {
-              "right": "0rem",
-            }
-          }
-        >
-          <button
-            style={
-              Object {
-                "background": "none",
-                "border": "1px solid #337AB7",
-                "borderRadius": "4px",
-                "color": "#337AB7",
-                "fontWeight": "700",
-                "padding": "4px 8px",
-              }
-            }
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-file-alt fa-w-12 "
-              data-icon="file-alt"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={
-                Object {
-                  "marginRight": "10px",
-                }
-              }
-              viewBox="0 0 384 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-            Edit
-          </button>
-        </td>
-      </tr>
-      <tr
-        className="TableRow"
-      >
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "0rem",
-              "maxWidth": "10rem",
-            }
-          }
-        >
-          faus555@userinterviews.com
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
-          style={
-            Object {
-              "left": "10rem",
-              "minWidth": "10rem",
-            }
-          }
-        >
-          Faustino
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          Gaitan
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          +90918394789
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          06/13/2019
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          03/25/2021
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          True
-        </td>
-        <td
-          className="TableCell"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--sticky-column"
-          style={Object {}}
-        >
-          -
-        </td>
-        <td
-          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
-          style={
-            Object {
-              "right": "0rem",
-            }
-          }
-        >
-          <button
-            style={
-              Object {
-                "background": "none",
-                "border": "1px solid #337AB7",
-                "borderRadius": "4px",
-                "color": "#337AB7",
-                "fontWeight": "700",
-                "padding": "4px 8px",
-              }
-            }
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-file-alt fa-w-12 "
-              data-icon="file-alt"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={
-                Object {
-                  "marginRight": "10px",
-                }
-              }
-              viewBox="0 0 384 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-            Edit
-          </button>
         </td>
       </tr>
     </tbody>

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -7760,7 +7760,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "maxWidth": "12rem",
+              "maxWidth": "192px",
             }
           }
         >
@@ -7771,7 +7771,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "minWidth": "20rem",
+              "minWidth": "320px",
             }
           }
         >
@@ -7816,7 +7816,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "maxWidth": "12rem",
+              "maxWidth": "192px",
             }
           }
         >
@@ -7827,7 +7827,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "minWidth": "20rem",
+              "minWidth": "320px",
             }
           }
         >
@@ -7872,7 +7872,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "maxWidth": "12rem",
+              "maxWidth": "192px",
             }
           }
         >
@@ -7883,7 +7883,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "minWidth": "20rem",
+              "minWidth": "320px",
             }
           }
         >
@@ -7928,7 +7928,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "maxWidth": "12rem",
+              "maxWidth": "192px",
             }
           }
         >
@@ -7939,7 +7939,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "minWidth": "20rem",
+              "minWidth": "320px",
             }
           }
         >
@@ -7984,7 +7984,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "maxWidth": "12rem",
+              "maxWidth": "192px",
             }
           }
         >
@@ -7995,7 +7995,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "minWidth": "20rem",
+              "minWidth": "320px",
             }
           }
         >
@@ -8040,7 +8040,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "maxWidth": "12rem",
+              "maxWidth": "192px",
             }
           }
         >
@@ -8051,7 +8051,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "minWidth": "20rem",
+              "minWidth": "320px",
             }
           }
         >
@@ -8096,7 +8096,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "maxWidth": "12rem",
+              "maxWidth": "192px",
             }
           }
         >
@@ -8107,7 +8107,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "minWidth": "20rem",
+              "minWidth": "320px",
             }
           }
         >
@@ -8152,7 +8152,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "maxWidth": "12rem",
+              "maxWidth": "192px",
             }
           }
         >
@@ -8163,7 +8163,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "minWidth": "20rem",
+              "minWidth": "320px",
             }
           }
         >
@@ -8208,7 +8208,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "maxWidth": "12rem",
+              "maxWidth": "192px",
             }
           }
         >
@@ -8219,7 +8219,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "minWidth": "20rem",
+              "minWidth": "320px",
             }
           }
         >
@@ -8264,7 +8264,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "maxWidth": "12rem",
+              "maxWidth": "192px",
             }
           }
         >
@@ -8275,7 +8275,7 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
           className="TableCell"
           style={
             Object {
-              "minWidth": "20rem",
+              "minWidth": "320px",
             }
           }
         >
@@ -11111,7 +11111,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "0px",
-              "maxWidth": "10rem",
+              "maxWidth": "160px",
             }
           }
         >
@@ -11122,7 +11122,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "160px",
-              "minWidth": "10rem",
+              "minWidth": "160px",
             }
           }
         >
@@ -11236,7 +11236,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "0px",
-              "maxWidth": "10rem",
+              "maxWidth": "160px",
             }
           }
         >
@@ -11247,7 +11247,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "160px",
-              "minWidth": "10rem",
+              "minWidth": "160px",
             }
           }
         >
@@ -11361,7 +11361,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "0px",
-              "maxWidth": "10rem",
+              "maxWidth": "160px",
             }
           }
         >
@@ -11372,7 +11372,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "160px",
-              "minWidth": "10rem",
+              "minWidth": "160px",
             }
           }
         >
@@ -11486,7 +11486,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "0px",
-              "maxWidth": "10rem",
+              "maxWidth": "160px",
             }
           }
         >
@@ -11497,7 +11497,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "160px",
-              "minWidth": "10rem",
+              "minWidth": "160px",
             }
           }
         >
@@ -11611,7 +11611,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "0px",
-              "maxWidth": "10rem",
+              "maxWidth": "160px",
             }
           }
         >
@@ -11622,7 +11622,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "160px",
-              "minWidth": "10rem",
+              "minWidth": "160px",
             }
           }
         >
@@ -11736,7 +11736,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "0px",
-              "maxWidth": "10rem",
+              "maxWidth": "160px",
             }
           }
         >
@@ -11747,7 +11747,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "160px",
-              "minWidth": "10rem",
+              "minWidth": "160px",
             }
           }
         >
@@ -11861,7 +11861,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "0px",
-              "maxWidth": "10rem",
+              "maxWidth": "160px",
             }
           }
         >
@@ -11872,7 +11872,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "160px",
-              "minWidth": "10rem",
+              "minWidth": "160px",
             }
           }
         >
@@ -11986,7 +11986,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "0px",
-              "maxWidth": "10rem",
+              "maxWidth": "160px",
             }
           }
         >
@@ -11997,7 +11997,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "160px",
-              "minWidth": "10rem",
+              "minWidth": "160px",
             }
           }
         >
@@ -12111,7 +12111,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "0px",
-              "maxWidth": "10rem",
+              "maxWidth": "160px",
             }
           }
         >
@@ -12122,7 +12122,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "160px",
-              "minWidth": "10rem",
+              "minWidth": "160px",
             }
           }
         >
@@ -12236,7 +12236,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "0px",
-              "maxWidth": "10rem",
+              "maxWidth": "160px",
             }
           }
         >
@@ -12247,7 +12247,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           style={
             Object {
               "left": "160px",
-              "minWidth": "10rem",
+              "minWidth": "160px",
             }
           }
         >

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -5082,44 +5082,53 @@ exports[`Storyshots Design System/Table Default 1`] = `
       >
         <th
           className="TableCell TableCell__header"
+          style={null}
         />
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Status
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Email
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           First name
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Last name
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Phone number
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Date added
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Last invited
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Last applied
         </th>
@@ -5133,53 +5142,53 @@ exports[`Storyshots Design System/Table Default 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         />
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Approved
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           riley@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Riley
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Researcher
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +18888888888
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/22/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           3 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           1 day ago
         </td>
@@ -5189,7 +5198,7 @@ exports[`Storyshots Design System/Table Default 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <span
             className="Pill Pill--blue"
@@ -5199,49 +5208,49 @@ exports[`Storyshots Design System/Table Default 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Approved
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           basel123@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Basel
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Fakhoury
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +467234460393409
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           04/08/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
@@ -5251,53 +5260,53 @@ exports[`Storyshots Design System/Table Default 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         />
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Paid
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           bob456@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Bob
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Saris
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/26/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           2 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
@@ -5307,53 +5316,53 @@ exports[`Storyshots Design System/Table Default 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         />
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Confirmed
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           dennis789@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Dennis
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Meng
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           12/21/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           6 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           5 days ago
         </td>
@@ -5363,7 +5372,7 @@ exports[`Storyshots Design System/Table Default 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <span
             className="Pill Pill--blue"
@@ -5373,49 +5382,49 @@ exports[`Storyshots Design System/Table Default 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Confirmed
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           erin007@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Erin
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           May
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1499090234
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           09/21/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           23 days ago
         </td>
@@ -5425,7 +5434,7 @@ exports[`Storyshots Design System/Table Default 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <span
             className="Pill Pill--blue"
@@ -5435,49 +5444,49 @@ exports[`Storyshots Design System/Table Default 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Qualified
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           jh247@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           John-Henry
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Forster
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1888938488
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           03/14/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
@@ -5487,7 +5496,7 @@ exports[`Storyshots Design System/Table Default 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <span
             className="Pill Pill--blue"
@@ -5497,49 +5506,49 @@ exports[`Storyshots Design System/Table Default 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Approved
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           jason909085119@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Jason
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Basuil
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/01/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
@@ -5549,7 +5558,7 @@ exports[`Storyshots Design System/Table Default 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <span
             className="Pill Pill--blue"
@@ -5559,49 +5568,49 @@ exports[`Storyshots Design System/Table Default 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Qualified
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           rachel777@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Rachel
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Rapollo
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +40988881822329308
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           07/21/2019
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
@@ -5611,7 +5620,7 @@ exports[`Storyshots Design System/Table Default 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <span
             className="Pill Pill--blue"
@@ -5621,49 +5630,49 @@ exports[`Storyshots Design System/Table Default 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Approved
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           jojo330@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           JoJo
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Lee
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1898374888
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           09/17/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           1 day ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           2 days ago
         </td>
@@ -5673,7 +5682,7 @@ exports[`Storyshots Design System/Table Default 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <span
             className="Pill Pill--blue"
@@ -5683,49 +5692,49 @@ exports[`Storyshots Design System/Table Default 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Approved
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           faus555@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Faustino
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Gaitan
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +90918394789
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           06/13/2019
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
@@ -5786,36 +5795,43 @@ exports[`Storyshots Design System/Table Table On Card 1`] = `
           >
             <th
               className="TableCell TableCell__header"
+              style={null}
             >
               Email
             </th>
             <th
               className="TableCell TableCell__header"
+              style={null}
             >
               First name
             </th>
             <th
               className="TableCell TableCell__header"
+              style={null}
             >
               Last name
             </th>
             <th
               className="TableCell TableCell__header"
+              style={null}
             >
               Phone number
             </th>
             <th
               className="TableCell TableCell__header"
+              style={null}
             >
               Date added
             </th>
             <th
               className="TableCell TableCell__header"
+              style={null}
             >
               Last invited
             </th>
             <th
               className="TableCell TableCell__header"
+              style={null}
             >
               Last applied
             </th>
@@ -5829,43 +5845,43 @@ exports[`Storyshots Design System/Table Table On Card 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               riley@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Riley
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Researcher
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               +18888888888
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               01/22/2021
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               3 days ago
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               1 day ago
             </td>
@@ -5875,43 +5891,43 @@ exports[`Storyshots Design System/Table Table On Card 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               basel123@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Basel
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Fakhoury
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               +467234460393409
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               04/08/2020
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
@@ -5921,43 +5937,43 @@ exports[`Storyshots Design System/Table Table On Card 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               bob456@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Bob
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Saris
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               01/26/2020
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               2 days ago
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
@@ -5967,43 +5983,43 @@ exports[`Storyshots Design System/Table Table On Card 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               dennis789@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Dennis
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Meng
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               12/21/2020
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               6 days ago
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               5 days ago
             </td>
@@ -6013,43 +6029,43 @@ exports[`Storyshots Design System/Table Table On Card 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               erin007@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Erin
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               May
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               +1499090234
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               09/21/2020
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               23 days ago
             </td>
@@ -6059,43 +6075,43 @@ exports[`Storyshots Design System/Table Table On Card 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               jh247@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               John-Henry
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Forster
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               +1888938488
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               03/14/2021
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
@@ -6105,43 +6121,43 @@ exports[`Storyshots Design System/Table Table On Card 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               jason909085119@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Jason
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Basuil
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               01/01/2021
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
@@ -6151,43 +6167,43 @@ exports[`Storyshots Design System/Table Table On Card 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               rachel777@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Rachel
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Rapollo
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               +40988881822329308
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               07/21/2019
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
@@ -6197,43 +6213,43 @@ exports[`Storyshots Design System/Table Table On Card 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               jojo330@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               JoJo
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Lee
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               +1898374888
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               09/17/2020
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               1 day ago
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               2 days ago
             </td>
@@ -6243,43 +6259,43 @@ exports[`Storyshots Design System/Table Table On Card 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               faus555@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Faustino
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Gaitan
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               +90918394789
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               06/13/2019
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
@@ -6328,36 +6344,43 @@ exports[`Storyshots Design System/Table Table On Card No Padding 1`] = `
           >
             <th
               className="TableCell TableCell__header"
+              style={null}
             >
               Email
             </th>
             <th
               className="TableCell TableCell__header"
+              style={null}
             >
               First name
             </th>
             <th
               className="TableCell TableCell__header"
+              style={null}
             >
               Last name
             </th>
             <th
               className="TableCell TableCell__header"
+              style={null}
             >
               Phone number
             </th>
             <th
               className="TableCell TableCell__header"
+              style={null}
             >
               Date added
             </th>
             <th
               className="TableCell TableCell__header"
+              style={null}
             >
               Last invited
             </th>
             <th
               className="TableCell TableCell__header"
+              style={null}
             >
               Last applied
             </th>
@@ -6371,43 +6394,43 @@ exports[`Storyshots Design System/Table Table On Card No Padding 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               riley@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Riley
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Researcher
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               +18888888888
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               01/22/2021
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               3 days ago
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               1 day ago
             </td>
@@ -6417,43 +6440,43 @@ exports[`Storyshots Design System/Table Table On Card No Padding 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               basel123@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Basel
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Fakhoury
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               +467234460393409
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               04/08/2020
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
@@ -6463,43 +6486,43 @@ exports[`Storyshots Design System/Table Table On Card No Padding 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               bob456@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Bob
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Saris
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               01/26/2020
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               2 days ago
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
@@ -6509,43 +6532,43 @@ exports[`Storyshots Design System/Table Table On Card No Padding 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               dennis789@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Dennis
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Meng
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               12/21/2020
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               6 days ago
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               5 days ago
             </td>
@@ -6555,43 +6578,43 @@ exports[`Storyshots Design System/Table Table On Card No Padding 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               erin007@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Erin
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               May
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               +1499090234
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               09/21/2020
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               23 days ago
             </td>
@@ -6601,43 +6624,43 @@ exports[`Storyshots Design System/Table Table On Card No Padding 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               jh247@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               John-Henry
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Forster
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               +1888938488
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               03/14/2021
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
@@ -6647,43 +6670,43 @@ exports[`Storyshots Design System/Table Table On Card No Padding 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               jason909085119@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Jason
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Basuil
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               01/01/2021
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
@@ -6693,43 +6716,43 @@ exports[`Storyshots Design System/Table Table On Card No Padding 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               rachel777@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Rachel
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Rapollo
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               +40988881822329308
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               07/21/2019
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
@@ -6739,43 +6762,43 @@ exports[`Storyshots Design System/Table Table On Card No Padding 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               jojo330@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               JoJo
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Lee
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               +1898374888
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               09/17/2020
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               1 day ago
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               2 days ago
             </td>
@@ -6785,43 +6808,43 @@ exports[`Storyshots Design System/Table Table On Card No Padding 1`] = `
           >
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               faus555@userinterviews.com
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Faustino
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               Gaitan
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               +90918394789
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               06/13/2019
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
             <td
               className="TableCell"
-              style={null}
+              style={Object {}}
             >
               -
             </td>
@@ -6852,21 +6875,25 @@ exports[`Storyshots Design System/Table Table With Cell Right Alignment 1`] = `
       >
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           First name
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Last name
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Incentives earned
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Unsubscribed
         </th>
@@ -6880,25 +6907,25 @@ exports[`Storyshots Design System/Table Table With Cell Right Alignment 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Anna
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Boston
         </td>
         <td
           className="TableCell TableCell--right"
-          style={null}
+          style={Object {}}
         >
           0
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           False
         </td>
@@ -6908,25 +6935,25 @@ exports[`Storyshots Design System/Table Table With Cell Right Alignment 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Carly
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Dixon
         </td>
         <td
           className="TableCell TableCell--right"
-          style={null}
+          style={Object {}}
         >
           1
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           True
         </td>
@@ -6936,25 +6963,25 @@ exports[`Storyshots Design System/Table Table With Cell Right Alignment 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Erin
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Fitzgerald
         </td>
         <td
           className="TableCell TableCell--right"
-          style={null}
+          style={Object {}}
         >
           10
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           True
         </td>
@@ -6964,25 +6991,25 @@ exports[`Storyshots Design System/Table Table With Cell Right Alignment 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Gregg
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Harris
         </td>
         <td
           className="TableCell TableCell--right"
-          style={null}
+          style={Object {}}
         >
           20
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           True
         </td>
@@ -6992,25 +7019,25 @@ exports[`Storyshots Design System/Table Table With Cell Right Alignment 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Izzie
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Jackson
         </td>
         <td
           className="TableCell TableCell--right"
-          style={null}
+          style={Object {}}
         >
           100
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           False
         </td>
@@ -7060,39 +7087,47 @@ exports[`Storyshots Design System/Table Table With Compact Option 1`] = `
         >
           <th
             className="TableCell TableCell__header"
+            style={null}
           />
           <th
             className="TableCell TableCell__header"
+            style={null}
           >
             Email
           </th>
           <th
             className="TableCell TableCell__header"
+            style={null}
           >
             First name
           </th>
           <th
             className="TableCell TableCell__header"
+            style={null}
           >
             Last name
           </th>
           <th
             className="TableCell TableCell__header"
+            style={null}
           >
             Phone number
           </th>
           <th
             className="TableCell TableCell__header"
+            style={null}
           >
             Date added
           </th>
           <th
             className="TableCell TableCell__header"
+            style={null}
           >
             Last invited
           </th>
           <th
             className="TableCell TableCell__header"
+            style={null}
           >
             Last applied
           </th>
@@ -7106,47 +7141,47 @@ exports[`Storyshots Design System/Table Table With Compact Option 1`] = `
         >
           <td
             className="TableCell"
-            style={null}
+            style={Object {}}
           />
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             riley@userinterviews.com
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             Riley
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             Researcher
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             +18888888888
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             01/22/2021
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             3 days ago
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             1 day ago
           </td>
@@ -7156,7 +7191,7 @@ exports[`Storyshots Design System/Table Table With Compact Option 1`] = `
         >
           <td
             className="TableCell"
-            style={null}
+            style={Object {}}
           >
             <span
               className="Pill Pill--blue"
@@ -7166,43 +7201,43 @@ exports[`Storyshots Design System/Table Table With Compact Option 1`] = `
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             basel123@userinterviews.com
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             Basel
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             Fakhoury
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             +467234460393409
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             04/08/2020
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             -
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             -
           </td>
@@ -7212,47 +7247,47 @@ exports[`Storyshots Design System/Table Table With Compact Option 1`] = `
         >
           <td
             className="TableCell"
-            style={null}
+            style={Object {}}
           />
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             bob456@userinterviews.com
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             Bob
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             Saris
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             01/26/2020
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             2 days ago
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             -
           </td>
@@ -7262,47 +7297,47 @@ exports[`Storyshots Design System/Table Table With Compact Option 1`] = `
         >
           <td
             className="TableCell"
-            style={null}
+            style={Object {}}
           />
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             dennis789@userinterviews.com
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             Dennis
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             Meng
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             12/21/2020
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             6 days ago
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             5 days ago
           </td>
@@ -7312,7 +7347,7 @@ exports[`Storyshots Design System/Table Table With Compact Option 1`] = `
         >
           <td
             className="TableCell"
-            style={null}
+            style={Object {}}
           >
             <span
               className="Pill Pill--blue"
@@ -7322,43 +7357,43 @@ exports[`Storyshots Design System/Table Table With Compact Option 1`] = `
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             erin007@userinterviews.com
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             Erin
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             May
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             +1499090234
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             09/21/2020
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             -
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             23 days ago
           </td>
@@ -7368,7 +7403,7 @@ exports[`Storyshots Design System/Table Table With Compact Option 1`] = `
         >
           <td
             className="TableCell"
-            style={null}
+            style={Object {}}
           >
             <span
               className="Pill Pill--blue"
@@ -7378,43 +7413,43 @@ exports[`Storyshots Design System/Table Table With Compact Option 1`] = `
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             jh247@userinterviews.com
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             John-Henry
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             Forster
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             +1888938488
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             03/14/2021
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             -
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             -
           </td>
@@ -7424,7 +7459,7 @@ exports[`Storyshots Design System/Table Table With Compact Option 1`] = `
         >
           <td
             className="TableCell"
-            style={null}
+            style={Object {}}
           >
             <span
               className="Pill Pill--blue"
@@ -7434,43 +7469,43 @@ exports[`Storyshots Design System/Table Table With Compact Option 1`] = `
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             jason909085119@userinterviews.com
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             Jason
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             Basuil
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             01/01/2021
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             -
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             -
           </td>
@@ -7480,7 +7515,7 @@ exports[`Storyshots Design System/Table Table With Compact Option 1`] = `
         >
           <td
             className="TableCell"
-            style={null}
+            style={Object {}}
           >
             <span
               className="Pill Pill--blue"
@@ -7490,43 +7525,43 @@ exports[`Storyshots Design System/Table Table With Compact Option 1`] = `
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             rachel777@userinterviews.com
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             Rachel
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             Rapollo
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             +40988881822329308
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             07/21/2019
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             -
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             -
           </td>
@@ -7536,7 +7571,7 @@ exports[`Storyshots Design System/Table Table With Compact Option 1`] = `
         >
           <td
             className="TableCell"
-            style={null}
+            style={Object {}}
           >
             <span
               className="Pill Pill--blue"
@@ -7546,43 +7581,43 @@ exports[`Storyshots Design System/Table Table With Compact Option 1`] = `
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             jojo330@userinterviews.com
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             JoJo
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             Lee
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             +1898374888
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             09/17/2020
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             1 day ago
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             2 days ago
           </td>
@@ -7592,7 +7627,7 @@ exports[`Storyshots Design System/Table Table With Compact Option 1`] = `
         >
           <td
             className="TableCell"
-            style={null}
+            style={Object {}}
           >
             <span
               className="Pill Pill--blue"
@@ -7602,43 +7637,43 @@ exports[`Storyshots Design System/Table Table With Compact Option 1`] = `
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             faus555@userinterviews.com
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             Faustino
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             Gaitan
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             +90918394789
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             06/13/2019
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             -
           </td>
           <td
             className="TableCell TableCell--compact"
-            style={null}
+            style={Object {}}
           >
             -
           </td>
@@ -7673,36 +7708,43 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
       >
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Email
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           First name
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Last name
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Phone number
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Date added
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Last invited
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Last applied
         </th>
@@ -7738,31 +7780,31 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Researcher
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +18888888888
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/22/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           3 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           1 day ago
         </td>
@@ -7794,31 +7836,31 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Fakhoury
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +467234460393409
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           04/08/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
@@ -7850,31 +7892,31 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Saris
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/26/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           2 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
@@ -7906,31 +7948,31 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Meng
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           12/21/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           6 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           5 days ago
         </td>
@@ -7962,31 +8004,31 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           May
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1499090234
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           09/21/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           23 days ago
         </td>
@@ -8018,31 +8060,31 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Forster
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1888938488
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           03/14/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
@@ -8074,31 +8116,31 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Basuil
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/01/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
@@ -8130,31 +8172,31 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Rapollo
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +40988881822329308
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           07/21/2019
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
@@ -8186,31 +8228,31 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Lee
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1898374888
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           09/17/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           1 day ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           2 days ago
         </td>
@@ -8242,31 +8284,31 @@ exports[`Storyshots Design System/Table Table With Fixed Column Widths 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Gaitan
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +90918394789
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           06/13/2019
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
@@ -8295,41 +8337,49 @@ exports[`Storyshots Design System/Table Table With Multiple Action Column 1`] = 
       >
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Email
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           First name
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Last name
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Phone number
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Date added
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Last invited
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Last applied
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Edit
         </th>
@@ -8343,49 +8393,49 @@ exports[`Storyshots Design System/Table Table With Multiple Action Column 1`] = 
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           riley@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Riley
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Researcher
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +18888888888
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/22/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           3 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           1 day ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             aria-label="kebab button"
@@ -8423,49 +8473,49 @@ exports[`Storyshots Design System/Table Table With Multiple Action Column 1`] = 
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           basel123@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Basel
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Fakhoury
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +467234460393409
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           04/08/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             aria-label="kebab button"
@@ -8503,49 +8553,49 @@ exports[`Storyshots Design System/Table Table With Multiple Action Column 1`] = 
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           bob456@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Bob
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Saris
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/26/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           2 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             aria-label="kebab button"
@@ -8583,49 +8633,49 @@ exports[`Storyshots Design System/Table Table With Multiple Action Column 1`] = 
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           dennis789@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Dennis
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Meng
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           12/21/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           6 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           5 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             aria-label="kebab button"
@@ -8663,49 +8713,49 @@ exports[`Storyshots Design System/Table Table With Multiple Action Column 1`] = 
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           erin007@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Erin
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           May
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1499090234
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           09/21/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           23 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             aria-label="kebab button"
@@ -8743,49 +8793,49 @@ exports[`Storyshots Design System/Table Table With Multiple Action Column 1`] = 
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           jh247@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           John-Henry
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Forster
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1888938488
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           03/14/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             aria-label="kebab button"
@@ -8823,49 +8873,49 @@ exports[`Storyshots Design System/Table Table With Multiple Action Column 1`] = 
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           jason909085119@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Jason
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Basuil
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/01/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             aria-label="kebab button"
@@ -8903,49 +8953,49 @@ exports[`Storyshots Design System/Table Table With Multiple Action Column 1`] = 
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           rachel777@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Rachel
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Rapollo
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +40988881822329308
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           07/21/2019
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             aria-label="kebab button"
@@ -8983,49 +9033,49 @@ exports[`Storyshots Design System/Table Table With Multiple Action Column 1`] = 
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           jojo330@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           JoJo
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Lee
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1898374888
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           09/17/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           1 day ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           2 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             aria-label="kebab button"
@@ -9063,49 +9113,49 @@ exports[`Storyshots Design System/Table Table With Multiple Action Column 1`] = 
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           faus555@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Faustino
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Gaitan
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +90918394789
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           06/13/2019
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             aria-label="kebab button"
@@ -9162,6 +9212,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
       >
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           <input
             id="checkbox"
@@ -9171,36 +9222,43 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Email
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           First name
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Last name
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Phone number
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Date added
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Last invited
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Last applied
         </th>
@@ -9215,7 +9273,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <input
             checked={false}
@@ -9226,43 +9284,43 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           riley@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Riley
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Researcher
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +18888888888
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/22/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           3 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           1 day ago
         </td>
@@ -9273,7 +9331,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <input
             checked={false}
@@ -9284,43 +9342,43 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           basel123@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Basel
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Fakhoury
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +467234460393409
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           04/08/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
@@ -9331,7 +9389,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <input
             checked={false}
@@ -9342,43 +9400,43 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           bob456@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Bob
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Saris
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/26/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           2 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
@@ -9389,7 +9447,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <input
             checked={false}
@@ -9400,43 +9458,43 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           dennis789@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Dennis
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Meng
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           12/21/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           6 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           5 days ago
         </td>
@@ -9447,7 +9505,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <input
             checked={false}
@@ -9458,43 +9516,43 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           erin007@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Erin
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           May
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1499090234
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           09/21/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           23 days ago
         </td>
@@ -9505,7 +9563,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <input
             checked={false}
@@ -9516,43 +9574,43 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           jh247@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           John-Henry
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Forster
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1888938488
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           03/14/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
@@ -9563,7 +9621,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <input
             checked={false}
@@ -9574,43 +9632,43 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           jason909085119@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Jason
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Basuil
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/01/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
@@ -9621,7 +9679,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <input
             checked={false}
@@ -9632,43 +9690,43 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           rachel777@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Rachel
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Rapollo
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +40988881822329308
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           07/21/2019
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
@@ -9679,7 +9737,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <input
             checked={false}
@@ -9690,43 +9748,43 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           jojo330@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           JoJo
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Lee
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1898374888
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           09/17/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           1 day ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           2 days ago
         </td>
@@ -9737,7 +9795,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <input
             checked={false}
@@ -9748,43 +9806,43 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           faus555@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Faustino
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Gaitan
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +90918394789
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           06/13/2019
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
@@ -9794,7 +9852,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select 1`] = `
 </div>
 `;
 
-exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Column And Header 1`] = `
+exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Columns And Header 1`] = `
 <div
   style={
     Object {
@@ -9812,7 +9870,12 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
         className="TableRow"
       >
         <th
-          className="TableCell TableCell__header TableCell--sticky-row"
+          className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--left TableCell--sticky-row"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           <input
             id="checkbox"
@@ -9821,7 +9884,12 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
           />
         </th>
         <th
-          className="TableCell TableCell__header TableCell--sticky-column--corner TableCell--sticky-column TableCell--sticky-row"
+          className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--left TableCell--sticky-row"
+          style={
+            Object {
+              "left": "3.813rem",
+            }
+          }
         >
           Email 
           <span
@@ -9864,33 +9932,43 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
         </th>
         <th
           className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
         >
           First name
         </th>
         <th
           className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
         >
           Last name
         </th>
         <th
           className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
         >
           Phone number
         </th>
         <th
           className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
         >
           Date added
         </th>
         <th
           className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
         >
           Last invited
         </th>
         <th
-          className="TableCell TableCell__header TableCell--sticky-row"
+          className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--right TableCell--sticky-row"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
         >
-          Last applied
+          Action
         </th>
       </tr>
     </thead>
@@ -9902,8 +9980,12 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
         onClick={[Function]}
       >
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           <input
             checked={false}
@@ -9913,46 +9995,82 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
           />
         </td>
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "3.813rem",
+            }
+          }
         >
           riley@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Riley
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Researcher
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +18888888888
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/22/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           3 days ago
         </td>
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
         >
-          1 day ago
+          <button
+            aria-label="kebab button"
+            style={
+              Object {
+                "background": "none",
+                "border": "none",
+                "color": "#337AB7",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-ellipsis-v fa-w-6 "
+              data-icon="ellipsis-v"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={Object {}}
+              viewBox="0 0 192 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+          </button>
         </td>
       </tr>
       <tr
@@ -9960,8 +10078,12 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
         onClick={[Function]}
       >
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           <input
             checked={false}
@@ -9971,46 +10093,82 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
           />
         </td>
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "3.813rem",
+            }
+          }
         >
           basel123@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Basel
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Fakhoury
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +467234460393409
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           04/08/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
         >
-          -
+          <button
+            aria-label="kebab button"
+            style={
+              Object {
+                "background": "none",
+                "border": "none",
+                "color": "#337AB7",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-ellipsis-v fa-w-6 "
+              data-icon="ellipsis-v"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={Object {}}
+              viewBox="0 0 192 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+          </button>
         </td>
       </tr>
       <tr
@@ -10018,8 +10176,12 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
         onClick={[Function]}
       >
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           <input
             checked={false}
@@ -10029,46 +10191,82 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
           />
         </td>
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "3.813rem",
+            }
+          }
         >
           bob456@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Bob
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Saris
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/26/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           2 days ago
         </td>
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
         >
-          -
+          <button
+            aria-label="kebab button"
+            style={
+              Object {
+                "background": "none",
+                "border": "none",
+                "color": "#337AB7",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-ellipsis-v fa-w-6 "
+              data-icon="ellipsis-v"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={Object {}}
+              viewBox="0 0 192 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+          </button>
         </td>
       </tr>
       <tr
@@ -10076,8 +10274,12 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
         onClick={[Function]}
       >
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           <input
             checked={false}
@@ -10087,46 +10289,82 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
           />
         </td>
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "3.813rem",
+            }
+          }
         >
           dennis789@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Dennis
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Meng
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           12/21/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           6 days ago
         </td>
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
         >
-          5 days ago
+          <button
+            aria-label="kebab button"
+            style={
+              Object {
+                "background": "none",
+                "border": "none",
+                "color": "#337AB7",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-ellipsis-v fa-w-6 "
+              data-icon="ellipsis-v"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={Object {}}
+              viewBox="0 0 192 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+          </button>
         </td>
       </tr>
       <tr
@@ -10134,8 +10372,12 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
         onClick={[Function]}
       >
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           <input
             checked={false}
@@ -10145,46 +10387,82 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
           />
         </td>
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "3.813rem",
+            }
+          }
         >
           erin007@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Erin
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           May
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1499090234
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           09/21/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
         >
-          23 days ago
+          <button
+            aria-label="kebab button"
+            style={
+              Object {
+                "background": "none",
+                "border": "none",
+                "color": "#337AB7",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-ellipsis-v fa-w-6 "
+              data-icon="ellipsis-v"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={Object {}}
+              viewBox="0 0 192 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+          </button>
         </td>
       </tr>
       <tr
@@ -10192,8 +10470,12 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
         onClick={[Function]}
       >
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           <input
             checked={false}
@@ -10203,46 +10485,82 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
           />
         </td>
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "3.813rem",
+            }
+          }
         >
           jh247@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           John-Henry
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Forster
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1888938488
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           03/14/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
         >
-          -
+          <button
+            aria-label="kebab button"
+            style={
+              Object {
+                "background": "none",
+                "border": "none",
+                "color": "#337AB7",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-ellipsis-v fa-w-6 "
+              data-icon="ellipsis-v"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={Object {}}
+              viewBox="0 0 192 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+          </button>
         </td>
       </tr>
       <tr
@@ -10250,8 +10568,12 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
         onClick={[Function]}
       >
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           <input
             checked={false}
@@ -10261,46 +10583,82 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
           />
         </td>
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "3.813rem",
+            }
+          }
         >
           jason909085119@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Jason
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Basuil
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/01/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
         >
-          -
+          <button
+            aria-label="kebab button"
+            style={
+              Object {
+                "background": "none",
+                "border": "none",
+                "color": "#337AB7",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-ellipsis-v fa-w-6 "
+              data-icon="ellipsis-v"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={Object {}}
+              viewBox="0 0 192 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+          </button>
         </td>
       </tr>
       <tr
@@ -10308,8 +10666,12 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
         onClick={[Function]}
       >
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           <input
             checked={false}
@@ -10319,46 +10681,82 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
           />
         </td>
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "3.813rem",
+            }
+          }
         >
           rachel777@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Rachel
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Rapollo
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +40988881822329308
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           07/21/2019
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
         >
-          -
+          <button
+            aria-label="kebab button"
+            style={
+              Object {
+                "background": "none",
+                "border": "none",
+                "color": "#337AB7",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-ellipsis-v fa-w-6 "
+              data-icon="ellipsis-v"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={Object {}}
+              viewBox="0 0 192 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+          </button>
         </td>
       </tr>
       <tr
@@ -10366,8 +10764,12 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
         onClick={[Function]}
       >
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           <input
             checked={false}
@@ -10377,46 +10779,82 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
           />
         </td>
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "3.813rem",
+            }
+          }
         >
           jojo330@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           JoJo
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Lee
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1898374888
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           09/17/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           1 day ago
         </td>
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
         >
-          2 days ago
+          <button
+            aria-label="kebab button"
+            style={
+              Object {
+                "background": "none",
+                "border": "none",
+                "color": "#337AB7",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-ellipsis-v fa-w-6 "
+              data-icon="ellipsis-v"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={Object {}}
+              viewBox="0 0 192 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+          </button>
         </td>
       </tr>
       <tr
@@ -10424,8 +10862,12 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
         onClick={[Function]}
       >
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           <input
             checked={false}
@@ -10435,46 +10877,82 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Sticky Co
           />
         </td>
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "3.813rem",
+            }
+          }
         >
           faus555@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Faustino
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Gaitan
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +90918394789
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           06/13/2019
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
-          className="TableCell"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
         >
-          -
+          <button
+            aria-label="kebab button"
+            style={
+              Object {
+                "background": "none",
+                "border": "none",
+                "color": "#337AB7",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-ellipsis-v fa-w-6 "
+              data-icon="ellipsis-v"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={Object {}}
+              viewBox="0 0 192 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+          </button>
         </td>
       </tr>
     </tbody>
@@ -10501,41 +10979,49 @@ exports[`Storyshots Design System/Table Table With Single Action Column 1`] = `
       >
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Email
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           First name
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Last name
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Phone number
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Date added
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Last invited
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Last applied
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Edit
         </th>
@@ -10549,49 +11035,49 @@ exports[`Storyshots Design System/Table Table With Single Action Column 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           riley@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Riley
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Researcher
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +18888888888
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/22/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           3 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           1 day ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             style={
@@ -10636,49 +11122,49 @@ exports[`Storyshots Design System/Table Table With Single Action Column 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           basel123@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Basel
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Fakhoury
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +467234460393409
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           04/08/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             style={
@@ -10723,49 +11209,49 @@ exports[`Storyshots Design System/Table Table With Single Action Column 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           bob456@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Bob
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Saris
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/26/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           2 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             style={
@@ -10810,49 +11296,49 @@ exports[`Storyshots Design System/Table Table With Single Action Column 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           dennis789@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Dennis
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Meng
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           12/21/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           6 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           5 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             style={
@@ -10897,49 +11383,49 @@ exports[`Storyshots Design System/Table Table With Single Action Column 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           erin007@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Erin
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           May
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1499090234
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           09/21/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           23 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             style={
@@ -10984,49 +11470,49 @@ exports[`Storyshots Design System/Table Table With Single Action Column 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           jh247@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           John-Henry
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Forster
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1888938488
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           03/14/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             style={
@@ -11071,49 +11557,49 @@ exports[`Storyshots Design System/Table Table With Single Action Column 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           jason909085119@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Jason
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Basuil
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/01/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             style={
@@ -11158,49 +11644,49 @@ exports[`Storyshots Design System/Table Table With Single Action Column 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           rachel777@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Rachel
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Rapollo
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +40988881822329308
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           07/21/2019
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             style={
@@ -11245,49 +11731,49 @@ exports[`Storyshots Design System/Table Table With Single Action Column 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           jojo330@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           JoJo
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Lee
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1898374888
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           09/17/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           1 day ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           2 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             style={
@@ -11332,49 +11818,49 @@ exports[`Storyshots Design System/Table Table With Single Action Column 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           faus555@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Faustino
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Gaitan
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +90918394789
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           06/13/2019
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           <button
             style={
@@ -11438,16 +11924,19 @@ exports[`Storyshots Design System/Table Table With Sorting 1`] = `
       >
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           First name
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Last name
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Incentives earned 
           <span
@@ -11474,6 +11963,7 @@ exports[`Storyshots Design System/Table Table With Sorting 1`] = `
         </th>
         <th
           className="TableCell TableCell__header"
+          style={null}
         >
           Unsubscribed 
           <span
@@ -11508,25 +11998,25 @@ exports[`Storyshots Design System/Table Table With Sorting 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Anna
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Boston
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           0
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           False
         </td>
@@ -11536,25 +12026,25 @@ exports[`Storyshots Design System/Table Table With Sorting 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Carly
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Dixon
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           1
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           True
         </td>
@@ -11564,25 +12054,25 @@ exports[`Storyshots Design System/Table Table With Sorting 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Erin
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Fitzgerald
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           10
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           True
         </td>
@@ -11592,25 +12082,25 @@ exports[`Storyshots Design System/Table Table With Sorting 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Gregg
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Harris
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           20
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           True
         </td>
@@ -11620,25 +12110,25 @@ exports[`Storyshots Design System/Table Table With Sorting 1`] = `
       >
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Izzie
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Jackson
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           100
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           False
         </td>
@@ -11666,7 +12156,12 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
         className="TableRow"
       >
         <th
-          className="TableCell TableCell__header TableCell--sticky-column--corner TableCell--sticky-column TableCell--sticky-row"
+          className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--left TableCell--sticky-row"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           Email 
           <span
@@ -11709,56 +12204,67 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
         </th>
         <th
           className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
         >
           First name
         </th>
         <th
           className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
         >
           Last name
         </th>
         <th
           className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
         >
           Phone number
         </th>
         <th
           className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
         >
           Date added
         </th>
         <th
           className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
         >
           Last invited
         </th>
         <th
           className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
         >
           Last applied
         </th>
         <th
           className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
         >
           Date
         </th>
         <th
           className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
         >
           Boolean
         </th>
         <th
           className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
         >
           Decimal
         </th>
         <th
           className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
         >
           Pick any
         </th>
         <th
           className="TableCell TableCell__header TableCell--right TableCell--sticky-row"
+          style={null}
         >
           Incentives earned
         </th>
@@ -11771,74 +12277,78 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
         className="TableRow"
       >
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           riley@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Riley
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Researcher
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +18888888888
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/22/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           3 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           1 day ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           03/25/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           True
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell TableCell--right"
-          style={null}
+          style={Object {}}
         >
           5
         </td>
@@ -11847,74 +12357,78 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
         className="TableRow"
       >
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           basel123@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Basel
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Fakhoury
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +467234460393409
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           04/08/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           03/25/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           True
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell TableCell--right"
-          style={null}
+          style={Object {}}
         >
           5
         </td>
@@ -11923,74 +12437,78 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
         className="TableRow"
       >
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           bob456@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Bob
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Saris
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/26/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           2 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           03/25/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           True
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell TableCell--right"
-          style={null}
+          style={Object {}}
         >
           5
         </td>
@@ -11999,74 +12517,78 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
         className="TableRow"
       >
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           dennis789@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Dennis
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Meng
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           12/21/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           6 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           5 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           03/25/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           True
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell TableCell--right"
-          style={null}
+          style={Object {}}
         >
           5
         </td>
@@ -12075,74 +12597,78 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
         className="TableRow"
       >
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           erin007@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Erin
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           May
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1499090234
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           09/21/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           23 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           03/25/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           True
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell TableCell--right"
-          style={null}
+          style={Object {}}
         >
           5
         </td>
@@ -12151,74 +12677,78 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
         className="TableRow"
       >
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           jh247@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           John-Henry
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Forster
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1888938488
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           03/14/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           03/25/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           True
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell TableCell--right"
-          style={null}
+          style={Object {}}
         >
           5
         </td>
@@ -12227,74 +12757,78 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
         className="TableRow"
       >
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           jason909085119@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Jason
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Basuil
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           01/01/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           03/25/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           True
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell TableCell--right"
-          style={null}
+          style={Object {}}
         >
           5
         </td>
@@ -12303,74 +12837,78 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
         className="TableRow"
       >
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           rachel777@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Rachel
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Rapollo
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +40988881822329308
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           07/21/2019
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           03/25/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           True
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell TableCell--right"
-          style={null}
+          style={Object {}}
         >
           5
         </td>
@@ -12379,74 +12917,78 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
         className="TableRow"
       >
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           jojo330@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           JoJo
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Lee
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +1898374888
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           09/17/2020
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           1 day ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           2 days ago
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           03/25/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           True
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell TableCell--right"
-          style={null}
+          style={Object {}}
         >
           5
         </td>
@@ -12455,76 +12997,1478 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
         className="TableRow"
       >
         <td
-          className="TableCell TableCell--sticky-column"
-          style={null}
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
         >
           faus555@userinterviews.com
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Faustino
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           Gaitan
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           +90918394789
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           06/13/2019
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           03/25/2021
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           True
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell"
-          style={null}
+          style={Object {}}
         >
           -
         </td>
         <td
           className="TableCell TableCell--right"
-          style={null}
+          style={Object {}}
         >
           5
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Storyshots Design System/Table Table With Sticky Columns And Header 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <table
+    className="Table"
+  >
+    <thead
+      className="TableHead"
+    >
+      <tr
+        className="TableRow"
+      >
+        <th
+          className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--left TableCell--sticky-row"
+          style={
+            Object {
+              "left": "0rem",
+            }
+          }
+        >
+          Email
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--left TableCell--sticky-row"
+          style={
+            Object {
+              "left": "10rem",
+            }
+          }
+        >
+          First name 
+          <span
+            style={
+              Object {
+                "float": "right",
+              }
+            }
+          >
+            <button
+              onClick={[Function]}
+              style={
+                Object {
+                  "background": "none",
+                  "border": "none",
+                  "color": "#337AB7",
+                }
+              }
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-thumbtack fa-w-12 "
+                data-icon="thumbtack"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 384 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M298.028 214.267L285.793 96H328c13.255 0 24-10.745 24-24V24c0-13.255-10.745-24-24-24H56C42.745 0 32 10.745 32 24v48c0 13.255 10.745 24 24 24h42.207L85.972 214.267C37.465 236.82 0 277.261 0 328c0 13.255 10.745 24 24 24h136v104.007c0 1.242.289 2.467.845 3.578l24 48c2.941 5.882 11.364 5.893 14.311 0l24-48a8.008 8.008 0 0 0 .845-3.578V352h136c13.255 0 24-10.745 24-24-.001-51.183-37.983-91.42-85.973-113.733z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </button>
+          </span>
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
+        >
+          Last name
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
+        >
+          Phone number
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
+        >
+          Date added
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
+        >
+          Last invited
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
+        >
+          Last applied
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
+        >
+          Date
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
+        >
+          Boolean
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-row"
+          style={null}
+        >
+          Decimal
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-row"
+          style={null}
+        >
+          Pick any
+        </th>
+        <th
+          className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--right TableCell--sticky-row"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          Action
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      className="TableBody"
+    >
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          riley@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          Riley
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          Researcher
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          +18888888888
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          01/22/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          3 days ago
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          1 day ago
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
+          </button>
+        </td>
+      </tr>
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          basel123@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          Basel
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          Fakhoury
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          +467234460393409
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          04/08/2020
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
+          </button>
+        </td>
+      </tr>
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          bob456@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          Bob
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          Saris
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          01/26/2020
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          2 days ago
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
+          </button>
+        </td>
+      </tr>
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          dennis789@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          Dennis
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          Meng
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          12/21/2020
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          6 days ago
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          5 days ago
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
+          </button>
+        </td>
+      </tr>
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          erin007@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          Erin
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          May
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          +1499090234
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          09/21/2020
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          23 days ago
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
+          </button>
+        </td>
+      </tr>
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          jh247@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          John-Henry
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          Forster
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          +1888938488
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/14/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
+          </button>
+        </td>
+      </tr>
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          jason909085119@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          Jason
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          Basuil
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          01/01/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
+          </button>
+        </td>
+      </tr>
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          rachel777@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          Rachel
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          Rapollo
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          +40988881822329308
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          07/21/2019
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
+          </button>
+        </td>
+      </tr>
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          jojo330@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          JoJo
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          Lee
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          +1898374888
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          09/17/2020
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          1 day ago
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          2 days ago
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
+          </button>
+        </td>
+      </tr>
+      <tr
+        className="TableRow"
+      >
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "0rem",
+              "maxWidth": "10rem",
+            }
+          }
+        >
+          faus555@userinterviews.com
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
+          style={
+            Object {
+              "left": "10rem",
+              "minWidth": "10rem",
+            }
+          }
+        >
+          Faustino
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          Gaitan
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          +90918394789
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          06/13/2019
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          03/25/2021
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          True
+        </td>
+        <td
+          className="TableCell"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--sticky-column"
+          style={Object {}}
+        >
+          -
+        </td>
+        <td
+          className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
+          style={
+            Object {
+              "right": "0rem",
+            }
+          }
+        >
+          <button
+            style={
+              Object {
+                "background": "none",
+                "border": "1px solid #337AB7",
+                "borderRadius": "4px",
+                "color": "#337AB7",
+                "fontWeight": "700",
+                "padding": "4px 8px",
+              }
+            }
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-file-alt fa-w-12 "
+              data-icon="file-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "marginRight": "10px",
+                }
+              }
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+            Edit
+          </button>
         </td>
       </tr>
     </tbody>

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -9873,7 +9873,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--left TableCell--sticky-row"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -9887,7 +9887,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--left TableCell--sticky-row"
           style={
             Object {
-              "left": "3.813rem",
+              "left": "61px",
             }
           }
         >
@@ -9964,7 +9964,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--right TableCell--sticky-row"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -9983,7 +9983,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -9998,7 +9998,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "3.813rem",
+              "left": "61px",
             }
           }
         >
@@ -10038,7 +10038,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -10081,7 +10081,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -10096,7 +10096,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "3.813rem",
+              "left": "61px",
             }
           }
         >
@@ -10136,7 +10136,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -10179,7 +10179,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -10194,7 +10194,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "3.813rem",
+              "left": "61px",
             }
           }
         >
@@ -10234,7 +10234,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -10277,7 +10277,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -10292,7 +10292,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "3.813rem",
+              "left": "61px",
             }
           }
         >
@@ -10332,7 +10332,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -10375,7 +10375,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -10390,7 +10390,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "3.813rem",
+              "left": "61px",
             }
           }
         >
@@ -10430,7 +10430,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -10473,7 +10473,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -10488,7 +10488,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "3.813rem",
+              "left": "61px",
             }
           }
         >
@@ -10528,7 +10528,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -10571,7 +10571,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -10586,7 +10586,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "3.813rem",
+              "left": "61px",
             }
           }
         >
@@ -10626,7 +10626,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -10669,7 +10669,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -10684,7 +10684,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "3.813rem",
+              "left": "61px",
             }
           }
         >
@@ -10724,7 +10724,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -10767,7 +10767,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -10782,7 +10782,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "3.813rem",
+              "left": "61px",
             }
           }
         >
@@ -10822,7 +10822,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -10865,7 +10865,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -10880,7 +10880,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "3.813rem",
+              "left": "61px",
             }
           }
         >
@@ -10920,7 +10920,7 @@ exports[`Storyshots Design System/Table Table With Multiple Select And Multiple 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -10981,7 +10981,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--left TableCell--sticky-row"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -10991,7 +10991,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--left TableCell--sticky-row"
           style={
             Object {
-              "left": "10rem",
+              "left": "160px",
             }
           }
         >
@@ -11092,7 +11092,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--right TableCell--sticky-row"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -11110,7 +11110,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
               "maxWidth": "10rem",
             }
           }
@@ -11121,7 +11121,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "10rem",
+              "left": "160px",
               "minWidth": "10rem",
             }
           }
@@ -11186,7 +11186,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -11235,7 +11235,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
               "maxWidth": "10rem",
             }
           }
@@ -11246,7 +11246,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "10rem",
+              "left": "160px",
               "minWidth": "10rem",
             }
           }
@@ -11311,7 +11311,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -11360,7 +11360,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
               "maxWidth": "10rem",
             }
           }
@@ -11371,7 +11371,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "10rem",
+              "left": "160px",
               "minWidth": "10rem",
             }
           }
@@ -11436,7 +11436,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -11485,7 +11485,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
               "maxWidth": "10rem",
             }
           }
@@ -11496,7 +11496,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "10rem",
+              "left": "160px",
               "minWidth": "10rem",
             }
           }
@@ -11561,7 +11561,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -11610,7 +11610,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
               "maxWidth": "10rem",
             }
           }
@@ -11621,7 +11621,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "10rem",
+              "left": "160px",
               "minWidth": "10rem",
             }
           }
@@ -11686,7 +11686,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -11735,7 +11735,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
               "maxWidth": "10rem",
             }
           }
@@ -11746,7 +11746,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "10rem",
+              "left": "160px",
               "minWidth": "10rem",
             }
           }
@@ -11811,7 +11811,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -11860,7 +11860,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
               "maxWidth": "10rem",
             }
           }
@@ -11871,7 +11871,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "10rem",
+              "left": "160px",
               "minWidth": "10rem",
             }
           }
@@ -11936,7 +11936,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -11985,7 +11985,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
               "maxWidth": "10rem",
             }
           }
@@ -11996,7 +11996,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "10rem",
+              "left": "160px",
               "minWidth": "10rem",
             }
           }
@@ -12061,7 +12061,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -12110,7 +12110,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
               "maxWidth": "10rem",
             }
           }
@@ -12121,7 +12121,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "10rem",
+              "left": "160px",
               "minWidth": "10rem",
             }
           }
@@ -12186,7 +12186,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -12235,7 +12235,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
               "maxWidth": "10rem",
             }
           }
@@ -12246,7 +12246,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "10rem",
+              "left": "160px",
               "minWidth": "10rem",
             }
           }
@@ -12311,7 +12311,7 @@ exports[`Storyshots Design System/Table Table With Multiple Sticky Columns And H
           className="TableCell TableCell--right TableCell--sticky-column TableCell--sticky-column--right"
           style={
             Object {
-              "right": "0rem",
+              "right": "0px",
             }
           }
         >
@@ -13557,7 +13557,7 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
           className="TableCell TableCell__header TableCell--sticky-column TableCell--sticky-column--corner TableCell--sticky-column--left TableCell--sticky-row"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -13678,7 +13678,7 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -13758,7 +13758,7 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -13838,7 +13838,7 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -13918,7 +13918,7 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -13998,7 +13998,7 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -14078,7 +14078,7 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -14158,7 +14158,7 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -14238,7 +14238,7 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -14318,7 +14318,7 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >
@@ -14398,7 +14398,7 @@ exports[`Storyshots Design System/Table Table With Sticky Column And Header 1`] 
           className="TableCell TableCell--sticky-column TableCell--sticky-column--left"
           style={
             Object {
-              "left": "0rem",
+              "left": "0px",
             }
           }
         >

--- a/src/Table/Table.mdx
+++ b/src/Table/Table.mdx
@@ -157,15 +157,63 @@ Can also have other components for additional functionality such as:
 </Preview>
 
 ### Table With Sticky Column And Header
-- A Table's header row can be made sticky to ensure column labels are always visible when the users scrolls down
+- A Table's header row can be made sticky to ensure column labels are always visible when a user scrolls down
 - `TableRow` can be given a single `stickyRow` prop (within `TableHead`)
-- A Table column can be made sticky to help a user keep track of which row they're currently looking at. The `TableCell` on the column that is made sticky can be given the `stickyColumn` prop (within `TableBody`)
-- The sticky column should be applied to the left-most column of the Table. Support for multiple sticky columns will come in a future release
-- A pin icon should be displayed on a sticky column to let the user toggle between a sticky column state and a default state
+- A Table column can be made sticky to help a user keep track of which row they're currently looking at. The `TableCell` on the column that is made sticky can be given the `stickyColumn` prop. The `TableCell`s both in the `TableHead` and `TableBody` need to `stickyColumn` prop.)
+- A sticky column requires a `stickyLeft` or `stickyRight` prop to designate which end of the Table it will be placed
+- If only a *single* `stickyColumn` is implemented on either left or right side of the Table, `stickyColumnXOffset` should be set to `0`
+- `stickyColumnXOffset` takes a number that translates into a `rem` value. Depending on whether a `TableCell` is provided `stickyLeft` or `stickyRight`, the output becomes a styling value of either `left: ${stickyColumnXOffset}rem` or `right: ${stickyColumnXOffset}rem`
+- A pin icon can optionally be displayed on a sticky column to let the user toggle between a sticky column state and a default state
 - *Note: view this story on Canvas instead of Docs to see the sticky header*
 
 <Preview>
   <Story id="design-system-table--table-with-sticky-column-and-header" />
+</Preview>
+
+### Table With Multiple Sticky Columns (left & right) And Header
+- If *multiple* `stickyColumn`s are needed on either left or right side of the Table (e.g. a Checkbox and Email column on the left-side of the Table), `stickyColumnXOffset` must be set precisely
+- Note: there is currently only support for only a single `stickyRight` column. This column should be reserved for an action or a relevant data column
+```
+// First left-side stickyColumn, 0rem starting position when sticky
+
+<TableCell
+  header
+  stickyColumn={isStickyColumn}
+  stickyColumnXOffset={0}
+  stickyLeft
+>
+  Email
+</TableCell>
+
+// Second left-side stickyColumn, 10rem starting position when sticky
+
+<TableCell
+  header
+  stickyColumn={isStickyColumn}
+  stickyColumnXOffset={10}
+  stickyLeft
+>
+```
+
+- For multiple `stickyColumn`s that may have a variable width, be sure to set a `maxWidth` and `minWidth` on each corresponding `TableCell`s within `TableBody`
+
+```
+// In this example, the Email column has a maxWidth="10rem"
+// The First name column therefore needs stickyColumnXOffset={10} to ensure its sticky position is placed exactly where the first column ends
+
+<TableBody>
+  {data.map(((row) => (
+    <TableRow key={row.id}>
+      <TableCell maxWidth="10rem" stickyColumn={isStickyColumn} stickyColumnXOffset={0} stickyLeft>{row.email}</TableCell>
+      <TableCell minWidth="10rem" stickyColumn={isStickyColumn} stickyColumnXOffset={10} stickyLeft>{row.firstName}</TableCell>
+      ...
+    </TableRow>
+    )))}
+</TableBody>
+```
+
+<Preview>
+  <Story id="design-system-table--table-with-multiple-sticky-columns-and-header" />
 </Preview>
 
 ### Table With Multiple Select 
@@ -178,13 +226,13 @@ Can also have other components for additional functionality such as:
   <Story id="design-system-table--table-with-multiple-select" />
 </Preview>
 
-### Table With Multiple Select And Sticky Column And Header
+### Table With Multiple Select And Multiple Sticky Columns And Header
 - Combining the sticky columns & headers with multi-select functionality.
 - Creates an easier scrolling and selecting experience for users while searching through table data.
 - *Note: view this story on Canvas instead of Docs to see the sticky header*
 
 <Preview>
-  <Story id="design-system-table--table-with-multiple-select-and-sticky-columns-and-headers" />
+  <Story id="design-system-table--table-with-multiple-select-and-multiple-sticky-columns-and-header" />
 </Preview>
 
 ### Table With Sorting 

--- a/src/Table/Table.mdx
+++ b/src/Table/Table.mdx
@@ -161,8 +161,8 @@ Can also have other components for additional functionality such as:
 - `TableRow` can be given a single `stickyRow` prop (within `TableHead`)
 - A Table column can be made sticky to help a user keep track of which row they're currently looking at. The `TableCell` on the column that is made sticky can be given the `stickyColumn` prop. The `TableCell`s both in the `TableHead` and `TableBody` need to `stickyColumn` prop.)
 - A sticky column requires a `stickyLeft` or `stickyRight` prop to designate which end of the Table it will be placed
-- If only a *single* `stickyColumn` is implemented on either left or right side of the Table, `stickyColumnXOffset` should be set to `0`
-- `stickyColumnXOffset` takes a number that translates into a `rem` value. Depending on whether a `TableCell` is provided `stickyLeft` or `stickyRight`, the output becomes a styling value of either `left: ${stickyColumnXOffset}rem` or `right: ${stickyColumnXOffset}rem`
+- If only a *single* `stickyColumn` is implemented on either left or right side of the Table, `stickyColumnOffsetX` should be set to `0`
+- `stickyColumnOffsetX` takes a number that translates into a `px` value. Depending on whether a `TableCell` is provided `stickyLeft` or `stickyRight`, the output becomes a styling value of either `left: ${stickyColumnOffsetX}px` or `right: ${stickyColumnOffsetX}px`
 - A pin icon can optionally be displayed on a sticky column to let the user toggle between a sticky column state and a default state
 - *Note: view this story on Canvas instead of Docs to see the sticky header*
 
@@ -171,26 +171,26 @@ Can also have other components for additional functionality such as:
 </Preview>
 
 ### Table With Multiple Sticky Columns (left & right) And Header
-- If *multiple* `stickyColumn`s are needed on either left or right side of the Table (e.g. a Checkbox and Email column on the left-side of the Table), `stickyColumnXOffset` must be set precisely
+- If *multiple* `stickyColumn`s are needed on either left or right side of the Table (e.g. a Checkbox and Email column on the left-side of the Table), `stickyColumnOffsetX` must be set precisely
 - Note: there is currently only support for only a single `stickyRight` column. This column should be reserved for an action or a relevant data column
 ```
-// First left-side stickyColumn, 0rem starting position when sticky
+// First left-side stickyColumn, 0px starting position when sticky
 
 <TableCell
   header
   stickyColumn={isStickyColumn}
-  stickyColumnXOffset={0}
+  stickyColumnOffsetX={0}
   stickyLeft
 >
   Email
 </TableCell>
 
-// Second left-side stickyColumn, 10rem starting position when sticky
+// Second left-side stickyColumn, 160px starting position when sticky
 
 <TableCell
   header
   stickyColumn={isStickyColumn}
-  stickyColumnXOffset={10}
+  stickyColumnOffsetX={160}
   stickyLeft
 >
 ```
@@ -199,13 +199,13 @@ Can also have other components for additional functionality such as:
 
 ```
 // In this example, the Email column has a maxWidth="10rem"
-// The First name column therefore needs stickyColumnXOffset={10} to ensure its sticky position is placed exactly where the first column ends
+// The First name column therefore needs stickyColumnOffsetX={160} to ensure its sticky position is placed exactly where the first column ends
 
 <TableBody>
   {data.map(((row) => (
     <TableRow key={row.id}>
-      <TableCell maxWidth="10rem" stickyColumn={isStickyColumn} stickyColumnXOffset={0} stickyLeft>{row.email}</TableCell>
-      <TableCell minWidth="10rem" stickyColumn={isStickyColumn} stickyColumnXOffset={10} stickyLeft>{row.firstName}</TableCell>
+      <TableCell maxWidth="10rem" stickyColumn={isStickyColumn} stickyColumnOffsetX={0} stickyLeft>{row.email}</TableCell>
+      <TableCell minWidth="10rem" stickyColumn={isStickyColumn} stickyColumnOffsetX={160} stickyLeft>{row.firstName}</TableCell>
       ...
     </TableRow>
     )))}

--- a/src/Table/Table.mdx
+++ b/src/Table/Table.mdx
@@ -119,8 +119,8 @@ Can also have other components for additional functionality such as:
 ### Table With Fixed Column Widths
 - Create a column with a fixed width
 - By default, all content of a `TableCell` will be fully displayed with no line breaks and no set width. Whichever `TableCell` has the longest content, the width of that entire column will be set at that
-- Set `maxWidth` to limit the width of the `TableCell`
-- Set `minWidth` to provide extra space for the `TableCell`
+- Set `maxWidth` to limit the width in `px` of the `TableCell` 
+- Set `minWidth` to provide extra space in `px` for the `TableCell`
 - `text-overflow: ellipsis` is set by default for content that exceeds the designated width. This would only be seen if `maxWidth` is set
 
 <Preview>
@@ -198,14 +198,14 @@ Can also have other components for additional functionality such as:
 - For multiple `stickyColumn`s that may have a variable width, be sure to set a `maxWidth` and `minWidth` on each corresponding `TableCell`s within `TableBody`
 
 ```
-// In this example, the Email column has a maxWidth="10rem"
+// In this example, the Email column has a maxWidth={160}
 // The First name column therefore needs stickyColumnOffsetX={160} to ensure its sticky position is placed exactly where the first column ends
 
 <TableBody>
   {data.map(((row) => (
     <TableRow key={row.id}>
-      <TableCell maxWidth="10rem" stickyColumn={isStickyColumn} stickyColumnOffsetX={0} stickyLeft>{row.email}</TableCell>
-      <TableCell minWidth="10rem" stickyColumn={isStickyColumn} stickyColumnOffsetX={160} stickyLeft>{row.firstName}</TableCell>
+      <TableCell maxWidth={160} stickyColumn={isStickyColumn} stickyColumnOffsetX={0} stickyLeft>{row.email}</TableCell>
+      <TableCell minWidth={160} stickyColumn={isStickyColumn} stickyColumnOffsetX={160} stickyLeft>{row.firstName}</TableCell>
       ...
     </TableRow>
     )))}

--- a/src/Table/Table.mdx
+++ b/src/Table/Table.mdx
@@ -159,8 +159,8 @@ Can also have other components for additional functionality such as:
 ### Table With Sticky Column And Header
 - A Table's header row can be made sticky to ensure column labels are always visible when a user scrolls down
 - `TableRow` can be given a single `stickyRow` prop (within `TableHead`)
-- A Table column can be made sticky to help a user keep track of which row they're currently looking at. The `TableCell` on the column that is made sticky can be given the `stickyColumn` prop. The `TableCell`s both in the `TableHead` and `TableBody` need to `stickyColumn` prop.)
-- A sticky column requires a `stickyLeft` or `stickyRight` prop to designate which end of the Table it will be placed
+- A Table column can be made sticky to help a user keep track of which row they're currently looking at. The `TableCell` on the column that is made sticky can be given the `stickyColumn` prop. The `TableCell`s both in the `TableHead` and `TableBody` need the `stickyColumn` prop.)
+- A sticky column requires a `stickyLeft` or `stickyRight` prop. This determines whether a sticky column will be positioned on the left-side or right-side of the Table
 - If only a *single* `stickyColumn` is implemented on either left or right side of the Table, `stickyColumnOffsetX` should be set to `0`
 - `stickyColumnOffsetX` takes a number that translates into a `px` value. Depending on whether a `TableCell` is provided `stickyLeft` or `stickyRight`, the output becomes a styling value of either `left: ${stickyColumnOffsetX}px` or `right: ${stickyColumnOffsetX}px`
 - A pin icon can optionally be displayed on a sticky column to let the user toggle between a sticky column state and a default state

--- a/src/Table/Table.stories.jsx
+++ b/src/Table/Table.stories.jsx
@@ -331,7 +331,7 @@ export const TableWithStickyColumnAndHeader = () => {
    );
 };
 
-export const TableWithStickyColumnsAndHeader = () => {
+export const TableWithMultipleStickyColumnsAndHeader = () => {
   const [isStickyColumn, setIsStickyColumn] = useState(true);
 
   const handlePinClick = () => {
@@ -475,7 +475,7 @@ export const TableWithMultipleSelect = () => {
   );
 };
 
-export const TableWithMultipleSelectAndStickyColumnsAndHeader = () => {
+export const TableWithMultipleSelectAndMultipleStickyColumnsAndHeader = () => {
   const [selectedRows, setSelectedRows] = useState([]);
   const [isSelectAllCheckboxChecked, setIsSelectAllCheckboxChecked] = useState(false);
 

--- a/src/Table/Table.stories.jsx
+++ b/src/Table/Table.stories.jsx
@@ -97,8 +97,8 @@ export const TableWithFixedColumnWidths = () => (
         <TableRow key={row.id}>
           {/* TODO: Wrap this TableCell in a Popover to show overflow text
               once that component is finished */}
-          <TableCell maxWidth="12rem">{row.email} (with a max-width)</TableCell>
-          <TableCell minWidth="20rem">{row.firstName} (with a min-width)</TableCell>
+          <TableCell maxWidth={192}>{row.email} (with a max-width)</TableCell>
+          <TableCell minWidth={320}>{row.firstName} (with a min-width)</TableCell>
           <TableCell>{row.lastName}</TableCell>
           <TableCell>{row.phoneNumber}</TableCell>
           <TableCell>{row.dateAdded}</TableCell>
@@ -380,8 +380,8 @@ export const TableWithMultipleStickyColumnsAndHeader = () => {
       <TableBody>
         {data.map(((row) => (
           <TableRow key={row.id}>
-            <TableCell maxWidth="10rem" stickyColumn={isStickyColumn} stickyColumnOffsetX={0} stickyLeft>{row.email}</TableCell>
-            <TableCell minWidth="10rem" stickyColumn={isStickyColumn} stickyColumnOffsetX={160} stickyLeft>{row.firstName}</TableCell>
+            <TableCell maxWidth={160} stickyColumn={isStickyColumn} stickyColumnOffsetX={0} stickyLeft>{row.email}</TableCell>
+            <TableCell minWidth={160} stickyColumn={isStickyColumn} stickyColumnOffsetX={160} stickyLeft>{row.firstName}</TableCell>
             <TableCell>{row.lastName}</TableCell>
             <TableCell>{row.phoneNumber}</TableCell>
             <TableCell>{row.dateAdded}</TableCell>

--- a/src/Table/Table.stories.jsx
+++ b/src/Table/Table.stories.jsx
@@ -288,7 +288,7 @@ export const TableWithStickyColumnAndHeader = () => {
     <Table>
       <TableHead>
         <TableRow stickyRow>
-          <TableCell header stickyColumn={isStickyColumn} stickyColumnXOffset={0} stickyLeft>
+          <TableCell header stickyColumn={isStickyColumn} stickyColumnOffsetX={0} stickyLeft>
             Email <span style={{ float: 'right' }}><PinButton isPinActive={isStickyColumn} onClick={handlePinClick} /></span>
           </TableCell>
           <TableCell header>First name</TableCell>
@@ -309,7 +309,7 @@ export const TableWithStickyColumnAndHeader = () => {
           <TableRow key={row.id}>
             <TableCell
               stickyColumn={isStickyColumn}
-              stickyColumnXOffset={0}
+              stickyColumnOffsetX={0}
               stickyLeft
             >{row.email}
             </TableCell>
@@ -345,7 +345,7 @@ export const TableWithMultipleStickyColumnsAndHeader = () => {
           <TableCell
             header
             stickyColumn={isStickyColumn}
-            stickyColumnXOffset={0}
+            stickyColumnOffsetX={0}
             stickyLeft
           >
             Email
@@ -353,7 +353,7 @@ export const TableWithMultipleStickyColumnsAndHeader = () => {
           <TableCell
             header
             stickyColumn={isStickyColumn}
-            stickyColumnXOffset={10}
+            stickyColumnOffsetX={160}
             stickyLeft
           >
             First name <span style={{ float: 'right' }}><PinButton isPinActive={isStickyColumn} onClick={handlePinClick} /></span>
@@ -370,7 +370,7 @@ export const TableWithMultipleStickyColumnsAndHeader = () => {
           <TableCell
             header
             stickyColumn={isStickyColumn}
-            stickyColumnXOffset={0}
+            stickyColumnOffsetX={0}
             stickyRight
           >
             Action
@@ -380,8 +380,8 @@ export const TableWithMultipleStickyColumnsAndHeader = () => {
       <TableBody>
         {data.map(((row) => (
           <TableRow key={row.id}>
-            <TableCell maxWidth="10rem" stickyColumn={isStickyColumn} stickyColumnXOffset={0} stickyLeft>{row.email}</TableCell>
-            <TableCell minWidth="10rem" stickyColumn={isStickyColumn} stickyColumnXOffset={10} stickyLeft>{row.firstName}</TableCell>
+            <TableCell maxWidth="10rem" stickyColumn={isStickyColumn} stickyColumnOffsetX={0} stickyLeft>{row.email}</TableCell>
+            <TableCell minWidth="10rem" stickyColumn={isStickyColumn} stickyColumnOffsetX={160} stickyLeft>{row.firstName}</TableCell>
             <TableCell>{row.lastName}</TableCell>
             <TableCell>{row.phoneNumber}</TableCell>
             <TableCell>{row.dateAdded}</TableCell>
@@ -394,7 +394,7 @@ export const TableWithMultipleStickyColumnsAndHeader = () => {
             <TableCell
               alignRight
               stickyColumn={isStickyColumn}
-              stickyColumnXOffset={0}
+              stickyColumnOffsetX={0}
               stickyRight
             >
               {editButton()}
@@ -509,10 +509,10 @@ export const TableWithMultipleSelectAndMultipleStickyColumnsAndHeader = () => {
     <Table>
       <TableHead>
         <TableRow stickyRow>
-          <TableCell header stickyColumn={isStickyColumn} stickyColumnXOffset={0} stickyLeft>
+          <TableCell header stickyColumn={isStickyColumn} stickyColumnOffsetX={0} stickyLeft>
             <CheckboxButton id="checkbox" onChange={() => handleCheckboxSelectAll(data)} />
           </TableCell>
-          <TableCell header stickyColumn={isStickyColumn} stickyColumnXOffset={3.813} stickyLeft>Email <span style={{ float: 'right' }}><PinButton isPinActive={isStickyColumn} onClick={handlePinClick} /></span></TableCell>
+          <TableCell header stickyColumn={isStickyColumn} stickyColumnOffsetX={61} stickyLeft>Email <span style={{ float: 'right' }}><PinButton isPinActive={isStickyColumn} onClick={handlePinClick} /></span></TableCell>
           <TableCell header>First name</TableCell>
           <TableCell header>Last name</TableCell>
           <TableCell header>Phone number</TableCell>
@@ -521,7 +521,7 @@ export const TableWithMultipleSelectAndMultipleStickyColumnsAndHeader = () => {
           <TableCell
             header
             stickyColumn={isStickyColumn}
-            stickyColumnXOffset={0}
+            stickyColumnOffsetX={0}
             stickyRight
           >
             Action
@@ -536,7 +536,7 @@ export const TableWithMultipleSelectAndMultipleStickyColumnsAndHeader = () => {
             selected={selectedRows.includes(row.id)}
             onClick={() => handleCheckboxSelectSingle(row.id)}
           >
-            <TableCell stickyColumn={isStickyColumn} stickyColumnXOffset={0} stickyLeft>
+            <TableCell stickyColumn={isStickyColumn} stickyColumnOffsetX={0} stickyLeft>
               <CheckboxButton
                 checked={isChecked(row.id)}
                 id="checkbox"
@@ -545,7 +545,7 @@ export const TableWithMultipleSelectAndMultipleStickyColumnsAndHeader = () => {
             </TableCell>
             <TableCell
               stickyColumn={isStickyColumn}
-              stickyColumnXOffset={3.813}
+              stickyColumnOffsetX={61}
               stickyLeft
             >{row.email}
             </TableCell>
@@ -556,7 +556,7 @@ export const TableWithMultipleSelectAndMultipleStickyColumnsAndHeader = () => {
             <TableCell>{row.lastInvited ? row.lastInvited : `-`}</TableCell>
             <TableCell
               stickyColumn={isStickyColumn}
-              stickyColumnXOffset={0}
+              stickyColumnOffsetX={0}
               stickyRight
             >{kebabButton()}
             </TableCell>

--- a/src/Table/Table.stories.jsx
+++ b/src/Table/Table.stories.jsx
@@ -288,7 +288,9 @@ export const TableWithStickyColumnAndHeader = () => {
     <Table>
       <TableHead>
         <TableRow stickyRow>
-          <TableCell header stickyColumn={isStickyColumn}>Email <span style={{ float: 'right' }}><PinButton isPinActive={isStickyColumn} onClick={handlePinClick} /></span></TableCell>
+          <TableCell header stickyColumn={isStickyColumn} stickyColumnXOffset={0} stickyLeft>
+            Email <span style={{ float: 'right' }}><PinButton isPinActive={isStickyColumn} onClick={handlePinClick} /></span>
+          </TableCell>
           <TableCell header>First name</TableCell>
           <TableCell header>Last name</TableCell>
           <TableCell header>Phone number</TableCell>
@@ -305,7 +307,12 @@ export const TableWithStickyColumnAndHeader = () => {
       <TableBody>
         {data.map(((row) => (
           <TableRow key={row.id}>
-            <TableCell stickyColumn={isStickyColumn}>{row.email}</TableCell>
+            <TableCell
+              stickyColumn={isStickyColumn}
+              stickyColumnXOffset={0}
+              stickyLeft
+            >{row.email}
+            </TableCell>
             <TableCell>{row.firstName}</TableCell>
             <TableCell>{row.lastName}</TableCell>
             <TableCell>{row.phoneNumber}</TableCell>
@@ -317,6 +324,81 @@ export const TableWithStickyColumnAndHeader = () => {
             <TableCell>{row.decimal ? 'True' : `-`}</TableCell>
             <TableCell>{row.pickAny ? 'True' : `-`}</TableCell>
             <TableCell alignRight>{row.incentivesEarned}</TableCell>
+          </TableRow>
+        )))}
+      </TableBody>
+    </Table>
+   );
+};
+
+export const TableWithStickyColumnsAndHeader = () => {
+  const [isStickyColumn, setIsStickyColumn] = useState(true);
+
+  const handlePinClick = () => {
+    setIsStickyColumn((prev) => !prev);
+  };
+
+  return (
+    <Table>
+      <TableHead>
+        <TableRow stickyRow>
+          <TableCell
+            header
+            stickyColumn={isStickyColumn}
+            stickyColumnXOffset={0}
+            stickyLeft
+          >
+            Email
+          </TableCell>
+          <TableCell
+            header
+            stickyColumn={isStickyColumn}
+            stickyColumnXOffset={10}
+            stickyLeft
+          >
+            First name <span style={{ float: 'right' }}><PinButton isPinActive={isStickyColumn} onClick={handlePinClick} /></span>
+          </TableCell>
+          <TableCell header>Last name</TableCell>
+          <TableCell header>Phone number</TableCell>
+          <TableCell header>Date added</TableCell>
+          <TableCell header>Last invited</TableCell>
+          <TableCell header>Last applied</TableCell>
+          <TableCell header>Date</TableCell>
+          <TableCell header>Boolean</TableCell>
+          <TableCell header>Decimal</TableCell>
+          <TableCell header stickyColumn={isStickyColumn}>Pick any</TableCell>
+          <TableCell
+            header
+            stickyColumn={isStickyColumn}
+            stickyColumnXOffset={0}
+            stickyRight
+          >
+            Action
+          </TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {data.map(((row) => (
+          <TableRow key={row.id}>
+            <TableCell maxWidth="10rem" stickyColumn={isStickyColumn} stickyColumnXOffset={0} stickyLeft>{row.email}</TableCell>
+            <TableCell minWidth="10rem" stickyColumn={isStickyColumn} stickyColumnXOffset={10} stickyLeft>{row.firstName}</TableCell>
+            <TableCell>{row.lastName}</TableCell>
+            <TableCell>{row.phoneNumber}</TableCell>
+            <TableCell>{row.dateAdded}</TableCell>
+            <TableCell>{row.lastInvited ? row.lastInvited : `-`}</TableCell>
+            <TableCell>{row.lastApplied ? row.lastApplied : `-`}</TableCell>
+            <TableCell>{row.date}</TableCell>
+            <TableCell>{row.boolean ? 'True' : `-`}</TableCell>
+            <TableCell>{row.decimal ? 'True' : `-`}</TableCell>
+            <TableCell stickyColumn={isStickyColumn}>{row.pickAny ? 'True' : `-`}</TableCell>
+            <TableCell
+              alignRight
+              stickyColumn={isStickyColumn}
+              stickyColumnXOffset={0}
+              stickyRight
+            >
+              {editButton()}
+            </TableCell>
           </TableRow>
         )))}
       </TableBody>
@@ -393,7 +475,7 @@ export const TableWithMultipleSelect = () => {
   );
 };
 
-export const TableWithMultipleSelectAndStickyColumnAndHeader = () => {
+export const TableWithMultipleSelectAndStickyColumnsAndHeader = () => {
   const [selectedRows, setSelectedRows] = useState([]);
   const [isSelectAllCheckboxChecked, setIsSelectAllCheckboxChecked] = useState(false);
 
@@ -427,16 +509,23 @@ export const TableWithMultipleSelectAndStickyColumnAndHeader = () => {
     <Table>
       <TableHead>
         <TableRow stickyRow>
-          <TableCell header>
+          <TableCell header stickyColumn={isStickyColumn} stickyColumnXOffset={0} stickyLeft>
             <CheckboxButton id="checkbox" onChange={() => handleCheckboxSelectAll(data)} />
           </TableCell>
-          <TableCell header stickyColumn={isStickyColumn}>Email <span style={{ float: 'right' }}><PinButton isPinActive={isStickyColumn} onClick={handlePinClick} /></span></TableCell>
+          <TableCell header stickyColumn={isStickyColumn} stickyColumnXOffset={3.813} stickyLeft>Email <span style={{ float: 'right' }}><PinButton isPinActive={isStickyColumn} onClick={handlePinClick} /></span></TableCell>
           <TableCell header>First name</TableCell>
           <TableCell header>Last name</TableCell>
           <TableCell header>Phone number</TableCell>
           <TableCell header>Date added</TableCell>
           <TableCell header>Last invited</TableCell>
-          <TableCell header>Last applied</TableCell>
+          <TableCell
+            header
+            stickyColumn={isStickyColumn}
+            stickyColumnXOffset={0}
+            stickyRight
+          >
+            Action
+          </TableCell>
         </TableRow>
       </TableHead>
       <TableBody>
@@ -447,20 +536,30 @@ export const TableWithMultipleSelectAndStickyColumnAndHeader = () => {
             selected={selectedRows.includes(row.id)}
             onClick={() => handleCheckboxSelectSingle(row.id)}
           >
-            <TableCell>
+            <TableCell stickyColumn={isStickyColumn} stickyColumnXOffset={0} stickyLeft>
               <CheckboxButton
                 checked={isChecked(row.id)}
                 id="checkbox"
                 onChange={() => handleCheckboxSelectSingle(row.id)}
               />
             </TableCell>
-            <TableCell stickyColumn={isStickyColumn}>{row.email}</TableCell>
+            <TableCell
+              stickyColumn={isStickyColumn}
+              stickyColumnXOffset={3.813}
+              stickyLeft
+            >{row.email}
+            </TableCell>
             <TableCell>{row.firstName}</TableCell>
             <TableCell>{row.lastName}</TableCell>
             <TableCell>{row.phoneNumber}</TableCell>
             <TableCell>{row.dateAdded}</TableCell>
             <TableCell>{row.lastInvited ? row.lastInvited : `-`}</TableCell>
-            <TableCell>{row.lastApplied ? row.lastApplied : `-`}</TableCell>
+            <TableCell
+              stickyColumn={isStickyColumn}
+              stickyColumnXOffset={0}
+              stickyRight
+            >{kebabButton()}
+            </TableCell>
           </TableRow>
         )))}
       </TableBody>

--- a/src/Table/Table.stories.jsx
+++ b/src/Table/Table.stories.jsx
@@ -380,8 +380,20 @@ export const TableWithMultipleStickyColumnsAndHeader = () => {
       <TableBody>
         {data.map(((row) => (
           <TableRow key={row.id}>
-            <TableCell maxWidth={160} stickyColumn={isStickyColumn} stickyColumnOffsetX={0} stickyLeft>{row.email}</TableCell>
-            <TableCell minWidth={160} stickyColumn={isStickyColumn} stickyColumnOffsetX={160} stickyLeft>{row.firstName}</TableCell>
+            <TableCell
+              maxWidth={160}
+              stickyColumn={isStickyColumn}
+              stickyColumnOffsetX={0}
+              stickyLeft
+            >{row.email}
+            </TableCell>
+            <TableCell
+              minWidth={160}
+              stickyColumn={isStickyColumn}
+              stickyColumnOffsetX={160}
+              stickyLeft
+            >{row.firstName}
+            </TableCell>
             <TableCell>{row.lastName}</TableCell>
             <TableCell>{row.phoneNumber}</TableCell>
             <TableCell>{row.dateAdded}</TableCell>

--- a/src/Table/TableCell.jsx
+++ b/src/Table/TableCell.jsx
@@ -13,6 +13,9 @@ const TableCell = ({
   maxWidth,
   minWidth,
   stickyColumn,
+  stickyColumnXOffset,
+  stickyLeft,
+  stickyRight,
   stickyRow,
   ...props
 }) => {
@@ -23,8 +26,10 @@ const TableCell = ({
         [`TableCell--compact`]: !!compact,
         [`TableCell__header`]: !!header,
         [`TableCell--right`]: !!alignRight,
-        [`TableCell--sticky-column--corner`]: header && stickyColumn,
         [`TableCell--sticky-column`]: !!stickyColumn,
+        [`TableCell--sticky-column--corner`]: header && stickyColumn,
+        [`TableCell--sticky-column--left`]: !!stickyLeft && stickyColumn,
+        [`TableCell--sticky-column--right`]: !!stickyRight && stickyColumn,
         [`TableCell--sticky-row`]: !!stickyRow,
       },
     );
@@ -43,10 +48,21 @@ const TableCell = ({
     return null;
   };
 
+  const getStickyStyling = () => {
+    if (stickyColumn && stickyLeft) {
+      return { left: `${stickyColumnXOffset}rem` };
+    }
+    if (stickyColumn && stickyRight) {
+      return { right: `${stickyColumnXOffset}rem` };
+    }
+    return null;
+  };
+
   if (header) {
     return (
       <th
         className={getTableCellClassName()}
+        style={getStickyStyling()}
         {...props}
       >
         {children}
@@ -57,7 +73,7 @@ const TableCell = ({
   return (
     <td
       className={getTableCellClassName()}
-      style={getWidthStyling()}
+      style={{ ...getWidthStyling(), ...getStickyStyling() }}
       {...props}
     >
       {children}
@@ -76,6 +92,9 @@ TableCell.propTypes = {
   maxWidth: PropTypes.string,
   minWidth: PropTypes.string,
   stickyColumn: PropTypes.bool,
+  stickyColumnXOffset: PropTypes.number,
+  stickyLeft: PropTypes.bool,
+  stickyRight: PropTypes.bool,
   stickyRow: PropTypes.bool,
 };
 
@@ -88,5 +107,8 @@ TableCell.defaultProps = {
   maxWidth: undefined,
   minWidth: undefined,
   stickyColumn: undefined,
+  stickyColumnXOffset: undefined,
+  stickyLeft: undefined,
+  stickyRight: undefined,
   stickyRow: undefined,
 };

--- a/src/Table/TableCell.jsx
+++ b/src/Table/TableCell.jsx
@@ -34,8 +34,8 @@ const TableCell = ({
       },
     );
 
-  const maxWidthObj = { maxWidth };
-  const minWidthObj = { minWidth };
+  const maxWidthObj = { maxWidth: `${maxWidth}px` };
+  const minWidthObj = { minWidth: `${minWidth}px` };
 
   const getWidthStyling = () => {
     if (maxWidth && minWidth) {
@@ -89,8 +89,8 @@ TableCell.propTypes = {
   className: PropTypes.string,
   compact: PropTypes.bool,
   header: PropTypes.bool,
-  maxWidth: PropTypes.string,
-  minWidth: PropTypes.string,
+  maxWidth: PropTypes.number,
+  minWidth: PropTypes.number,
   stickyColumn: PropTypes.bool,
   stickyColumnOffsetX: PropTypes.number,
   stickyLeft: PropTypes.bool,

--- a/src/Table/TableCell.jsx
+++ b/src/Table/TableCell.jsx
@@ -13,7 +13,7 @@ const TableCell = ({
   maxWidth,
   minWidth,
   stickyColumn,
-  stickyColumnXOffset,
+  stickyColumnOffsetX,
   stickyLeft,
   stickyRight,
   stickyRow,
@@ -50,10 +50,10 @@ const TableCell = ({
 
   const getStickyStyling = () => {
     if (stickyColumn && stickyLeft) {
-      return { left: `${stickyColumnXOffset}rem` };
+      return { left: `${stickyColumnOffsetX}px` };
     }
     if (stickyColumn && stickyRight) {
-      return { right: `${stickyColumnXOffset}rem` };
+      return { right: `${stickyColumnOffsetX}px` };
     }
     return null;
   };
@@ -92,7 +92,7 @@ TableCell.propTypes = {
   maxWidth: PropTypes.string,
   minWidth: PropTypes.string,
   stickyColumn: PropTypes.bool,
-  stickyColumnXOffset: PropTypes.number,
+  stickyColumnOffsetX: PropTypes.number,
   stickyLeft: PropTypes.bool,
   stickyRight: PropTypes.bool,
   stickyRow: PropTypes.bool,
@@ -107,7 +107,7 @@ TableCell.defaultProps = {
   maxWidth: undefined,
   minWidth: undefined,
   stickyColumn: undefined,
-  stickyColumnXOffset: undefined,
+  stickyColumnOffsetX: undefined,
   stickyLeft: undefined,
   stickyRight: undefined,
   stickyRow: undefined,

--- a/src/Table/TableCell.scss
+++ b/src/Table/TableCell.scss
@@ -30,14 +30,20 @@
 
   &--sticky-column {
     position: sticky; 
-    left: 0;
     background: $ux-white;
-    box-shadow: $ux-box-shadow-table-sticky-column;
     z-index: $z-index-10;
 
     &--corner {
       background-color: $ux-gray-100;
       z-index: $z-index-20 !important;
+    }
+
+    &--left {
+      box-shadow: $ux-box-shadow-table-sticky-column-left;
+    }
+
+    &--right {
+      box-shadow: $ux-box-shadow-table-sticky-column-right;
     }
   }
 


### PR DESCRIPTION
This edit to the DS Table comes from the need to support multiple sticky columns. This emerged while working in `rails-server` on the Hub Participants view. 

This was the attempt to make adjustments on the `results.scss` for this view, but was running into some overriding issues especially with the multiple select functionality. 

https://user-images.githubusercontent.com/37383785/118170749-53351a00-b3df-11eb-9dcb-44a311e1cd02.mov

I thought it would be better to build support on the DS side instead as a solution, including support for a right-side sticky column should we ever need it in the future.

https://user-images.githubusercontent.com/37383785/118170418-e883de80-b3de-11eb-8b70-79291a020ad6.mov


