### PR TITLE
add brand variants to Button

### DIFF
--- a/cypress/integration/button_spec.js
+++ b/cypress/integration/button_spec.js
@@ -23,6 +23,12 @@ const buttons = [
     class: '.Button',
     match: 'Skip',
   },
+  {
+    name: 'Brands',
+    path: 'components-button--brands',
+    class: '.Button',
+    match: 'Google',
+  },
 ];
 
 describe('Button', () => {

--- a/scss/buttons.scss
+++ b/scss/buttons.scss
@@ -254,3 +254,131 @@ $warning: $ux-yellow-400;
   }
 }
 
+@mixin btn-brand-google {
+  $btn-brand-google-background: $brand-color-google-alt;
+  $btn-brand-google-border: $brand-color-google-alt;
+  $btn-brand-google-color: $ux-white;
+  
+  $btn-brand-google-hover-background: #2069cf;
+  $btn-brand-google-hover-border: #2069cf;
+  $btn-brand-google-hover-color: $ux-white;
+  
+  $btn-brand-google-active-background: #2069cf;
+  $btn-brand-google-active-border: #2069cf;
+  $btn-brand-google-active-color: $ux-white;
+
+  @include button-variant(
+    $btn-brand-google-background, 
+    $btn-brand-google-border,
+    $btn-brand-google-color,
+    
+    $btn-brand-google-hover-background,
+    $btn-brand-google-hover-border,
+    $btn-brand-google-hover-color,
+    
+    $btn-brand-google-active-background,
+    $btn-brand-google-active-border,
+    $btn-brand-google-active-color,
+  );
+
+  &:disabled {
+    color: $ux-white;
+  }
+}
+
+@mixin btn-brand-facebook {
+  $btn-brand-facebook-background: $brand-color-facebook;
+  $btn-brand-facebook-border: $brand-color-facebook;
+  $btn-brand-facebook-color: $ux-white;
+  
+  $btn-brand-facebook-hover-background: darken($brand-color-facebook, 5%);
+  $btn-brand-facebook-hover-border: darken($brand-color-facebook, 5%);
+  $btn-brand-facebook-hover-color: $ux-white;
+  
+  $btn-brand-facebook-active-background: darken($brand-color-facebook, 5%);
+  $btn-brand-facebook-active-border: darken($brand-color-facebook, 5%);
+  $btn-brand-facebook-active-color: $ux-white;
+
+  @include button-variant(
+    $btn-brand-facebook-background, 
+    $btn-brand-facebook-border,
+    $btn-brand-facebook-color,
+    
+    $btn-brand-facebook-hover-background,
+    $btn-brand-facebook-hover-border,
+    $btn-brand-facebook-hover-color,
+    
+    $btn-brand-facebook-active-background,
+    $btn-brand-facebook-active-border,
+    $btn-brand-facebook-active-color,
+  );
+
+  &:disabled {
+    color: $ux-white;
+  }
+}
+
+  @mixin btn-brand-linkedin {
+    $btn-brand-linkedin-background: $brand-color-linkedin;
+    $btn-brand-linkedin-border: $brand-color-linkedin;
+    $btn-brand-linkedin-color: $ux-white;
+    
+    $btn-brand-linkedin-hover-background: darken($brand-color-linkedin, 5%);
+    $btn-brand-linkedin-hover-border: darken($brand-color-linkedin, 5%);
+    $btn-brand-linkedin-hover-color: $ux-white;
+    
+    $btn-brand-linkedin-active-background: darken($brand-color-linkedin, 5%);
+    $btn-brand-linkedin-active-border: darken($brand-color-linkedin, 5%);
+    $btn-brand-linkedin-active-color: $ux-white;
+  
+    @include button-variant(
+      $btn-brand-linkedin-background, 
+      $btn-brand-linkedin-border,
+      $btn-brand-linkedin-color,
+      
+      $btn-brand-linkedin-hover-background,
+      $btn-brand-linkedin-hover-border,
+      $btn-brand-linkedin-hover-color,
+      
+      $btn-brand-linkedin-active-background,
+      $btn-brand-linkedin-active-border,
+      $btn-brand-linkedin-active-color,
+    );
+  
+    &:disabled {
+      color: $ux-white;
+    }
+  }
+
+  @mixin btn-brand-twitter {
+    $btn-brand-twitter-background: $brand-color-twitter;
+    $btn-brand-twitter-border: $brand-color-twitter;
+    $btn-brand-twitter-color: $ux-white;
+    
+    $btn-brand-twitter-hover-background: darken($brand-color-twitter, 5%);
+    $btn-brand-twitter-hover-border: darken($brand-color-twitter, 5%);
+    $btn-brand-twitter-hover-color: $ux-white;
+    
+    $btn-brand-twitter-active-background: darken($brand-color-twitter, 5%);
+    $btn-brand-twitter-active-border: darken($brand-color-twitter, 5%);
+    $btn-brand-twitter-active-color: $ux-white;
+  
+    @include button-variant(
+      $btn-brand-twitter-background, 
+      $btn-brand-twitter-border,
+      $btn-brand-twitter-color,
+      
+      $btn-brand-twitter-hover-background,
+      $btn-brand-twitter-hover-border,
+      $btn-brand-twitter-hover-color,
+      
+      $btn-brand-twitter-active-background,
+      $btn-brand-twitter-active-border,
+      $btn-brand-twitter-active-color,
+    );
+  
+    &:disabled {
+      color: $ux-white;
+    }
+  }
+

--- a/scss/colors/palette.scss
+++ b/scss/colors/palette.scss
@@ -17,7 +17,7 @@ $ux-teal: #0E4749;
 $ux-yellow: #F3CE14;
 $ux-white: #FFFFFF;
 
-$brand-color-facebook: #4C67A1;
+$brand-color-facebook: #3577ea;
 $brand-color-google: #DB3236;
 $brand-color-google-alt: #2D8CFF;
 $brand-color-linkedin: #0077B5;

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -1654,6 +1654,435 @@ exports[`Storyshots Components/Avatar With Image 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Button Brands 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <button
+    className="Button btn btn-brand-google btn-sm"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-google fa-w-16 icon-left"
+      data-icon="google"
+      data-prefix="fab"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 488 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M488 261.8C488 403.3 391.1 504 248 504 110.8 504 0 393.2 0 256S110.8 8 248 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9C258.5 52.6 94.3 116.6 94.3 256c0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9H248v-85.3h236.1c2.3 12.7 3.9 24.9 3.9 41.4z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Google
+  </button>
+   
+  <button
+    className="Button btn btn-brand-google btn-sm"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-google fa-w-16 icon-left"
+      data-icon="google"
+      data-prefix="fab"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 488 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M488 261.8C488 403.3 391.1 504 248 504 110.8 504 0 393.2 0 256S110.8 8 248 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9C258.5 52.6 94.3 116.6 94.3 256c0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9H248v-85.3h236.1c2.3 12.7 3.9 24.9 3.9 41.4z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Google
+  </button>
+   
+  <button
+    className="Button btn btn-brand-google btn-md"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-google fa-w-16 icon-left"
+      data-icon="google"
+      data-prefix="fab"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 488 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M488 261.8C488 403.3 391.1 504 248 504 110.8 504 0 393.2 0 256S110.8 8 248 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9C258.5 52.6 94.3 116.6 94.3 256c0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9H248v-85.3h236.1c2.3 12.7 3.9 24.9 3.9 41.4z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Google
+  </button>
+   
+  <button
+    className="Button btn btn-brand-google btn-md"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-google fa-w-16 icon-left"
+      data-icon="google"
+      data-prefix="fab"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 488 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M488 261.8C488 403.3 391.1 504 248 504 110.8 504 0 393.2 0 256S110.8 8 248 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9C258.5 52.6 94.3 116.6 94.3 256c0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9H248v-85.3h236.1c2.3 12.7 3.9 24.9 3.9 41.4z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Google
+  </button>
+  <div
+    style={
+      Object {
+        "margin": ".5rem",
+      }
+    }
+  />
+  <button
+    className="Button btn btn-brand-facebook btn-sm"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-facebook fa-w-16 icon-left"
+      data-icon="facebook"
+      data-prefix="fab"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M504 256C504 119 393 8 256 8S8 119 8 256c0 123.78 90.69 226.38 209.25 245V327.69h-63V256h63v-54.64c0-62.15 37-96.48 93.67-96.48 27.14 0 55.52 4.84 55.52 4.84v61h-31.28c-30.8 0-40.41 19.12-40.41 38.73V256h68.78l-11 71.69h-57.78V501C413.31 482.38 504 379.78 504 256z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Facebook
+  </button>
+   
+  <button
+    className="Button btn btn-brand-facebook btn-sm"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-facebook fa-w-16 icon-left"
+      data-icon="facebook"
+      data-prefix="fab"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M504 256C504 119 393 8 256 8S8 119 8 256c0 123.78 90.69 226.38 209.25 245V327.69h-63V256h63v-54.64c0-62.15 37-96.48 93.67-96.48 27.14 0 55.52 4.84 55.52 4.84v61h-31.28c-30.8 0-40.41 19.12-40.41 38.73V256h68.78l-11 71.69h-57.78V501C413.31 482.38 504 379.78 504 256z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Facebook
+  </button>
+   
+  <button
+    className="Button btn btn-brand-facebook btn-md"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-facebook fa-w-16 icon-left"
+      data-icon="facebook"
+      data-prefix="fab"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M504 256C504 119 393 8 256 8S8 119 8 256c0 123.78 90.69 226.38 209.25 245V327.69h-63V256h63v-54.64c0-62.15 37-96.48 93.67-96.48 27.14 0 55.52 4.84 55.52 4.84v61h-31.28c-30.8 0-40.41 19.12-40.41 38.73V256h68.78l-11 71.69h-57.78V501C413.31 482.38 504 379.78 504 256z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Facebook
+  </button>
+   
+  <button
+    className="Button btn btn-brand-facebook btn-md"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-facebook fa-w-16 icon-left"
+      data-icon="facebook"
+      data-prefix="fab"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M504 256C504 119 393 8 256 8S8 119 8 256c0 123.78 90.69 226.38 209.25 245V327.69h-63V256h63v-54.64c0-62.15 37-96.48 93.67-96.48 27.14 0 55.52 4.84 55.52 4.84v61h-31.28c-30.8 0-40.41 19.12-40.41 38.73V256h68.78l-11 71.69h-57.78V501C413.31 482.38 504 379.78 504 256z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Facebook
+  </button>
+   
+  <div
+    style={
+      Object {
+        "margin": ".5rem",
+      }
+    }
+  />
+  <button
+    className="Button btn btn-brand-linkedin btn-sm"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-linkedin fa-w-14 icon-left"
+      data-icon="linkedin"
+      data-prefix="fab"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 448 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    LinkedIn
+  </button>
+   
+  <button
+    className="Button btn btn-brand-linkedin btn-sm"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-linkedin fa-w-14 icon-left"
+      data-icon="linkedin"
+      data-prefix="fab"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 448 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    LinkedIn
+  </button>
+   
+  <button
+    className="Button btn btn-brand-linkedin btn-md"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-linkedin fa-w-14 icon-left"
+      data-icon="linkedin"
+      data-prefix="fab"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 448 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    LinkedIn
+  </button>
+   
+  <button
+    className="Button btn btn-brand-linkedin btn-md"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-linkedin fa-w-14 icon-left"
+      data-icon="linkedin"
+      data-prefix="fab"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 448 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    LinkedIn
+  </button>
+  <div
+    style={
+      Object {
+        "margin": ".5rem",
+      }
+    }
+  />
+  <button
+    className="Button btn btn-brand-twitter btn-sm"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-twitter fa-w-16 icon-left"
+      data-icon="twitter"
+      data-prefix="fab"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Twitter
+  </button>
+   
+  <button
+    className="Button btn btn-brand-twitter btn-sm"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-twitter fa-w-16 icon-left"
+      data-icon="twitter"
+      data-prefix="fab"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Twitter
+  </button>
+   
+  <button
+    className="Button btn btn-brand-twitter btn-md"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-twitter fa-w-16 icon-left"
+      data-icon="twitter"
+      data-prefix="fab"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Twitter
+  </button>
+   
+  <button
+    className="Button btn btn-brand-twitter btn-md"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-twitter fa-w-16 icon-left"
+      data-icon="twitter"
+      data-prefix="fab"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Twitter
+  </button>
+</div>
+`;
+
 exports[`Storyshots Components/Button Danger 1`] = `
 <div
   style={

--- a/src/Button/Button.mdx
+++ b/src/Button/Button.mdx
@@ -80,3 +80,10 @@ import { ArgsTable, Story, Canvas } from '@storybook/addon-docs/blocks';
   <Story id="components-button--transparent" />
 </Preview>
 
+### Brands
+- Usually used for authentication purposes with different brands
+
+<Preview>
+  <Story id="components-button--brands" />
+</Preview>
+

--- a/src/Button/Button.scss
+++ b/src/Button/Button.scss
@@ -48,4 +48,20 @@
   &.btn-outline-transparent {
     @include btn-outline-transparent;
   }
+
+  &.btn-brand-google {
+    @include btn-brand-google;
+  }
+
+  &.btn-brand-facebook {
+    @include btn-brand-facebook;
+  }
+
+  &.btn-brand-linkedin {
+    @include btn-brand-linkedin;
+  }
+
+  &.btn-brand-twitter {
+    @include btn-brand-twitter;
+  }
 }

--- a/src/Button/Buttons.stories.jsx
+++ b/src/Button/Buttons.stories.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 
 import Button from 'src/Button';
 import { faFileAlt, faCaretDown } from '@fortawesome/pro-regular-svg-icons';
+import {
+ faGoogle, faFacebook, faLinkedin, faTwitter,
+} from '@fortawesome/free-brands-svg-icons';
 import mdx from './Button.mdx';
 
 export default {
@@ -250,6 +253,147 @@ export const Transparent = () => (
       variant="transparent"
     >
       Skip
+    </Button>
+  </>
+);
+
+export const Brands = () => (
+  <>
+    <Button
+      leadingIcon={faGoogle}
+      size="sm"
+      variant="brand-google"
+    >
+      Google
+    </Button>
+    {' '}
+    <Button
+      disabled
+      leadingIcon={faGoogle}
+      size="sm"
+      variant="brand-google"
+    >
+      Google
+    </Button>
+    {' '}
+    <Button
+      leadingIcon={faGoogle}
+      size="md"
+      variant="brand-google"
+    >
+      Google
+    </Button>
+    {' '}
+    <Button
+      disabled
+      leadingIcon={faGoogle}
+      size="md"
+      variant="brand-google"
+    >
+      Google
+    </Button>
+    <div style={{ margin: '.5rem' }} />
+    <Button
+      leadingIcon={faFacebook}
+      size="sm"
+      variant="brand-facebook"
+    >
+      Facebook
+    </Button>
+    {' '}
+    <Button
+      disabled
+      leadingIcon={faFacebook}
+      size="sm"
+      variant="brand-facebook"
+    >
+      Facebook
+    </Button>
+    {' '}
+    <Button
+      leadingIcon={faFacebook}
+      size="md"
+      variant="brand-facebook"
+    >
+      Facebook
+    </Button>
+    {' '}
+    <Button
+      disabled
+      leadingIcon={faFacebook}
+      size="md"
+      variant="brand-facebook"
+    >
+      Facebook
+    </Button>
+    {' '}
+    <div style={{ margin: '.5rem' }} />
+    <Button
+      leadingIcon={faLinkedin}
+      size="sm"
+      variant="brand-linkedin"
+    >
+      LinkedIn
+    </Button>
+    {' '}
+    <Button
+      disabled
+      leadingIcon={faLinkedin}
+      size="sm"
+      variant="brand-linkedin"
+    >
+      LinkedIn
+    </Button>
+    {' '}
+    <Button
+      leadingIcon={faLinkedin}
+      size="md"
+      variant="brand-linkedin"
+    >
+      LinkedIn
+    </Button>
+    {' '}
+    <Button
+      disabled
+      leadingIcon={faLinkedin}
+      size="md"
+      variant="brand-linkedin"
+    >
+      LinkedIn
+    </Button>
+    <div style={{ margin: '.5rem' }} />
+    <Button
+      leadingIcon={faTwitter}
+      size="sm"
+      variant="brand-twitter"
+    >
+      Twitter
+    </Button>
+    {' '}
+    <Button
+      disabled
+      leadingIcon={faTwitter}
+      size="sm"
+      variant="brand-twitter"
+    >
+      Twitter
+    </Button>
+    {' '}
+    <Button
+      leadingIcon={faTwitter}
+      size="md"
+      variant="brand-twitter"
+    >
+      Twitter
+    </Button>
+    {' '}
+    <Button
+      disabled
+      leadingIcon={faTwitter}
+      size="md"
+      variant="brand-twitter"
+    >
+      Twitter
     </Button>
   </>
 );


### PR DESCRIPTION
closes #592 

While working on transitioning the TrackedButton to use the DS Button, I found the need for adding variants for the different brands that we use primarily for authentication. One example is the `OauthButton`. 

Lmk if we have any others that we might be missing!

![Screen Shot 2022-04-20 at 12 00 37 PM](https://user-images.githubusercontent.com/37383785/164303670-6230ca0d-9996-4926-b162-774c1f5e6fe2.png)

