### PR TITLE
add CardList to DS

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -2739,6 +2739,108 @@ exports[`Storyshots Components/Card Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/CardList Default 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="CardList"
+  >
+    <section
+      className="Card Card--sm"
+    >
+      <div
+        className="Card__header"
+      >
+        <h2
+          className="Card__title"
+        >
+          Card 1
+        </h2>
+      </div>
+      <h3
+        className="Card__subtitle"
+      >
+        The fastest way to recruit research participants. Source from a pool of more than 850,000 participants to reach nearly any target audience.
+      </h3>
+      <ul>
+        <li>
+          500,000+ sessions completed
+        </li>
+        <li>
+          $19 million+ incentives distributed
+        </li>
+        <li>
+          3 hours median time to 1st matched participant
+        </li>
+      </ul>
+    </section>
+    <section
+      className="Card Card--sm"
+    >
+      <div
+        className="Card__header"
+      >
+        <h2
+          className="Card__title"
+        >
+          Card 2
+        </h2>
+      </div>
+      <h3
+        className="Card__subtitle"
+      >
+        The fastest way to recruit research participants. Source from a pool of more than 850,000 participants to reach nearly any target audience.
+      </h3>
+      <ul>
+        <li>
+          500,000+ sessions completed
+        </li>
+        <li>
+          $19 million+ incentives distributed
+        </li>
+        <li>
+          3 hours median time to 1st matched participant
+        </li>
+      </ul>
+    </section>
+    <section
+      className="Card Card--sm"
+    >
+      <div
+        className="Card__header"
+      >
+        <h2
+          className="Card__title"
+        >
+          Card 3
+        </h2>
+      </div>
+      <h3
+        className="Card__subtitle"
+      >
+        The fastest way to recruit research participants. Source from a pool of more than 850,000 participants to reach nearly any target audience.
+      </h3>
+      <ul>
+        <li>
+          500,000+ sessions completed
+        </li>
+        <li>
+          $19 million+ incentives distributed
+        </li>
+        <li>
+          3 hours median time to 1st matched participant
+        </li>
+      </ul>
+    </section>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Components/CheckboxButton Default 1`] = `
 <div
   style={

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -2748,7 +2748,7 @@ exports[`Storyshots Components/CardList Default 1`] = `
   }
 >
   <div
-    className="CardList"
+    className="CardList CardList__alignItems--center"
   >
     <section
       className="Card Card--sm"

--- a/src/CardList/CardList.jsx
+++ b/src/CardList/CardList.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 
 import './CardList.scss';
 
+export const CardListAlignItemsOptions = ['center', 'flex-start', 'flex-end'];
+
 const CardList = ({
   alignItems,
   className,
@@ -25,7 +27,7 @@ const CardList = ({
   );
 
 CardList.propTypes = {
-  alignItems: PropTypes.oneOf(['center', 'flex-start', 'flex-end']),
+  alignItems: PropTypes.oneOf(CardListAlignItemsOptions),
   className: PropTypes.string,
 };
 

--- a/src/CardList/CardList.jsx
+++ b/src/CardList/CardList.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+
+import './CardList.scss';
+
+const CardList = ({
+  className,
+  children,
+  ...props
+}) => (
+  <div
+    className={classNames('CardList', className)}
+    {...props}
+  >
+    {children}
+  </div>
+  );
+
+CardList.propTypes = {
+  className: PropTypes.string,
+};
+
+CardList.defaultProps = {
+  className: undefined,
+};
+
+export default CardList;

--- a/src/CardList/CardList.jsx
+++ b/src/CardList/CardList.jsx
@@ -5,12 +5,19 @@ import PropTypes from 'prop-types';
 import './CardList.scss';
 
 const CardList = ({
+  alignItems,
   className,
   children,
   ...props
 }) => (
   <div
-    className={classNames('CardList', className)}
+    className={classNames(
+      'CardList',
+      className,
+      {
+        [`CardList__alignItems--${alignItems}`]: !!alignItems,
+      },
+      )}
     {...props}
   >
     {children}
@@ -18,10 +25,12 @@ const CardList = ({
   );
 
 CardList.propTypes = {
+  alignItems: PropTypes.oneOf(['center', 'flex-start', 'flex-end']),
   className: PropTypes.string,
 };
 
 CardList.defaultProps = {
+  alignItems: 'center',
   className: undefined,
 };
 

--- a/src/CardList/CardList.mdx
+++ b/src/CardList/CardList.mdx
@@ -6,7 +6,7 @@ import CardList from './CardList';
 ##
 
 <h4>
-	A simple container for positioning Cards.
+	A simple layout container for positioning Cards.
 </h4>
 
 <Canvas>
@@ -14,11 +14,8 @@ import CardList from './CardList';
 </Canvas>
 
 ### When to use 
-- Use `CardList` to wrap around `Card` components.
-
-### When to not use
-- Reason 1
-- Reason 2
+- Use `CardList` to wrap one or more `Card` components.
+- `CardList` centers `Card` components by default and should handle the most common page layouts that use `Card`.
 
 ## Props
 
@@ -34,21 +31,5 @@ import CardList from './CardList';
 
 ## Formatting
 
-### States
-
-### Anatomy 
-
-### Sizing
-
 ### Alignment
-
-
-## Best practices
-
-### General
-
-### Behavior
-
-### Implementation
-
-### UX Copy
+- `Card`s within `CardList` are centered by default

--- a/src/CardList/CardList.mdx
+++ b/src/CardList/CardList.mdx
@@ -1,0 +1,54 @@
+import { ArgsTable, Story, Canvas } from '@storybook/addon-docs/blocks';
+import CardList from './CardList';
+
+# CardList
+
+##
+
+<h4>
+	A simple container for positioning Cards.
+</h4>
+
+<Canvas>
+  <Story id="components-cardlist--default" />
+</Canvas>
+
+### When to use 
+- Use `CardList` to wrap around `Card` components.
+
+### When to not use
+- Reason 1
+- Reason 2
+
+## Props
+
+<ArgsTable of={CardList} />
+
+## Stories
+
+### Default 
+
+<Canvas>
+  <Story id="components-cardlist--default" />
+</Canvas>
+
+## Formatting
+
+### States
+
+### Anatomy 
+
+### Sizing
+
+### Alignment
+
+
+## Best practices
+
+### General
+
+### Behavior
+
+### Implementation
+
+### UX Copy

--- a/src/CardList/CardList.scss
+++ b/src/CardList/CardList.scss
@@ -1,11 +1,16 @@
 @import '../../scss/theme';
 
+$card-list-spacing: 1.5rem;
+$card-list-child-card-spacing: 0.75rem;
+
 .CardList {
   display: flex;
   flex-direction: column;
   align-items: center;
 
+  margin: $card-list-spacing 0;
+  
   .Card {
-    margin: 1.5rem;
+    margin: $card-list-child-card-spacing;
   }
 }

--- a/src/CardList/CardList.scss
+++ b/src/CardList/CardList.scss
@@ -1,0 +1,11 @@
+@import '../../scss/theme';
+
+.CardList {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .Card {
+    margin: 1.5rem;
+  }
+}

--- a/src/CardList/CardList.scss
+++ b/src/CardList/CardList.scss
@@ -6,11 +6,24 @@ $card-list-child-card-spacing: 0.75rem;
 .CardList {
   display: flex;
   flex-direction: column;
-  align-items: center;
 
   margin: $card-list-spacing 0;
   
   .Card {
     margin: $card-list-child-card-spacing;
+  }
+
+  &__alignItems {
+    &--center {
+      align-items: center;
+    }
+
+    &--flex-start {
+      align-items: flex-start;
+    }
+
+    &--flex-end {
+      align-items: flex-end;
+    }
   }
 }

--- a/src/CardList/CardList.stories.jsx
+++ b/src/CardList/CardList.stories.jsx
@@ -2,10 +2,12 @@ import React from 'react';
 
 import Card, { CardSizes } from 'src/Card';
 import CardList from 'src/CardList';
+import { withKnobs, select } from '@storybook/addon-knobs';
 import mdx from './CardList.mdx';
 
 export default {
   title: 'Components/CardList',
+  decorators: [withKnobs],
   component: CardList,
   parameters: {
     docs: {
@@ -18,7 +20,7 @@ export const Default = () => (
   <>
     <CardList>
       <Card
-        size={CardSizes.SMALL}
+        size={select('Card Size', Object.values(CardSizes), CardSizes.SMALL)}
         subTitle="The fastest way to recruit research participants.
         Source from a pool of more than 850,000 participants to reach nearly any target audience."
         title="Card 1"
@@ -30,7 +32,7 @@ export const Default = () => (
         </ul>
       </Card>
       <Card
-        size={CardSizes.SMALL}
+        size={select('Card Size', Object.values(CardSizes), CardSizes.SMALL)}
         subTitle="The fastest way to recruit research participants.
         Source from a pool of more than 850,000 participants to reach nearly any target audience."
         title="Card 2"
@@ -42,7 +44,7 @@ export const Default = () => (
         </ul>
       </Card>
       <Card
-        size={CardSizes.SMALL}
+        size={select('Card Size', Object.values(CardSizes), CardSizes.SMALL)}
         subTitle="The fastest way to recruit research participants.
         Source from a pool of more than 850,000 participants to reach nearly any target audience."
         title="Card 3"

--- a/src/CardList/CardList.stories.jsx
+++ b/src/CardList/CardList.stories.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import Card, { CardSizes } from 'src/Card';
+import CardList from 'src/CardList';
+import mdx from './CardList.mdx';
+
+export default {
+  title: 'Components/CardList',
+  component: CardList,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+};
+
+export const Default = () => (
+  <>
+    <CardList>
+      <Card
+        size={CardSizes.SMALL}
+        subTitle="The fastest way to recruit research participants.
+        Source from a pool of more than 850,000 participants to reach nearly any target audience."
+        title="Card 1"
+      >
+        <ul>
+          <li>500,000+ sessions completed</li>
+          <li>$19 million+ incentives distributed</li>
+          <li>3 hours median time to 1st matched participant</li>
+        </ul>
+      </Card>
+      <Card
+        size={CardSizes.SMALL}
+        subTitle="The fastest way to recruit research participants.
+        Source from a pool of more than 850,000 participants to reach nearly any target audience."
+        title="Card 2"
+      >
+        <ul>
+          <li>500,000+ sessions completed</li>
+          <li>$19 million+ incentives distributed</li>
+          <li>3 hours median time to 1st matched participant</li>
+        </ul>
+      </Card>
+      <Card
+        size={CardSizes.SMALL}
+        subTitle="The fastest way to recruit research participants.
+        Source from a pool of more than 850,000 participants to reach nearly any target audience."
+        title="Card 3"
+      >
+        <ul>
+          <li>500,000+ sessions completed</li>
+          <li>$19 million+ incentives distributed</li>
+          <li>3 hours median time to 1st matched participant</li>
+        </ul>
+      </Card>
+    </CardList>
+  </>
+);

--- a/src/CardList/CardList.stories.jsx
+++ b/src/CardList/CardList.stories.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import Card, { CardSizes } from 'src/Card';
-import CardList from 'src/CardList';
+import CardList, { CardListAlignItemsOptions } from 'src/CardList';
 import { withKnobs, select } from '@storybook/addon-knobs';
 import mdx from './CardList.mdx';
 
@@ -16,47 +16,43 @@ export default {
   },
 };
 
-const CardListAlignItemsOptions = ['center', 'flex-start', 'flex-end'];
-
 export const Default = () => (
-  <>
-    <CardList alignItems={select('alignItems', CardListAlignItemsOptions, 'center')}>
-      <Card
-        size={select('Card Size', Object.values(CardSizes), CardSizes.SMALL)}
-        subTitle="The fastest way to recruit research participants.
-        Source from a pool of more than 850,000 participants to reach nearly any target audience."
-        title="Card 1"
-      >
-        <ul>
-          <li>500,000+ sessions completed</li>
-          <li>$19 million+ incentives distributed</li>
-          <li>3 hours median time to 1st matched participant</li>
-        </ul>
-      </Card>
-      <Card
-        size={select('Card Size', Object.values(CardSizes), CardSizes.SMALL)}
-        subTitle="The fastest way to recruit research participants.
-        Source from a pool of more than 850,000 participants to reach nearly any target audience."
-        title="Card 2"
-      >
-        <ul>
-          <li>500,000+ sessions completed</li>
-          <li>$19 million+ incentives distributed</li>
-          <li>3 hours median time to 1st matched participant</li>
-        </ul>
-      </Card>
-      <Card
-        size={select('Card Size', Object.values(CardSizes), CardSizes.SMALL)}
-        subTitle="The fastest way to recruit research participants.
-        Source from a pool of more than 850,000 participants to reach nearly any target audience."
-        title="Card 3"
-      >
-        <ul>
-          <li>500,000+ sessions completed</li>
-          <li>$19 million+ incentives distributed</li>
-          <li>3 hours median time to 1st matched participant</li>
-        </ul>
-      </Card>
-    </CardList>
-  </>
+  <CardList alignItems={select('alignItems', CardListAlignItemsOptions, 'center')}>
+    <Card
+      size={select('Card Size', Object.values(CardSizes), CardSizes.SMALL)}
+      subTitle="The fastest way to recruit research participants.
+      Source from a pool of more than 850,000 participants to reach nearly any target audience."
+      title="Card 1"
+    >
+      <ul>
+        <li>500,000+ sessions completed</li>
+        <li>$19 million+ incentives distributed</li>
+        <li>3 hours median time to 1st matched participant</li>
+      </ul>
+    </Card>
+    <Card
+      size={select('Card Size', Object.values(CardSizes), CardSizes.SMALL)}
+      subTitle="The fastest way to recruit research participants.
+      Source from a pool of more than 850,000 participants to reach nearly any target audience."
+      title="Card 2"
+    >
+      <ul>
+        <li>500,000+ sessions completed</li>
+        <li>$19 million+ incentives distributed</li>
+        <li>3 hours median time to 1st matched participant</li>
+      </ul>
+    </Card>
+    <Card
+      size={select('Card Size', Object.values(CardSizes), CardSizes.SMALL)}
+      subTitle="The fastest way to recruit research participants.
+      Source from a pool of more than 850,000 participants to reach nearly any target audience."
+      title="Card 3"
+    >
+      <ul>
+        <li>500,000+ sessions completed</li>
+        <li>$19 million+ incentives distributed</li>
+        <li>3 hours median time to 1st matched participant</li>
+      </ul>
+    </Card>
+  </CardList>
 );

--- a/src/CardList/CardList.stories.jsx
+++ b/src/CardList/CardList.stories.jsx
@@ -16,9 +16,11 @@ export default {
   },
 };
 
+const CardListAlignItemsOptions = ['center', 'flex-start', 'flex-end'];
+
 export const Default = () => (
   <>
-    <CardList>
+    <CardList alignItems={select('alignItems', CardListAlignItemsOptions, 'center')}>
       <Card
         size={select('Card Size', Object.values(CardSizes), CardSizes.SMALL)}
         subTitle="The fastest way to recruit research participants.

--- a/src/CardList/index.js
+++ b/src/CardList/index.js
@@ -1,0 +1,3 @@
+import CardList from './CardList';
+
+export default CardList;

--- a/src/CardList/index.js
+++ b/src/CardList/index.js
@@ -1,3 +1,3 @@
-import CardList from './CardList';
+import CardList, { CardListAlignItemsOptions } from './CardList';
 
-export default CardList;
+export { CardList as default, CardListAlignItemsOptions };

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import { Alert, MessageTypes } from 'src/Alert';
 import Button from 'src/Button';
 import Avatar from 'src/Avatar';
 import Card, { CardSizes } from 'src/Card';
+import CardList from 'src/CardList';
 import CheckboxButton, { CHECKED_STATES } from 'src/CheckboxButton';
 import CheckboxButtonGroup from 'src/CheckboxButtonGroup';
 import { ORIENTATIONS as BUTTON_GROUP_ORIENTATIONS } from 'src/ControlButtonGroup';
@@ -74,6 +75,7 @@ export {
   Button,
   BUTTON_GROUP_ORIENTATIONS,
   Card,
+  CardList,
   CardSizes,
   CheckboxButton,
   CheckboxButtonGroup,


### PR DESCRIPTION
closes #566 

Note: Comment out `margin: $card-spacing auto;` in `src/Card/Card.scss` before viewing.

We're opting to create a layout component `CardList` as an alternative to bringing in `Grid` from MUI. This should be simpler and solve for what we're wanting the accomplish: eventually removing `margin` and centering responsibilities from `Card` . 

This should hopefully handle most cases where we use the DS `Card` as they're just stacked on top of each other and centered. 

![Screen Shot 2022-03-10 at 3 39 43 PM](https://user-images.githubusercontent.com/37383785/157773862-9ea775ba-651b-428d-a24f-7323f5500ab2.png)


What it would look like on RS:

![Screen Shot 2022-03-10 at 3 40 18 PM](https://user-images.githubusercontent.com/37383785/157773836-ed8939dd-9302-4d4a-af18-03ded0cc911f.png)

