### PR TITLE
Feature/UIDS-337 update multiselect styles to match rails-server

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -4527,7 +4527,7 @@ exports[`Storyshots Design System/Selects/Async Default 1`] = `
         className=" css-g1d714-ValueContainer"
       >
         <div
-          className=" css-1wa3eu0-placeholder"
+          className=" css-1269n2i-placeholder"
         >
           Select...
         </div>
@@ -4649,7 +4649,7 @@ exports[`Storyshots Design System/Selects/Async Labeled 1`] = `
         className=" css-g1d714-ValueContainer"
       >
         <div
-          className=" css-1wa3eu0-placeholder"
+          className=" css-1269n2i-placeholder"
         >
           Select...
         </div>
@@ -4764,7 +4764,7 @@ exports[`Storyshots Design System/Selects/Creatable Default 1`] = `
         className=" css-g1d714-ValueContainer"
       >
         <div
-          className=" css-1wa3eu0-placeholder"
+          className=" css-1269n2i-placeholder"
         >
           Select...
         </div>
@@ -4878,7 +4878,7 @@ exports[`Storyshots Design System/Selects/Single Default 1`] = `
         className=" css-g1d714-ValueContainer"
       >
         <div
-          className=" css-1wa3eu0-placeholder"
+          className=" css-1269n2i-placeholder"
         >
           Select...
         </div>
@@ -4955,7 +4955,7 @@ exports[`Storyshots Design System/Selects/Single Labeled 1`] = `
         className=" css-g1d714-ValueContainer"
       >
         <div
-          className=" css-1wa3eu0-placeholder"
+          className=" css-1269n2i-placeholder"
         >
           Select...
         </div>
@@ -5025,7 +5025,7 @@ exports[`Storyshots Design System/Selects/Single Loading 1`] = `
         className=" css-g1d714-ValueContainer"
       >
         <div
-          className=" css-1wa3eu0-placeholder"
+          className=" css-1269n2i-placeholder"
         >
           Select...
         </div>
@@ -5102,7 +5102,7 @@ exports[`Storyshots Design System/Selects/Single Multi Select 1`] = `
         className=" css-g1d714-ValueContainer"
       >
         <div
-          className=" css-1wa3eu0-placeholder"
+          className=" css-1269n2i-placeholder"
         >
           Select...
         </div>

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -4519,7 +4519,7 @@ exports[`Storyshots Design System/Selects/Async Default 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      className=" css-p7mq78-control"
+      className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -4641,7 +4641,7 @@ exports[`Storyshots Design System/Selects/Async Labeled 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      className=" css-p7mq78-control"
+      className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -4756,7 +4756,7 @@ exports[`Storyshots Design System/Selects/Creatable Default 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      className=" css-p7mq78-control"
+      className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -4870,7 +4870,7 @@ exports[`Storyshots Design System/Selects/Single Default 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      className=" css-p7mq78-control"
+      className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -4947,7 +4947,7 @@ exports[`Storyshots Design System/Selects/Single Labeled 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      className=" css-p7mq78-control"
+      className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -5017,7 +5017,7 @@ exports[`Storyshots Design System/Selects/Single Loading 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      className=" css-ego0uw-control"
+      className=" css-1930729-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -5094,7 +5094,7 @@ exports[`Storyshots Design System/Selects/Single Multi Select 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      className=" css-p7mq78-control"
+      className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -4519,7 +4519,7 @@ exports[`Storyshots Design System/Selects/Async Default 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      className=" css-qv254q-control"
+      className=" css-p7mq78-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -4641,7 +4641,7 @@ exports[`Storyshots Design System/Selects/Async Labeled 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      className=" css-qv254q-control"
+      className=" css-p7mq78-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -4756,7 +4756,7 @@ exports[`Storyshots Design System/Selects/Creatable Default 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      className=" css-qv254q-control"
+      className=" css-p7mq78-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -4870,7 +4870,7 @@ exports[`Storyshots Design System/Selects/Single Default 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      className=" css-qv254q-control"
+      className=" css-p7mq78-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -4947,7 +4947,7 @@ exports[`Storyshots Design System/Selects/Single Labeled 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      className=" css-qv254q-control"
+      className=" css-p7mq78-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -5017,7 +5017,7 @@ exports[`Storyshots Design System/Selects/Single Loading 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      className=" css-1wkj6wz-control"
+      className=" css-ego0uw-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -5048,6 +5048,83 @@ exports[`Storyshots Design System/Selects/Single Loading 1`] = `
       >
         <span
           className=" css-3igypj-indicatorSeparator"
+        />
+        <div
+          aria-hidden="true"
+          className=" css-fric97-indicatorContainer"
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+        >
+          <svg
+            aria-hidden="true"
+            className="css-6q0nyr-Svg"
+            focusable="false"
+            height={20}
+            viewBox="0 0 20 20"
+            width={20}
+          >
+            <path
+              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Design System/Selects/Single Multi Select 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <label
+    htmlFor="multi-select"
+    id="select-label"
+  >
+    Multi select
+  </label>
+  <div
+    className="SingleSelect css-2b097c-container"
+    id="multi-select"
+    onKeyDown={[Function]}
+  >
+    <div
+      className=" css-p7mq78-control"
+      onMouseDown={[Function]}
+      onTouchEnd={[Function]}
+    >
+      <div
+        className=" css-g1d714-ValueContainer"
+      >
+        <div
+          className=" css-1wa3eu0-placeholder"
+        >
+          Select...
+        </div>
+        <input
+          aria-autocomplete="list"
+          aria-labelledby="select-label"
+          className="css-62g3xt-dummyInput"
+          disabled={false}
+          id="react-select-8-input"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          readOnly={true}
+          tabIndex="0"
+          value=""
+        />
+      </div>
+      <div
+        className=" css-1hb7zxy-IndicatorsContainer"
+      >
+        <span
+          className=" css-43ykx9-indicatorSeparator"
         />
         <div
           aria-hidden="true"

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -5111,7 +5111,7 @@ exports[`Storyshots Design System/Selects/Single Multi Select 1`] = `
           aria-labelledby="select-label"
           className="css-62g3xt-dummyInput"
           disabled={false}
-          id="react-select-8-input"
+          id="react-select-9-input"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -5164,7 +5164,7 @@ exports[`Storyshots Design System/Selects/Single Searchable 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      className=" css-qv254q-control"
+      className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -5172,7 +5172,7 @@ exports[`Storyshots Design System/Selects/Single Searchable 1`] = `
         className=" css-g1d714-ValueContainer"
       >
         <div
-          className=" css-1wa3eu0-placeholder"
+          className=" css-1269n2i-placeholder"
         >
           Select...
         </div>

--- a/src/Select/AsyncSelect.test.jsx
+++ b/src/Select/AsyncSelect.test.jsx
@@ -3,6 +3,7 @@ import Async from 'react-select/async';
 import { create } from 'react-test-renderer';
 
 import { AsyncSelect, SELECT_SIZES } from 'src/Select';
+import { SIZE_SMALL_HEIGHT } from 'src/Select/styles';
 
 const renderAsync = (props) => create(
   <AsyncSelect loadOptions={jest.fn()} {...props} />,
@@ -16,8 +17,8 @@ describe('AsyncSelect', () => {
     const { props } = root.findByType(Async);
     const contentStyles = getContentStyles(props);
 
-    expect(contentStyles.height).toBe('2.25rem');
-    expect(contentStyles.minHeight).toBe('2.25rem');
+    expect(contentStyles.height).toBe(SIZE_SMALL_HEIGHT.height);
+    expect(contentStyles.minHeight).toBe(SIZE_SMALL_HEIGHT.minHeight);
   });
 
   test('size prop set to null will not set height of select', () => {

--- a/src/Select/SingleSelect.jsx
+++ b/src/Select/SingleSelect.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import Select from 'react-select';
 import propTypes from 'prop-types';
 
@@ -32,7 +33,7 @@ const SingleSelect = ({
     {...props}
     aria-label={ariaLabel}
     aria-labelledby={ariaLabelledBy}
-    className={`${className || ''} SingleSelect`}
+    className={classNames('SingleSelect', className)}
     defaultValue={defaultValue}
     getOptionLabel={getOptionLabel}
     getOptionValue={getOptionValue}

--- a/src/Select/SingleSelect.stories.jsx
+++ b/src/Select/SingleSelect.stories.jsx
@@ -40,3 +40,16 @@ export const Labeled = () => (
     />
   </Fragment>
 );
+
+export const MultiSelect = () => (
+  <Fragment>
+    <label htmlFor="multi-select" id="select-label">Multi select</label>
+    <SingleSelect
+      aria-labelledby="select-label"
+      id="multi-select"
+      isMulti
+      options={options}
+      onChange={onChange}
+    />
+  </Fragment>
+);

--- a/src/Select/SingleSelect.test.jsx
+++ b/src/Select/SingleSelect.test.jsx
@@ -3,6 +3,7 @@ import Select from 'react-select';
 import { create } from 'react-test-renderer';
 
 import { SingleSelect, SELECT_SIZES } from 'src/Select';
+import { SIZE_SMALL_HEIGHT } from 'src/Select/styles';
 
 const renderSelect = (props) => create(
   <SingleSelect options={[]} onChange={jest.fn()} {...props} />,
@@ -16,8 +17,8 @@ describe('SingleSelect', () => {
     const { props } = root.findByType(Select);
     const contentStyles = getContentStyles(props);
 
-    expect(contentStyles.height).toBe('2.25rem');
-    expect(contentStyles.minHeight).toBe('2.25rem');
+    expect(contentStyles.height).toBe(SIZE_SMALL_HEIGHT.height);
+    expect(contentStyles.minHeight).toBe(SIZE_SMALL_HEIGHT.minHeight);
   });
 
   test('size prop set to null will not set height of select', () => {

--- a/src/Select/styles.js
+++ b/src/Select/styles.js
@@ -3,12 +3,14 @@ import fontWeights from '../Styles/fontWeights';
 
 export const SELECT_SIZES = { SMALL: 'small' };
 
+export const SIZE_SMALL_HEIGHT = {
+  height: 'auto',
+  minHeight: '2.25rem',
+};
+
 const getHeightProps = (size) => {
   if (size === SELECT_SIZES.SMALL) {
-    return {
-      height: 'auto',
-      minHeight: '36px', // rem units don't work for this
-    };
+    return SIZE_SMALL_HEIGHT;
   }
   return null;
 };
@@ -18,8 +20,8 @@ function getBorderStyles(isFocused, isSelected) {
     boxShadow: (isFocused || isSelected) ? 'inset 0 1px 1px rgba(0, 0, 0, 0.08)' : 'none',
     borderColor: (
       (isFocused || isSelected) ? systemColors.UX_BLUE_300 : systemColors.inputBorderColor
-    )
-  }
+    ),
+  };
 }
 
 /*

--- a/src/Select/styles.js
+++ b/src/Select/styles.js
@@ -6,26 +6,63 @@ export const SELECT_SIZES = { SMALL: 'small' };
 const getHeightProps = (size) => {
   if (size === SELECT_SIZES.SMALL) {
     return {
-      height: '2.25rem',
-      minHeight: '2.25rem',
+      height: 'auto',
+      minHeight: '36px', // rem units don't work for this
     };
   }
   return null;
 };
+
+function getBorderStyles(isFocused, isSelected) {
+  return {
+    boxShadow: (isFocused || isSelected) ? 'inset 0 1px 1px rgba(0, 0, 0, 0.08)' : 'none',
+    borderColor: (
+      (isFocused || isSelected) ? systemColors.UX_BLUE_300 : systemColors.inputBorderColor
+    )
+  }
+}
 
 /*
  To set styles for your item, make sure your option object has a child `colors` object
  with a text and/or hover key defined to override the defaults
  */
 const defaultStyles = ({ size }) => ({
-    control: (styles, { isDisabled }) => ({
+    control: (styles, { isDisabled, isFocused, isSelected }) => ({
       ...styles,
       ...getHeightProps(size),
       backgroundColor: isDisabled ? systemColors.inputDisabledBg : styles.backgroundColor,
-      borderColor: systemColors.inputBorderColor,
+      ...getBorderStyles(isFocused, isSelected),
+      ':hover': {
+        ...styles[':hover'],
+        ...getBorderStyles(isFocused, isSelected),
+      },
     }),
     dropdownIndicator: (styles) => ({ ...styles, color: systemColors.UX_GRAY_600 }),
     indicatorSeparator: (styles) => ({ ...styles, display: 'none' }),
+    multiValue: (styles) => ({
+      ...styles,
+      backgroundColor: systemColors.UX_BLUE_100,
+      color: systemColors.UX_BLUE_700,
+      borderRadius: '.25rem',
+    }),
+    multiValueLabel: (styles) => ({
+      ...styles,
+      color: systemColors.UX_BLUE_700,
+      fontSize: '0.875rem',
+      fontWeight: 400,
+      lineHeight: '1.25rem',
+      paddingLeft: '.5rem',
+    }),
+    multiValueRemove: (styles) => ({
+      ...styles,
+      color: systemColors.UX_BLUE,
+      cursor: 'pointer',
+      ':hover': {
+        ...styles[':hover'],
+        backgroundColor: systemColors.selectOptionFocusedBg,
+        color: systemColors.UX_BLUE_700,
+      },
+    }),
     singleValue: (styles, { data }) => ({
       ...styles,
       color: (
@@ -46,6 +83,7 @@ const defaultStyles = ({ size }) => ({
         backgroundColor: isSelected || isFocused ? colors.hover : styles.backgroundColor,
         color: colors.text,
         fontWeight: fontWeights.light,
+        fontSize: '0.875rem',
         cursor: 'pointer',
 
         ':active': {

--- a/src/Select/styles.js
+++ b/src/Select/styles.js
@@ -17,7 +17,7 @@ const getHeightProps = (size) => {
 
 function getBorderStyles(isFocused, isSelected) {
   return {
-    boxShadow: (isFocused || isSelected) ? 'inset 0 1px 1px rgba(0, 0, 0, 0.08)' : 'none',
+    boxShadow: (isFocused || isSelected) ? '0px 0px 8px 0px #66AFE9B2;' : 'none',
     borderColor: (
       (isFocused || isSelected) ? systemColors.UX_BLUE_300 : systemColors.inputBorderColor
     ),
@@ -65,6 +65,11 @@ const defaultStyles = ({ size }) => ({
         color: systemColors.UX_BLUE_700,
       },
     }),
+    placeholder: (styles) => ({
+      ...styles,
+      color: systemColors.UX_GRAY_800,
+      fontWeight: '300',
+    }),
     singleValue: (styles, { data }) => ({
       ...styles,
       color: (
@@ -96,7 +101,7 @@ const defaultStyles = ({ size }) => ({
 
         ':hover': {
           ...styles[':hover'],
-          backgroundColor: colors.hover || systemColors.UX_GRAY_200,
+          backgroundColor: colors.hover || systemColors.UX_BLUE_100,
         },
       };
     },

--- a/src/Styles/colors/inputs.js
+++ b/src/Styles/colors/inputs.js
@@ -3,4 +3,5 @@ import palette from './palette';
 export default {
   inputBorderColor: palette.UX_GRAY_400,
   inputDisabledBg: palette.UX_GRAY_300,
+  selectOptionFocusedBg: '#C7DDEF',
 };


### PR DESCRIPTION
Closes #337 

We override some styles from the design system select components in the app. This PR moves these styles to be the default from the design system. Namely:
- Supporting the multi-select
- Updating the default selected color to blue for the mult-select
- Setting height to auto vs. a fixed height to support line-wrapping on the multi-select dropdown
- Making selected border blue with drop shadow to match app styles
- Set remove button styles from multi-select to match app styles

<img width="565" alt="Screen Shot 2021-08-02 at 12 30 15 PM" src="https://user-images.githubusercontent.com/4008333/127913621-c221f080-d963-483e-bb23-c69e5df9111d.png">
