### PR TITLE
Move alert CTAs to the end of the alert vs. centered

### DIFF
--- a/src/Alert/Alert.scss
+++ b/src/Alert/Alert.scss
@@ -16,7 +16,7 @@
   padding: $ux-spacing-20 $ux-spacing-40;
   text-decoration: none;
   white-space: nowrap;
-  
+
   &:hover {
     background-color: $bg-color-hover;
   }
@@ -26,13 +26,13 @@
   display: grid;
   grid-template-columns: 2rem auto auto 2rem;
   grid-template-rows: auto auto;
-  grid-template-areas: 
+  grid-template-areas:
     'icon content content close'
     'icon action action close'
     ;
-  
+
   @media (min-width: 450px) {
-    grid-template-areas: 
+    grid-template-areas:
     'icon content action close'
     'icon content action close'
     ;
@@ -58,9 +58,9 @@
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    
+
     @media (min-width: 450px) {
-      justify-content: center;
+      justify-content: flex-end;
     }
   }
 


### PR DESCRIPTION
Hey team -- I noticed that the CTA is centered in alerts vs right aligned. I'm not sure how much went into this decision (so if it was a lot please ignore me) but to my eye this looks better:

Before: 
![image](https://user-images.githubusercontent.com/6667277/126004546-b2bc5423-f005-43fb-beb0-a0f19e9482a8.png)

After:
![image](https://user-images.githubusercontent.com/6667277/126004561-c0a0c1b8-f3bd-4e8a-83a1-0614483be535.png)

Note -- this doesn't touch the sub 450px version (where it's left aligned under the initial text).