### PR TITLE
CHORE Fix node version in deploy action

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -12,6 +12,10 @@
       steps:
         - name: Checkout branch
           uses: actions/checkout@v2
+        - name: Setup node
+          uses: actions/setup-node@v1
+            with:
+              node-version: '14.17.4'
 
         - name: Configure npm
           run: npm config set "@fortawesome:registry" https://npm.fontawesome.com/ &&


### PR DESCRIPTION
Fix deploy script to use correct node version

I think this might actually be the real issue with the ally plugin not working on the deployed storybook page