### PR TITLE
Feature/UI ds 453 improve close button aria labels on Alert

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -512,7 +512,7 @@ exports[`Storyshots Design System/Alert With Call To Action 1`] = `
       className="Alert__close"
     >
       <button
-        aria-label="close"
+        aria-label="close success"
         className="close"
         onClick={[Function]}
         type="button"
@@ -641,7 +641,7 @@ exports[`Storyshots Design System/Alert With Call To Action 1`] = `
       className="Alert__close"
     >
       <button
-        aria-label="close"
+        aria-label="close info"
         className="close"
         onClick={[Function]}
         type="button"
@@ -734,7 +734,7 @@ exports[`Storyshots Design System/Alert With Call To Action 1`] = `
       className="Alert__close"
     >
       <button
-        aria-label="close"
+        aria-label="close announcement"
         className="close"
         onClick={[Function]}
         type="button"
@@ -827,7 +827,7 @@ exports[`Storyshots Design System/Alert With Call To Action 1`] = `
       className="Alert__close"
     >
       <button
-        aria-label="close"
+        aria-label="close error"
         className="close"
         onClick={[Function]}
         type="button"
@@ -920,7 +920,7 @@ exports[`Storyshots Design System/Alert With Call To Action 1`] = `
       className="Alert__close"
     >
       <button
-        aria-label="close"
+        aria-label="close warning"
         className="close"
         onClick={[Function]}
         type="button"
@@ -1052,7 +1052,7 @@ exports[`Storyshots Design System/Alert With Call To Action 1`] = `
       className="Alert__close"
     >
       <button
-        aria-label="close"
+        aria-label="close announcement"
         className="close"
         onClick={[Function]}
         type="button"
@@ -1187,7 +1187,7 @@ exports[`Storyshots Design System/Alert With Call To Action 1`] = `
       className="Alert__close"
     >
       <button
-        aria-label="close"
+        aria-label="close announcement"
         className="close"
         onClick={[Function]}
         type="button"
@@ -1316,7 +1316,7 @@ exports[`Storyshots Design System/Alert With Dismiss 1`] = `
       className="Alert__close"
     >
       <button
-        aria-label="close"
+        aria-label="close success"
         className="close"
         onClick={[Function]}
         type="button"

--- a/src/Alert/Alert.jsx
+++ b/src/Alert/Alert.jsx
@@ -107,7 +107,7 @@ function Alert(props) {
         props.onDismiss && (
           <div className="Alert__close">
             <button
-              aria-label="close"
+              aria-label={`close ${props.type}`}
               className="close"
               type="button"
               onClick={() => props.onDismiss(props.id)}

--- a/src/Toast/__snapshots__/withToast.test.jsx.snap
+++ b/src/Toast/__snapshots__/withToast.test.jsx.snap
@@ -90,7 +90,7 @@ Array [
       className="Alert__close"
     >
       <button
-        aria-label="close"
+        aria-label="close success"
         className="close"
         onClick={[Function]}
         type="button"


### PR DESCRIPTION
In the situation where we have more than one Alert being displayed, we have multiple buttons with the ARIA label of 'close' which makes it hard to differentiate between the two. This PR will add the type of alert to the label, so the screen reader should read "close error" or "close announcement".

This also makes it easier to target the close button in testing library!