### PR TITLE
chore/UIDS-443 Add nightly Percy run in GitHub actions

### DIFF
--- a/.github/workflows/percy-nightly-tests.yml
+++ b/.github/workflows/percy-nightly-tests.yml
@@ -1,0 +1,20 @@
+name: "Run Percy Tests"
+on:
+  schedule:
+    - cron: "0 0 * * *"
+    branches:
+      - develop
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Install
+        run: yarn
+      - name: Percy Test
+        uses: percy/exec-action@v0.x.x
+        with:
+          command: "cypress run"
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.github/workflows/percy-nightly-tests.yml
+++ b/.github/workflows/percy-nightly-tests.yml
@@ -1,9 +1,9 @@
 name: "Run Percy Tests"
+
 on:
   schedule:
     - cron: "0 0 * * *"
-    branches:
-      - develop
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
@rroppolo not sure the best way to test this out or if this is how we should do it.

I think you need to set the `PERCY_TOKEN` for us since I don't seem to have the settings button. 

How I came up with yaml:
https://github.com/percy/exec-action