### PR TITLE
hotfix/UIDS-470 update Card to conditionally render header

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -11115,9 +11115,6 @@ exports[`Storyshots Design System/Table Table On Card No Padding 1`] = `
     className="Card Card--lg Card--no-padding"
   >
     <div
-      className="Card__header"
-    />
-    <div
       id="Some table container"
       style={
         Object {

--- a/src/Card/Card.jsx
+++ b/src/Card/Card.jsx
@@ -25,10 +25,12 @@ const Card = ({
 }) => {
   const cardChildren = (
     <Fragment>
-      <div className="Card__header">
-        { title && <h2 className="Card__title">{title}</h2> }
-        { helperText && <span className="Card__helper-text">{helperText}</span>}
-      </div>
+      { title && (
+        <div className="Card__header">
+          <h2 className="Card__title">{title}</h2>
+          { helperText && <span className="Card__helper-text">{helperText}</span>}
+        </div>
+      )}
 
       { divided && <hr className="Card__divider" /> }
       { subTitle && <h3 className="Card__subtitle">{subTitle}</h3> }


### PR DESCRIPTION
closes #470 

- This should make the `Card` component less opinionated on layout. Ran into this issue before where I was trying to create a flexbox layout, but because the `Card__header` always rendered, it made it difficult to do things like justify-content. Example [here](https://github.com/user-interviews/rails-server/pull/8593#discussion_r746930193)

Note to self: will need to QA on rails-server since there may be places where we were writing custom css to get around this issue. 