### PR TITLE
allow setting id on InputLabel

### DIFF
--- a/src/InputLabel/InputLabel.jsx
+++ b/src/InputLabel/InputLabel.jsx
@@ -6,19 +6,26 @@ import Tooltip from 'src/Tooltip';
 
 import 'scss/forms/input_label.scss';
 
-export default function InputLabel(props) {
-  return (
-    <label
-      className={classNames('InputLabel', props.className)}
-      htmlFor={props.labelHtmlFor}
-    >
-      {props.text}
-      {props.required && <span className="InputLabel__helper-text">&nbsp;(Required)</span>}
-      {props.labelHelperText && <span className="InputLabel__helper-text">&nbsp;({props.labelHelperText})</span>}
-      {props.tooltipText && <Tooltip iconClasses="Tooltip__icon--gray" placement="right" text={props.tooltipText} />}
-    </label>
+const InputLabel = ({
+  className,
+  labelHtmlFor,
+  text,
+  required,
+  labelHelperText,
+  tooltipText,
+  ...props
+}) => (
+  <label
+    className={classNames('InputLabel', className)}
+    htmlFor={labelHtmlFor}
+    {...props}
+  >
+    {text}
+    {required && <span className="InputLabel__helper-text">&nbsp;(Required)</span>}
+    {labelHelperText && <span className="InputLabel__helper-text">&nbsp;({labelHelperText})</span>}
+    {tooltipText && <Tooltip iconClasses="Tooltip__icon--gray" placement="right" text={tooltipText} />}
+  </label>
   );
-}
 
 InputLabel.propTypes = {
   className: PropTypes.string,
@@ -36,3 +43,5 @@ InputLabel.defaultProps = {
   required: false,
   tooltipText: undefined,
 };
+
+export default InputLabel;


### PR DESCRIPTION
closes #620 

I was running into an issue with setting an `id` on an InputLabel and realized that wasn't possible since we didn't spread props on the component.

Mostly doing this in rare cases where you're using `InputLabel` by itself and some input element and need to set the `id` on it if another element is using `aria-labelledby` and needs it.

For context, working on `PhoneNumber` component which attempts to set id on `InputLabel` and causes some sad a11y error. Tested adding `id` in screenshot below for CountryCode to confirm. Sorry it's a bit hard to read.

![Screen Shot 2022-05-17 at 1 39 15 PM](https://user-images.githubusercontent.com/37383785/168906194-55e056dc-a3f1-4417-912b-aa3ab484a94e.png)


