### PR TITLE
UIDS-438 Add AsyncCreatableSelect

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -6071,7 +6071,7 @@ exports[`Storyshots Design System/Selects/Async Default 1`] = `
               autoComplete="off"
               autoCorrect="off"
               disabled={false}
-              id="react-select-2-input"
+              id="react-select-3-input"
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
@@ -6193,7 +6193,122 @@ exports[`Storyshots Design System/Selects/Async Labeled 1`] = `
               autoComplete="off"
               autoCorrect="off"
               disabled={false}
-              id="react-select-3-input"
+              id="react-select-4-input"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              spellCheck="false"
+              style={
+                Object {
+                  "background": 0,
+                  "border": 0,
+                  "boxSizing": "content-box",
+                  "color": "inherit",
+                  "fontSize": "inherit",
+                  "label": "input",
+                  "opacity": 1,
+                  "outline": 0,
+                  "padding": 0,
+                  "width": "1px",
+                }
+              }
+              tabIndex="0"
+              type="text"
+              value=""
+            />
+            <div
+              style={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "overflow": "scroll",
+                  "position": "absolute",
+                  "top": 0,
+                  "visibility": "hidden",
+                  "whiteSpace": "pre",
+                }
+              }
+            >
+              
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className=" css-1hb7zxy-IndicatorsContainer"
+      >
+        <span
+          className=" css-43ykx9-indicatorSeparator"
+        />
+        <div
+          aria-hidden="true"
+          className=" css-7sl878-indicatorContainer"
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+        >
+          <svg
+            aria-hidden="true"
+            className="css-6q0nyr-Svg"
+            focusable="false"
+            height={20}
+            viewBox="0 0 20 20"
+            width={20}
+          >
+            <path
+              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Design System/Selects/AsyncCreatable Default 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="AsyncSelect css-2b097c-container"
+    onKeyDown={[Function]}
+  >
+    <div
+      className=" css-15ub2n0-control"
+      onMouseDown={[Function]}
+      onTouchEnd={[Function]}
+    >
+      <div
+        className=" css-g1d714-ValueContainer"
+      >
+        <div
+          className=" css-1269n2i-placeholder"
+        >
+          Select...
+        </div>
+        <div
+          className="css-b8ldur-Input"
+        >
+          <div
+            className=""
+            style={
+              Object {
+                "display": "inline-block",
+              }
+            }
+          >
+            <input
+              aria-autocomplete="list"
+              aria-label="Async creatable select"
+              autoCapitalize="none"
+              autoComplete="off"
+              autoCorrect="off"
+              disabled={false}
+              id="react-select-2-input"
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
@@ -6307,7 +6422,7 @@ exports[`Storyshots Design System/Selects/Creatable Default 1`] = `
               autoComplete="off"
               autoCorrect="off"
               disabled={false}
-              id="react-select-4-input"
+              id="react-select-5-input"
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
@@ -6416,7 +6531,7 @@ exports[`Storyshots Design System/Selects/Single Custom Option With Checkbox 1`]
           aria-labelledby="select-label"
           className="css-62g3xt-dummyInput"
           disabled={false}
-          id="react-select-11-input"
+          id="react-select-12-input"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -6493,7 +6608,7 @@ exports[`Storyshots Design System/Selects/Single Custom Value Container 1`] = `
           aria-labelledby="select-label"
           className="css-62g3xt-dummyInput"
           disabled={false}
-          id="react-select-12-input"
+          id="react-select-13-input"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -6563,7 +6678,7 @@ exports[`Storyshots Design System/Selects/Single Default 1`] = `
           aria-label="Default select"
           className="css-62g3xt-dummyInput"
           disabled={false}
-          id="react-select-5-input"
+          id="react-select-6-input"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -6688,7 +6803,7 @@ exports[`Storyshots Design System/Selects/Single In Modal 1`] = `
                 aria-labelledby="select-label"
                 className="css-62g3xt-dummyInput"
                 disabled={false}
-                id="react-select-10-input"
+                id="react-select-11-input"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -6784,7 +6899,7 @@ exports[`Storyshots Design System/Selects/Single Labeled 1`] = `
           aria-labelledby="select-label"
           className="css-62g3xt-dummyInput"
           disabled={false}
-          id="react-select-8-input"
+          id="react-select-9-input"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -6854,7 +6969,7 @@ exports[`Storyshots Design System/Selects/Single Loading 1`] = `
           aria-label="Loading select"
           className="css-62g3xt-dummyInput"
           disabled={true}
-          id="react-select-7-input"
+          id="react-select-8-input"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -6931,7 +7046,7 @@ exports[`Storyshots Design System/Selects/Single Multi Select 1`] = `
           aria-labelledby="select-label"
           className="css-62g3xt-dummyInput"
           disabled={false}
-          id="react-select-9-input"
+          id="react-select-10-input"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -7014,7 +7129,7 @@ exports[`Storyshots Design System/Selects/Single Searchable 1`] = `
               autoComplete="off"
               autoCorrect="off"
               disabled={false}
-              id="react-select-6-input"
+              id="react-select-7-input"
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}

--- a/src/Select/AsyncCreatableSelect.jsx
+++ b/src/Select/AsyncCreatableSelect.jsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import AsyncCreatable from 'react-select/async-creatable';
+
+import zStack from 'src/Styles/zStack';
+
+import { defaultStyles, defaultTheme, SELECT_SIZES } from './styles';
+
+const AsyncCreatableSelect = ({
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  className,
+  defaultOptions,
+  defaultValue,
+  disabled,
+  getOptionLabel,
+  getOptionValue,
+  isClearable,
+  id,
+  ignoreCase,
+  inputId,
+  isLoading,
+  loadOptions,
+  modal,
+  name,
+  noOptionsMessage,
+  placeholder,
+  size,
+  value,
+
+  onChange,
+  ...props
+}) => (
+  <AsyncCreatable
+    {...props}
+    aria-label={ariaLabel}
+    aria-labelledby={ariaLabelledBy}
+    className={`${className || ''} AsyncSelect`}
+    defaultOptions={defaultOptions}
+    defaultValue={defaultValue}
+    getOptionLabel={getOptionLabel}
+    getOptionValue={getOptionValue}
+    id={id}
+    ignoreCase={ignoreCase}
+    inputId={inputId}
+    isClearable={isClearable}
+    isDisabled={disabled}
+    isLoading={isLoading}
+    loadOptions={loadOptions}
+    menuPortalTarget={modal ? document.body : undefined}
+    name={name}
+    noOptionsMessage={noOptionsMessage}
+    placeholder={placeholder}
+    shouldShowValue
+    styles={{
+      ...defaultStyles({ size }),
+      menuPortal: (base) => (
+        modal ?
+          base :
+          { ...base, zIndex: zStack.zIndexModalBackdrop + 1 }
+      ),
+    }}
+    theme={defaultTheme}
+    value={value}
+    onBlurResetsInput={false}
+    onChange={onChange}
+    onSelectResetsInput={false}
+  />
+);
+
+AsyncCreatableSelect.propTypes = {
+  'aria-label': propTypes.string,
+  'aria-labelledby': propTypes.string,
+  className: propTypes.string,
+  defaultOptions: propTypes.oneOfType([propTypes.bool, propTypes.array]),
+  defaultValue: propTypes.object,
+  disabled: propTypes.bool,
+  getOptionLabel: propTypes.func,
+  getOptionValue: propTypes.func,
+  id: propTypes.string,
+  ignoreCase: propTypes.bool,
+  inputId: propTypes.string,
+  isClearable: propTypes.bool,
+  isLoading: propTypes.bool,
+  loadOptions: propTypes.func.isRequired,
+  modal: propTypes.bool,
+  name: propTypes.string,
+  noOptionsMessage: propTypes.func,
+  placeholder: propTypes.string,
+  size: propTypes.oneOf(Object.values(SELECT_SIZES)),
+  value: propTypes.object,
+
+  onChange: propTypes.func,
+};
+
+AsyncCreatableSelect.defaultProps = {
+  'aria-label': undefined,
+  'aria-labelledby': undefined,
+  className: undefined,
+  defaultOptions: false,
+  defaultValue: undefined,
+  disabled: false,
+  getOptionLabel: undefined,
+  getOptionValue: undefined,
+  id: undefined,
+  ignoreCase: undefined,
+  inputId: undefined,
+  isClearable: false,
+  isLoading: false,
+  modal: false,
+  name: undefined,
+  noOptionsMessage: undefined,
+  placeholder: undefined,
+  size: SELECT_SIZES.SMALL,
+  value: undefined,
+
+  onChange: undefined,
+};
+
+export default AsyncCreatableSelect;

--- a/src/Select/AsyncCreatableSelect.stories.jsx
+++ b/src/Select/AsyncCreatableSelect.stories.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import AsyncCreatableSelect from 'src/Select/AsyncCreatableSelect';
+
+export default {
+  title: 'Design System/Selects/AsyncCreatable',
+  component: AsyncCreatableSelect,
+};
+
+const options = [
+  { label: 'Red', value: 1 },
+  { label: 'Green', value: 2 },
+  { label: 'Blue', value: 3 },
+];
+
+async function loadOptions(search) {
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  if (!search || !search.length) { return options; }
+
+  return options.filter(({ label }) => label.toLowerCase().includes(search.toLowerCase()));
+}
+
+export const Default = () => {
+  const handleChange = () => {};
+  const handleInputChange = () => {};
+
+  return (
+    <AsyncCreatableSelect
+      aria-label="Async creatable select"
+      getOptionLabel={({ label }) => label}
+      getOptionValue={({ value }) => value}
+      isClearable
+      loadOptions={loadOptions}
+      onChange={handleChange}
+      onInputChange={handleInputChange}
+    />
+  );
+};

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -1,3 +1,5 @@
+import { components as SelectComponents } from 'react-select';
+import AsyncCreatableSelect from './AsyncCreatableSelect';
 import AsyncSelect from './AsyncSelect';
 import CreatableSelect from './CreatableSelect';
 import Option from './Option';
@@ -6,10 +8,12 @@ import ValueContainer from './ValueContainer';
 import { SELECT_SIZES } from './styles';
 
 export {
+  AsyncCreatableSelect,
   AsyncSelect,
   CreatableSelect,
   Option,
   SELECT_SIZES,
+  SelectComponents,
   SingleSelect,
   ValueContainer,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -29,9 +29,11 @@ import RadioButton from 'src/RadioButton';
 import RadioButtonGroup from 'src/RadioButtonGroup';
 import {
   AsyncSelect,
+  AsyncCreatableSelect,
   CreatableSelect,
   Option,
   SELECT_SIZES,
+  SelectComponents,
   SingleSelect,
   ValueContainer,
 } from 'src/Select';
@@ -61,6 +63,7 @@ export {
   Alert,
   Avatar,
   AsyncSelect,
+  AsyncCreatableSelect,
   Button,
   BUTTON_GROUP_ORIENTATIONS,
   Card,
@@ -94,6 +97,7 @@ export {
   RadioButton,
   RadioButtonGroup,
   SELECT_SIZES,
+  SelectComponents,
   SingleSelect,
   Tab,
   Tabs,


### PR DESCRIPTION
CLoses #438 

Right now we make use of two different versions of react-select on rails-server and uids. This PR sets up some missing functionality to remove from rails-server and only use the DS component.