### PR TITLE
Chore/UIDS-536 fullscreen before percy snapshots

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -21,6 +21,14 @@ Cypress.Commands.add('iframe', { prevSubject: 'element' }, ($iframe) => {
 Cypress.Commands.add('takePercySnapshot', (name) => {
   cy.get('body').should('contain', 'Tests completed');
   cy.get('body').type('f'); // Fullscreen component
+
+  // Close the storybook update popup if it is there
+  cy.get('body').then((body) => {
+    if (body.find('button[title="Dismiss notification"]').length > 0) {
+      cy.get('button[title="Dismiss notification"]').click();
+    }
+  });
+
   cy.percySnapshot(name);
   cy.get('body').type('f'); // Un-fullscreen component
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -19,11 +19,8 @@ Cypress.Commands.add('iframe', { prevSubject: 'element' }, ($iframe) => {
 });
 
 Cypress.Commands.add('takePercySnapshot', (name) => {
-  // Check for accessibility tests to finish first
   cy.get('body').should('contain', 'Tests completed');
-
-  // Also wait for the nav to load
-  cy.get('body').should('contain', 'Components');
-
+  cy.get('body').type('f'); // Fullscreen component
   cy.percySnapshot(name);
+  cy.get('body').type('f'); // Un-fullscreen component
 });


### PR DESCRIPTION
Resolves #536 
This will help make our diffs in Percy better by getting around the accessibility test issues (being in different states with `Tests Completed` shown) and conditionally checking / and closing Storybook update modal:
https://percy.io/f38ae9b9/ui-design-system/builds/15401748
