### PR TITLE
handle setting title prop on Toast

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -18117,6 +18117,33 @@ exports[`Storyshots Components/Toast Toast 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Toast Toast Custom Message 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="Toast"
+  />
+  <div>
+    <p>
+      Click the button to see a toast message.  Use the knobs to try different types!
+    </p>
+    <button
+      className="Button btn btn-primary"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Components/Toast Toast With Action 1`] = `
 <div
   style={

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -50,16 +50,16 @@ exports[`Storyshots Components/Alert Announcement 1`] = `
     <div
       className="Alert__content"
     >
-      <p
+      <div
         className="Alert__title"
       >
         Announcement title
-      </p>
-      <p
+      </div>
+      <div
         className="Alert__message"
       >
         Announcement message
-      </p>
+      </div>
     </div>
   </div>
 </div>
@@ -115,16 +115,16 @@ exports[`Storyshots Components/Alert Error 1`] = `
     <div
       className="Alert__content"
     >
-      <p
+      <div
         className="Alert__title"
       >
         Error title
-      </p>
-      <p
+      </div>
+      <div
         className="Alert__message"
       >
         Error message
-      </p>
+      </div>
     </div>
   </div>
 </div>
@@ -216,16 +216,16 @@ exports[`Storyshots Components/Alert Info 1`] = `
     <div
       className="Alert__content"
     >
-      <p
+      <div
         className="Alert__title"
       >
         Info title
-      </p>
-      <p
+      </div>
+      <div
         className="Alert__message"
       >
         Info message
-      </p>
+      </div>
     </div>
   </div>
 </div>
@@ -317,16 +317,16 @@ exports[`Storyshots Components/Alert Success 1`] = `
     <div
       className="Alert__content"
     >
-      <p
+      <div
         className="Alert__title"
       >
         Success title
-      </p>
-      <p
+      </div>
+      <div
         className="Alert__message"
       >
         Success message
-      </p>
+      </div>
     </div>
   </div>
 </div>
@@ -382,16 +382,16 @@ exports[`Storyshots Components/Alert Warning 1`] = `
     <div
       className="Alert__content"
     >
-      <p
+      <div
         className="Alert__title"
       >
         Warning title
-      </p>
-      <p
+      </div>
+      <div
         className="Alert__message"
       >
         Warning message
-      </p>
+      </div>
     </div>
   </div>
 </div>
@@ -486,16 +486,16 @@ exports[`Storyshots Components/Alert With Call To Action 1`] = `
     <div
       className="Alert__content"
     >
-      <p
+      <div
         className="Alert__title"
       >
         Success title
-      </p>
-      <p
+      </div>
+      <div
         className="Alert__message"
       >
         Success message
-      </p>
+      </div>
     </div>
     <div
       className="Alert__action"
@@ -615,16 +615,16 @@ exports[`Storyshots Components/Alert With Call To Action 1`] = `
     <div
       className="Alert__content"
     >
-      <p
+      <div
         className="Alert__title"
       >
         Info title
-      </p>
-      <p
+      </div>
+      <div
         className="Alert__message"
       >
         Info message
-      </p>
+      </div>
     </div>
     <div
       className="Alert__action"
@@ -708,16 +708,16 @@ exports[`Storyshots Components/Alert With Call To Action 1`] = `
     <div
       className="Alert__content"
     >
-      <p
+      <div
         className="Alert__title"
       >
         Announcement title
-      </p>
-      <p
+      </div>
+      <div
         className="Alert__message"
       >
         Announcement message
-      </p>
+      </div>
     </div>
     <div
       className="Alert__action"
@@ -801,16 +801,16 @@ exports[`Storyshots Components/Alert With Call To Action 1`] = `
     <div
       className="Alert__content"
     >
-      <p
+      <div
         className="Alert__title"
       >
         Error title
-      </p>
-      <p
+      </div>
+      <div
         className="Alert__message"
       >
         Error message
-      </p>
+      </div>
     </div>
     <div
       className="Alert__action"
@@ -894,16 +894,16 @@ exports[`Storyshots Components/Alert With Call To Action 1`] = `
     <div
       className="Alert__content"
     >
-      <p
+      <div
         className="Alert__title"
       >
         Warning title
-      </p>
-      <p
+      </div>
+      <div
         className="Alert__message"
       >
         Warning message
-      </p>
+      </div>
     </div>
     <div
       className="Alert__action"
@@ -994,12 +994,12 @@ exports[`Storyshots Components/Alert With Call To Action 1`] = `
     <div
       className="Alert__content"
     >
-      <p
+      <div
         className="Alert__title"
       >
         Connect to Google Calendar to create reminders automatically
-      </p>
-      <p
+      </div>
+      <div
         className="Alert__message"
       >
         <div>
@@ -1046,7 +1046,7 @@ exports[`Storyshots Components/Alert With Call To Action 1`] = `
           </svg>
           Connect Google Calendar
         </button>
-      </p>
+      </div>
     </div>
     <div
       className="Alert__close"
@@ -1126,17 +1126,17 @@ exports[`Storyshots Components/Alert With Call To Action 1`] = `
     <div
       className="Alert__content"
     >
-      <p
+      <div
         className="Alert__title"
       >
         Connect to Google Calendar to create reminders automatically
-      </p>
-      <p
+      </div>
+      <div
         className="Alert__message"
       >
         When you confirm a session we’ll automatically
       add an event and reminders to your Google Calendar.
-      </p>
+      </div>
     </div>
     <div
       className="Alert__action"
@@ -1301,16 +1301,16 @@ exports[`Storyshots Components/Alert With Dismiss 1`] = `
     <div
       className="Alert__content"
     >
-      <p
+      <div
         className="Alert__title"
       >
         Default title
-      </p>
-      <p
+      </div>
+      <div
         className="Alert__message"
       >
         Default message
-      </p>
+      </div>
     </div>
     <div
       className="Alert__close"

--- a/src/Alert/Alert.jsx
+++ b/src/Alert/Alert.jsx
@@ -80,12 +80,12 @@ function Alert(props) {
       <div className="Alert__content">
         {
           props.title && (
-            <p className="Alert__title">
+            <div className="Alert__title">
               {props.title}
-            </p>
+            </div>
           )
         }
-        <p className="Alert__message">{props.message}</p>
+        <div className="Alert__message">{props.message}</div>
       </div>
       {
         props.action && (

--- a/src/Toast/Toast.stories.jsx
+++ b/src/Toast/Toast.stories.jsx
@@ -14,11 +14,11 @@ export default {
 };
 
 const DummyComponent = ({
- action, type, message, setToastMessage,
+ action, type, message, title, setToastMessage,
 }) => (
   <div>
     <p>Click the button to see a toast message.  Use the knobs to try different types!</p>
-    <Button variant="primary" onClick={() => setToastMessage(type, message, action)}>Submit</Button>
+    <Button variant="primary" onClick={() => setToastMessage(type, message, action, title)}>Submit</Button>
   </div>
   );
 DummyComponent.propTypes = withToastPropTypes;
@@ -27,6 +27,19 @@ const ToastDummyComponent = withToast(DummyComponent);
 export const Toast = () => (
   <ToastDummyComponent
     message={text('Message', 'Your action was a success!')}
+    title={text('Title', 'Title')}
+    type={radios('Message Type', MessageTypes, MessageTypes.SUCCESS)}
+  />
+);
+
+export const ToastCustomMessage = () => (
+  <ToastDummyComponent
+    message={(
+      <>
+        <strong>[Some strong text]</strong> and additional text that is wrapped in a fragment.
+      </>
+    )}
+    title={text('Title', 'Normal string title')}
     type={radios('Message Type', MessageTypes, MessageTypes.SUCCESS)}
   />
 );
@@ -36,6 +49,7 @@ const ManualDismissToastComponent = withToast(DummyComponent, { autoDismiss: fal
 export const ManualDismissToast = () => (
   <ManualDismissToastComponent
     message={text('Message', 'Your action was a success!')}
+    title={text('Title', 'Title')}
     type={radios('Message Type', MessageTypes, MessageTypes.SUCCESS)}
   />
 );
@@ -44,6 +58,7 @@ export const ToastWithAction = () => (
   <ManualDismissToastComponent
     action={{ content: 'Primary action', url: 'https://www.userinterviews.com/' }}
     message={text('Message', 'Your action was a success!')}
+    title={text('Title', 'Title')}
     type={radios('Message Type', MessageTypes, MessageTypes.SUCCESS)}
   />
 );

--- a/src/Toast/__snapshots__/withToast.test.jsx.snap
+++ b/src/Toast/__snapshots__/withToast.test.jsx.snap
@@ -80,11 +80,11 @@ Array [
     <div
       className="Alert__content"
     >
-      <p
+      <div
         className="Alert__message"
       >
         This is just a test...
-      </p>
+      </div>
     </div>
     <div
       className="Alert__close"

--- a/src/Toast/useToast.js
+++ b/src/Toast/useToast.js
@@ -1,11 +1,12 @@
 import { useCallback, useReducer } from 'react';
 import { v4 as generateUUID } from 'uuid';
 
-const createMessage = (messageType, messageText, messageAction) => ({
+const createMessage = (messageType, messageText, messageAction, messageTitle) => ({
   id: generateUUID(),
   message: messageText,
   type: messageType,
   action: messageAction,
+  title: messageTitle,
 });
 
 const ACTIONS = {
@@ -19,7 +20,12 @@ const messagesReducer = (state, { type, payload }) => {
     case ACTIONS.SET_MESSAGE:
       return [
         ...state,
-        createMessage(payload.messageAction, payload.messageType, payload.messageText),
+        createMessage(
+          payload.messageAction,
+          payload.messageType,
+          payload.messageText,
+          payload.messageTitle,
+        ),
       ];
     case ACTIONS.CLEAR_MESSAGES:
       return [];
@@ -37,8 +43,13 @@ const useToast = (initialMessages = []) => {
     dispatch({ type: ACTIONS.CLEAR_MESSAGES });
   }, []);
 
-  const setMessage = useCallback((messageAction, messageType, messageText) => {
-    dispatch({ type: ACTIONS.SET_MESSAGE, payload: { messageAction, messageType, messageText } });
+  const setMessage = useCallback((messageAction, messageType, messageText, messageTitle) => {
+    dispatch({
+ type: ACTIONS.SET_MESSAGE,
+payload: {
+ messageAction, messageType, messageText, messageTitle,
+},
+});
   }, []);
 
   const dismissMessage = useCallback((messageId) => {


### PR DESCRIPTION
closes #606 

We previously weren't able to explicitly set the `title` prop for a `Toast` and often devs were finding it difficult to get this set properly (and sometimes were diverging from our defined styles). Hopefully adding this will make it easier. 

Something as simple as creating this:

![image](https://user-images.githubusercontent.com/37383785/166594415-f89b0cb0-7cd7-4f4a-9c6d-d7c86e8f7ce9.png)

Also, changed the `<p>` tags into `<div>` on the `Alert` component which should fix some of the issues explained here: https://userinterviews.slack.com/archives/CJYUKSM5M/p1650942546277709

Also just noticing now this margin override was made in `app/javascript/researcher/email_themes/builder/builder.jsx` and would have to be removed since the Alert message would change from a `<p>` to a `<div>`.

```
<Alert
  message={(
    <div style={{marginTop: '-1rem'}}>
      Please note that this preview is approximate.
      Make sure you test this theme with your preferred email client.
      For more tips about styling emails, you can check out our&nbsp;
      <a href={Routes.email_theme_support_path()}>support page.</a>
    </div>
  )}
  type={MessageTypes.INFO}
/>
```