### PR TITLE
chore/UIDS-308 remove box shadow from inline alert

### DIFF
--- a/src/Alert/Alert.scss
+++ b/src/Alert/Alert.scss
@@ -41,7 +41,6 @@
   background-color: $ux-green-200;
   color: $ux-green-800;
   border-left: 0.5rem solid $ux-green-400;
-  box-shadow: $ux-elevations-20;
 
   .close {
     color: $ux-green-800;
@@ -52,7 +51,6 @@
   background-color: $ux-blue-100;
   color: $ux-blue-700;
   border-left: 0.5rem solid $ux-blue-300;
-  box-shadow: $ux-elevations-20;
 
   .close {
     color: $ux-blue-700;
@@ -63,7 +61,6 @@
   background-color: $ux-blue-100;
   color: $ux-blue-700;
   border-left: 0.5rem solid $ux-blue-300;
-  box-shadow: $ux-elevations-20;
 
   .close {
     color: $ux-blue-700;
@@ -74,7 +71,6 @@
   background-color: $ux-yellow-100;
   color: $ux-yellow-800;
   border-left: 0.5rem solid $ux-yellow-600;
-  box-shadow: $ux-elevations-20;
 
   .close {
     color: $ux-yellow-800;
@@ -85,7 +81,6 @@
   background-color: $ux-red-100;
   color: $ux-red-800;
   border-left: 0.5rem solid $ux-red-400;
-  box-shadow: $ux-elevations-20;
 
   .close {
     color: $ux-red-800;

--- a/src/Alert/Alert.scss
+++ b/src/Alert/Alert.scss
@@ -13,7 +13,6 @@
   margin-bottom: 1rem;
   padding: .75rem 1.25rem;
   position: relative;
-  border: 0.06rem solid transparent;
 
   &__icon {
     grid-column-start: 1;

--- a/src/Toast/Toast.scss
+++ b/src/Toast/Toast.scss
@@ -19,4 +19,8 @@
     padding: $ux-spacing-20;
     width: 100vw;
   }
+  
+  .Alert {
+    box-shadow: $ux-elevations-20;
+  }
 }


### PR DESCRIPTION
Inline Alerts should not have box-shadows. Only Toasts should have box-shadows.

Also fixed this weird angled issue on the border-left of Alerts/Toasts, so it should be flush against the sides now.

![Screen Shot 2021-03-19 at 10 29 03 AM](https://user-images.githubusercontent.com/37383785/121068384-127fb500-c781-11eb-893a-bd3e73686237.png)

