### PR TITLE
removing TrackedButton from export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,6 @@ import {
   withToastPropTypes,
 } from 'src/Toast';
 import Tooltip from 'src/Tooltip';
-import TrackedButton from 'src/TrackedButton';
 
 export {
   Alert,
@@ -125,7 +124,6 @@ export {
   TableSortLabel,
   Toast,
   Tooltip,
-  TrackedButton,
   useToast,
   ValueContainer,
   withToast,


### PR DESCRIPTION
closes #599 

Removing `TrackedButton` from DS exports. It's still used in `CopyToClipboardButton` but have some questions about its use in there (might need to rework it a bit). But for now, will just make sure we are only using `TrackedButton` from `common/analytics` on rails-server.