### PR TITLE
hotfix/UIDS-515-fix-font-size-on-form-control

### DIFF
--- a/scss/forms/form_group.scss
+++ b/scss/forms/form_group.scss
@@ -80,10 +80,12 @@
   }
 
   .form-control {
+    @include font-type-30;
     height: 2.25rem;
   }
 
   textarea.form-control {
+    @include font-type-30;
     height: auto;
   }
 }


### PR DESCRIPTION
closes #515 

Fixing a font-size issue with `.form-control` and `textarea` that appeared in release v1.26.0. Since importing Bootstrap on the DS, the form-control scss module `webpack:///./node_modules/bootstrap/scss/forms/_form-control.scss` increases the font-size to 1rem

This should fix a majority of them on RS.