### PR TITLE
update Pill color and border

### DIFF
--- a/cypress/integration/pill_spec.js
+++ b/cypress/integration/pill_spec.js
@@ -4,6 +4,10 @@ const pills = [
     path: 'components-pill--default',
   },
   {
+    name: 'With Container',
+    path: 'components-pill--with-container',
+  },
+  {
     name: 'With Leading Icon',
     path: 'components-pill--with-leading-icon',
   },

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -6131,6 +6131,109 @@ exports[`Storyshots Components/Pill With Close 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Pill With Container 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="Pills"
+  >
+    <span
+      className="Pill Pill--gray"
+    >
+      <svg
+        aria-hidden="true"
+        className="svg-inline--fa fa-microphone fa-w-11 Pill__icon--lead"
+        data-icon="microphone"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        style={Object {}}
+        viewBox="0 0 352 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M176 352c53.02 0 96-42.98 96-96V96c0-53.02-42.98-96-96-96S80 42.98 80 96v160c0 53.02 42.98 96 96 96zm160-160h-16c-8.84 0-16 7.16-16 16v48c0 74.8-64.49 134.82-140.79 127.38C96.71 376.89 48 317.11 48 250.3V208c0-8.84-7.16-16-16-16H16c-8.84 0-16 7.16-16 16v40.16c0 89.64 63.97 169.55 152 181.69V464H96c-8.84 0-16 7.16-16 16v16c0 8.84 7.16 16 16 16h160c8.84 0 16-7.16 16-16v-16c0-8.84-7.16-16-16-16h-56v-33.77C285.71 418.47 352 344.9 352 256v-48c0-8.84-7.16-16-16-16z"
+          fill="currentColor"
+          style={Object {}}
+        />
+      </svg>
+      1-on-1 Interview
+    </span>
+    <span
+      className="Pill Pill--gray"
+    >
+      <svg
+        aria-hidden="true"
+        className="svg-inline--fa fa-globe fa-w-16 Pill__icon--lead"
+        data-icon="globe"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        style={Object {}}
+        viewBox="0 0 496 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M336.5 160C322 70.7 287.8 8 248 8s-74 62.7-88.5 152h177zM152 256c0 22.2 1.2 43.5 3.3 64h185.3c2.1-20.5 3.3-41.8 3.3-64s-1.2-43.5-3.3-64H155.3c-2.1 20.5-3.3 41.8-3.3 64zm324.7-96c-28.6-67.9-86.5-120.4-158-141.6 24.4 33.8 41.2 84.7 50 141.6h108zM177.2 18.4C105.8 39.6 47.8 92.1 19.3 160h108c8.7-56.9 25.5-107.8 49.9-141.6zM487.4 192H372.7c2.1 21 3.3 42.5 3.3 64s-1.2 43-3.3 64h114.6c5.5-20.5 8.6-41.8 8.6-64s-3.1-43.5-8.5-64zM120 256c0-21.5 1.2-43 3.3-64H8.6C3.2 212.5 0 233.8 0 256s3.2 43.5 8.6 64h114.6c-2-21-3.2-42.5-3.2-64zm39.5 96c14.5 89.3 48.7 152 88.5 152s74-62.7 88.5-152h-177zm159.3 141.6c71.4-21.2 129.4-73.7 158-141.6h-108c-8.8 56.9-25.6 107.8-50 141.6zM19.3 352c28.6 67.9 86.5 120.4 158 141.6-24.4-33.8-41.2-84.7-50-141.6h-108z"
+          fill="currentColor"
+          style={Object {}}
+        />
+      </svg>
+      Online
+    </span>
+    <span
+      className="Pill Pill--gray"
+    >
+      <svg
+        aria-hidden="true"
+        className="svg-inline--fa fa-gift-card fa-w-18 Pill__icon--lead"
+        data-icon="gift-card"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        style={Object {}}
+        viewBox="0 0 576 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M528 128h-58.07c6.22-12.06 10.07-25.52 10.07-40 0-48.52-39.48-88-88-88-41.6 0-68.51 21.34-103.04 68.33C254.44 21.33 227.53 0 185.93 0c-48.52 0-88 39.48-88 88 0 14.48 3.85 27.94 10.07 40H48c-26.51 0-48 21.49-48 48v288c0 26.51 21.49 48 48 48h480c26.51 0 48-21.49 48-48V176c0-26.51-21.49-48-48-48zM392 48c22.06 0 40 17.94 40 40 0 22.05-17.94 40-40 40h-86.07c51.36-76.47 65.72-80 86.07-80zM145.93 88c0-22.06 17.94-40 40-40 19.94 0 34.58 3.27 86.07 80h-86.07c-22.06 0-40-17.95-40-40zm60.13 104l-35.72 35.72c-6.25 6.25-6.25 16.38 0 22.63l11.31 11.31c6.25 6.25 16.38 6.25 22.63 0L273.94 192h28.13l69.65 69.65c6.25 6.25 16.38 6.25 22.63 0l11.31-11.31c6.25-6.25 6.25-16.38 0-22.63L369.94 192H512v128H64V192h142.06zM64 448v-64h448v64H64z"
+          fill="currentColor"
+          style={Object {}}
+        />
+      </svg>
+      $120 choice of dozens of digital gift cards
+    </span>
+    <span
+      className="Pill Pill--gray"
+    >
+      <svg
+        aria-hidden="true"
+        className="svg-inline--fa fa-clock fa-w-16 Pill__icon--lead"
+        data-icon="clock"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        style={Object {}}
+        viewBox="0 0 512 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M256,8C119,8,8,119,8,256S119,504,256,504,504,393,504,256,393,8,256,8Zm92.49,313h0l-20,25a16,16,0,0,1-22.49,2.5h0l-67-49.72a40,40,0,0,1-15-31.23V112a16,16,0,0,1,16-16h32a16,16,0,0,1,16,16V256l58,42.5A16,16,0,0,1,348.49,321Z"
+          fill="currentColor"
+          style={Object {}}
+        />
+      </svg>
+      1 hour
+    </span>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Components/Pill With Leading Icon 1`] = `
 <div
   style={

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -6101,7 +6101,7 @@ exports[`Storyshots Components/Pill With Close 1`] = `
   }
 >
   <span
-    className="Pill Pill--blue"
+    className="Pill Pill--blue Pill--closeable"
   >
     Text
     <button

--- a/src/Pill/Pill.jsx
+++ b/src/Pill/Pill.jsx
@@ -23,7 +23,10 @@ const Pill = ({
     className={
         classNames(
           'Pill',
-          { [`Pill--${color}`]: !!color },
+          {
+            [`Pill--${color}`]: !!color,
+            [`Pill--closeable`]: !!onClose,
+          },
         )
       }
     {...props}

--- a/src/Pill/Pill.mdx
+++ b/src/Pill/Pill.mdx
@@ -37,6 +37,13 @@ import Pill from './Pill';
   <Story id="components-pill--default" />
 </Canvas>
 
+### With Container
+- The `Pills` container should be used when a collection of `Pill` components are displayed
+
+<Canvas>
+  <Story id="components-pill--with-container" />
+</Canvas>
+
 ### With Leading Icon
 - Import an icon that is most relevant to the text
 

--- a/src/Pill/Pill.scss
+++ b/src/Pill/Pill.scss
@@ -21,10 +21,16 @@
     .Pill__button--close {
       background-color: unset; 
       border: none;
-      color: $ux-blue-300;
+      color: $ux-blue-500;
       margin-left: $ux-spacing-20;
       margin-right: 0;
       padding: 0;
+    }
+
+    &.Pill--closeable {
+      &:hover {
+        background-color: $ux-blue-200;
+      }
     }
   }
 
@@ -45,6 +51,12 @@
       margin-right: 0;
       padding: 0;
     }
+
+    &.Pill--closeable {
+      &:hover {
+        background-color: $ux-orange-200;
+      }
+    }
   }
 
   &--green {
@@ -59,10 +71,16 @@
     .Pill__button--close {
       background-color: unset; 
       border: none;
-      color: $ux-green-500;
+      color: $ux-green-600;
       margin-left: $ux-spacing-20;
       margin-right: 0;
       padding: 0;
+    }
+
+    &.Pill--closeable {
+      &:hover {
+        background-color: $ux-green-200;
+      }
     }
   }
 
@@ -83,6 +101,12 @@
       margin-right: 0;
       padding: 0;
     }
+
+    &.Pill--closeable {
+      &:hover {
+        background-color: $ux-yellow-200;
+      }
+    }
   }
 
   &--gray {
@@ -90,6 +114,7 @@
     color: $ux-gray-800;
 
     .Pill__icon--lead {
+      color: $ux-gray-800;
       margin-right: $ux-spacing-10;
     }
 
@@ -100,6 +125,12 @@
       margin-left: $ux-spacing-20;
       margin-right: 0;
       padding: 0;
+    }
+
+    &.Pill--closeable {
+      &:hover {
+        background-color: $ux-gray-400;
+      }
     }
   }
 
@@ -119,6 +150,12 @@
       margin-left: $ux-spacing-20;
       margin-right: 0;
       padding: 0;
+    }
+
+    &.Pill--closeable {
+      &:hover {
+        background-color: $ux-gray-300;
+      }
     }
   }
 }

--- a/src/Pill/Pill.scss
+++ b/src/Pill/Pill.scss
@@ -6,14 +6,12 @@
   display: inline;
   background-color: $ux-blue-100;
   color: $ux-blue-700;
-  border: 0.06rem solid $ux-blue-300;
   border-radius: $ux-border-radius;
   padding: $ux-spacing-10 $ux-spacing-30;
 
   &--blue {
     background-color: $ux-blue-100;
     color: $ux-blue-700;
-    border: 0.06rem solid $ux-blue-300;
 
     .Pill__icon--lead {
       color: $ux-blue;
@@ -33,7 +31,6 @@
   &--orange {
     background-color: $ux-orange-100;
     color: $ux-orange-900;
-    border: 0.06rem solid $ux-orange-400;
 
     .Pill__icon--lead {
       color: $ux-orange-700;
@@ -51,9 +48,8 @@
   }
 
   &--green {
-    background-color: $ux-green-200;
+    background-color: $ux-green-100;
     color: $ux-green-800;
-    border: 0.06rem solid $ux-green-400;
 
     .Pill__icon--lead {
       color: $ux-green-600;
@@ -73,7 +69,6 @@
   &--yellow {
     background-color: $ux-yellow-100;
     color: $ux-yellow-900;
-    border: 0.06rem solid $ux-yellow-600;
 
     .Pill__icon--lead {
       color: $ux-yellow-700;
@@ -93,7 +88,6 @@
   &--gray {
     background-color: $ux-gray-300;
     color: $ux-gray-800;
-    border: 0.06rem solid $ux-gray-400;
 
     .Pill__icon--lead {
       margin-right: $ux-spacing-10;
@@ -112,7 +106,6 @@
   &--silver {
     background-color: $ux-gray-200;
     color: $ux-gray-800;
-    border: 0.06rem solid $ux-gray-400;
 
     .Pill__icon--lead {
       color: $ux-gray-700;

--- a/src/Pill/Pill.scss
+++ b/src/Pill/Pill.scss
@@ -8,6 +8,7 @@
   color: $ux-blue-700;
   border-radius: $ux-border-radius;
   padding: $ux-spacing-10 $ux-spacing-30;
+  white-space: nowrap;
 
   &--blue {
     background-color: $ux-blue-100;

--- a/src/Pill/Pill.stories.jsx
+++ b/src/Pill/Pill.stories.jsx
@@ -5,9 +5,11 @@ import {
   text,
   select,
 } from '@storybook/addon-knobs';
-import { faUsers } from '@fortawesome/pro-solid-svg-icons';
+import {
+ faClock, faGiftCard, faGlobe, faMicrophone, faUsers,
+} from '@fortawesome/pro-solid-svg-icons';
 
-import { Pill, PILL_COLORS } from 'src/Pill';
+import { Pill, Pills, PILL_COLORS } from 'src/Pill';
 import mdx from './Pill.mdx';
 
 export default {
@@ -66,6 +68,35 @@ export const Default = () => (
       silver
     </Pill>
   </div>
+);
+
+export const WithContainer = () => (
+  <Pills>
+    <Pill
+      color={PILL_COLORS.GRAY}
+      icon={faMicrophone}
+    >
+      1-on-1 Interview
+    </Pill>
+    <Pill
+      color={PILL_COLORS.GRAY}
+      icon={faGlobe}
+    >
+      Online
+    </Pill>
+    <Pill
+      color={PILL_COLORS.GRAY}
+      icon={faGiftCard}
+    >
+      $120 choice of dozens of digital gift cards
+    </Pill>
+    <Pill
+      color={PILL_COLORS.GRAY}
+      icon={faClock}
+    >
+      1 hour
+    </Pill>
+  </Pills>
 );
 
 export const WithLeadingIcon = () => (

--- a/src/Pill/Pills.jsx
+++ b/src/Pill/Pills.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import './Pills.scss';
+
+const Pills = ({
+  children,
+  className,
+  ...props
+}) => (
+  <div
+    className={classNames('Pills', className)}
+    {...props}
+  >
+    {children}
+  </div>
+);
+
+Pills.propTypes = {
+  className: PropTypes.string,
+};
+
+Pills.defaultProps = {
+  className: undefined,
+};
+
+export default Pills;

--- a/src/Pill/Pills.scss
+++ b/src/Pill/Pills.scss
@@ -1,0 +1,13 @@
+@import '../../scss/theme';
+
+$pills-spacing: 0.25rem;
+
+.Pills {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+
+  .Pill {
+    margin: $pills-spacing;
+  }
+}

--- a/src/Pill/index.js
+++ b/src/Pill/index.js
@@ -1,6 +1,8 @@
 import Pill, { PILL_COLORS } from './Pill';
+import Pills from './Pills';
 
 export {
   Pill,
+  Pills,
   PILL_COLORS,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ import {
   ModalFooter,
   ModalHeader,
 } from 'src/Modal';
-import { Pill, PILL_COLORS } from 'src/Pill';
+import { Pill, Pills, PILL_COLORS } from 'src/Pill';
 import Popper from 'src/Popper';
 import ProfileCell from 'src/ProfileCell';
 import RadioButton from 'src/RadioButton';
@@ -102,6 +102,7 @@ export {
   ModalHeader,
   Option,
   Pill,
+  Pills,
   PILL_COLORS,
   Popper,
   ProfileCell,


### PR DESCRIPTION
closes #561 

https://www.figma.com/file/471iS3QrpPtXZpS1xbsJ20/Components?node-id=2000%3A1155

- Removes Pill border and updates colors
- Change bg color on closeable Pills
- add white-space: nowrap to Pill
- add Pills layout container

![Screen Shot 2022-03-14 at 10 08 19 AM](https://user-images.githubusercontent.com/37383785/158224266-90c814b1-b427-40ac-b207-5503c97ffb0e.png)
![Screen Shot 2022-03-14 at 10 08 44 AM](https://user-images.githubusercontent.com/37383785/158224289-2a3ef9f2-8c39-44f4-b2c8-1729f6c923c6.png)

