### PR TITLE
fix styles on Select to allow for tabbing and proper focus

### DIFF
--- a/src/Select/styles.js
+++ b/src/Select/styles.js
@@ -86,17 +86,12 @@ const defaultStyles = ({ size }) => ({
       fontWeight: fontWeights.light,
     }),
     option: (styles, {
-      data,
       isDisabled,
-      isFocused,
       isSelected,
-    }) => {
-      const colors = data.colors || {};
-
-      return {
+    }) => ({
         ...styles,
-        backgroundColor: isSelected || isFocused ? colors.hover : styles.backgroundColor,
-        color: colors.text,
+        backgroundColor: isSelected ? systemColors.UX_BLUE_200 : styles.backgroundColor,
+        color: systemColors.UX_BLACK,
         fontWeight: fontWeights.light,
         fontSize: '0.875rem',
         cursor: 'pointer',
@@ -109,10 +104,9 @@ const defaultStyles = ({ size }) => ({
 
         ':hover': {
           ...styles[':hover'],
-          backgroundColor: colors.hover || systemColors.UX_BLUE_100,
+          backgroundColor: isSelected ? systemColors.UX_BLUE_200 : systemColors.UX_BLUE_100,
         },
-      };
-    },
+      }),
 });
 
 const defaultTheme = (theme) => ({


### PR DESCRIPTION
closes #614 

I think some parts of the custom `styles.js` for `option` was breaking the ability to tab through options and focus on them on our Select components. You should be able to tab through and the screen reader should be able to read through them all.

https://user-images.githubusercontent.com/37383785/168151426-e4cbffef-4f42-4519-a584-31c6c828bcb4.mov


