### PR TITLE
removes indeterminate attribute from CheckboxButton input element

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -674,7 +674,6 @@ exports[`Storyshots Design System/CheckboxButton Indeterminate 1`] = `
     <input
       checked={false}
       id="select-all"
-      indeterminate={false}
       onChange={[Function]}
       type="checkbox"
     />

--- a/src/CheckboxButton/CheckboxButton.jsx
+++ b/src/CheckboxButton/CheckboxButton.jsx
@@ -31,7 +31,6 @@ const CheckboxButton = React.forwardRef(({
       className={className}
       disabled={disabled}
       id={id}
-      indeterminate={indeterminate}
       name={name}
       ref={ref}
       type="checkbox"


### PR DESCRIPTION
Since we are setting the indeterminate state via JavaScript now, we can remove the indeterminate attribute from the `input` element which helps us avoid that boolean value console error. 