### PR TITLE
UIDS-506 Update Form to handle GET method

### DIFF
--- a/src/Form/Form.jsx
+++ b/src/Form/Form.jsx
@@ -18,20 +18,21 @@ const Form = forwardRef(({
 }, ref) => {
   const hasMethod = method != null;
   const hasCSRF = CSRFParam && CSRFToken;
+  const isGetFormMethod = method === 'GET';
 
   return (
     <form
       action={action}
       className={classNames('Form', className)}
       id={id}
-      method="POST"
+      method={isGetFormMethod ? 'GET' : 'POST'}
       multipart={multipart}
       name={name}
       ref={ref}
       onSubmit={onSubmit}
     >
-      { hasCSRF && <input name={CSRFParam} type="hidden" value={CSRFToken} /> }
-      { hasMethod && <input name="_method" type="hidden" value={method} /> }
+      { hasCSRF && !isGetFormMethod && <input name={CSRFParam} type="hidden" value={CSRFToken} /> }
+      { hasMethod && !isGetFormMethod && <input name="_method" type="hidden" value={method} /> }
       {children}
     </form>
   );

--- a/src/Form/Form.mdx
+++ b/src/Form/Form.mdx
@@ -13,13 +13,12 @@ import Form from './Form';
   <Story id="design-system-form--default" />
 </Canvas>
 
-### When to use 
-- Reason 1
-- Reason 2
+### When to use
+- You are writing a page which submits a form via HTML
+- You are handling a grouping of inputs for a single API endpoint and want to ensure it functions like a traditional form.
 
 ### When to not use
-- Reason 1
-- Reason 2
+- You want to style something to look like a form but it is not interactive
 
 ## Props
 
@@ -37,7 +36,7 @@ import Form from './Form';
 
 ### States
 
-### Anatomy 
+### Anatomy
 
 ### Sizing
 


### PR DESCRIPTION
Previously passing a GET method would have worked for Rails, but it wouldn't
put the params in the URL which is the expected behavior. This makes it so we
properly pass GET directly to the form method parameter.

One other thing this does is remove the CSRF params if GET is passed. These are
ignored in GET and thus aren't necessary and would add extra params to the URL.

One potential upgrade that was left on the cutting room floor was passing any
extra props directly to the form component.