### PR TITLE
UIDS-354 Add inputId to react select components.

### DIFF
--- a/src/Select/AsyncSelect.jsx
+++ b/src/Select/AsyncSelect.jsx
@@ -18,6 +18,7 @@ const AsyncSelect = ({
   isClearable,
   id,
   ignoreCase,
+  inputId,
   isLoading,
   loadOptions,
   modal,
@@ -41,6 +42,7 @@ const AsyncSelect = ({
     getOptionValue={getOptionValue}
     id={id}
     ignoreCase={ignoreCase}
+    inputId={inputId}
     isClearable={isClearable}
     isDisabled={disabled}
     isLoading={isLoading}
@@ -77,6 +79,7 @@ AsyncSelect.propTypes = {
   getOptionValue: propTypes.func,
   id: propTypes.string,
   ignoreCase: propTypes.bool,
+  inputId: propTypes.string,
   isClearable: propTypes.bool,
   isLoading: propTypes.bool,
   loadOptions: propTypes.func.isRequired,
@@ -101,6 +104,7 @@ AsyncSelect.defaultProps = {
   getOptionValue: undefined,
   id: undefined,
   ignoreCase: undefined,
+  inputId: undefined,
   isClearable: false,
   isLoading: false,
   modal: false,

--- a/src/Select/SingleSelect.jsx
+++ b/src/Select/SingleSelect.jsx
@@ -16,6 +16,7 @@ const SingleSelect = ({
   getOptionValue,
   isClearable,
   id,
+  inputId,
   isLoading,
   isSearchable,
   modal,
@@ -36,6 +37,7 @@ const SingleSelect = ({
     getOptionLabel={getOptionLabel}
     getOptionValue={getOptionValue}
     id={id}
+    inputId={inputId}
     isClearable={isClearable}
     isDisabled={disabled || isLoading}
     isSearchable={isSearchable}
@@ -66,6 +68,7 @@ SingleSelect.propTypes = {
   getOptionLabel: propTypes.func,
   getOptionValue: propTypes.func,
   id: propTypes.string,
+  inputId: propTypes.string,
   isClearable: propTypes.bool,
   isLoading: propTypes.bool,
   isSearchable: propTypes.bool,
@@ -89,6 +92,7 @@ SingleSelect.defaultProps = {
   getOptionValue: undefined,
   isClearable: false,
   id: undefined,
+  inputId: undefined,
   isLoading: false,
   isSearchable: false,
   modal: false,


### PR DESCRIPTION
This is necessary for adding an ID to the input element in React Select for use with `for` on forms.

I had the idea of changing the `id` to point here but that would block the ability to set ID on the react-select element which may cause other issues.