### PR TITLE
update FormGroup and InputLabel to support fieldset and legend

### DIFF
--- a/scss/forms/input_label.scss
+++ b/scss/forms/input_label.scss
@@ -1,7 +1,7 @@
 @import '../colors';
 @import '../typography';
 
-.InputLabel {
+.InputLabel, .InputLegend {
   @include font-type-30--bold;
   display: flex;
   flex-wrap: wrap;

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -4005,12 +4005,12 @@ exports[`Storyshots Components/Form Elements/CheckboxButtonGroup Bordered Row 1`
     id="with-checkbox-button-group-2"
   >
     <legend
-      className="InputLabel"
+      className="InputLegend"
       htmlFor="checkbox-button-group"
     >
-      Label
+      Legend
       <span
-        className="InputLabel__helper-text"
+        className="InputLegend__helper-text"
       >
          (
         helper text
@@ -4093,12 +4093,12 @@ exports[`Storyshots Components/Form Elements/CheckboxButtonGroup Default 1`] = `
     id="with-checkbox-button-group"
   >
     <legend
-      className="InputLabel"
+      className="InputLegend"
       htmlFor="checkbox-button-group"
     >
-      Label
+      Legend
       <span
-        className="InputLabel__helper-text"
+        className="InputLegend__helper-text"
       >
          (
         use the knobs to try out different variations
@@ -4181,12 +4181,12 @@ exports[`Storyshots Components/Form Elements/CheckboxButtonGroup Default Row 1`]
     id="with-checkbox-button-group-1"
   >
     <legend
-      className="InputLabel"
+      className="InputLegend"
       htmlFor="checkbox-button-group"
     >
-      Label
+      Legend
       <span
-        className="InputLabel__helper-text"
+        className="InputLegend__helper-text"
       >
          (
         helper text
@@ -4269,12 +4269,12 @@ exports[`Storyshots Components/Form Elements/CheckboxButtonGroup Description 1`]
     id="with-checkbox-button-group-3"
   >
     <legend
-      className="InputLabel"
+      className="InputLegend"
       htmlFor="checkbox-button-group"
     >
-      Label
+      Legend
       <span
-        className="InputLabel__helper-text"
+        className="InputLegend__helper-text"
       >
          (
         helper text
@@ -4393,12 +4393,12 @@ exports[`Storyshots Components/Form Elements/CheckboxButtonGroup Description Row
     id="with-checkbox-button-group-4"
   >
     <legend
-      className="InputLabel"
+      className="InputLegend"
       htmlFor="checkbox-button-group"
     >
-      Label
+      Legend
       <span
-        className="InputLabel__helper-text"
+        className="InputLegend__helper-text"
       >
          (
         helper text
@@ -5030,12 +5030,12 @@ exports[`Storyshots Components/Form Elements/Form Group With Radio Button Group 
     id="with-radio-button-group"
   >
     <legend
-      className="InputLabel"
+      className="InputLegend"
       htmlFor="radio-button-group"
     >
       Form Group with radio button group
       <span
-        className="InputLabel__helper-text"
+        className="InputLegend__helper-text"
       >
          (
         with some helper text
@@ -5322,12 +5322,12 @@ exports[`Storyshots Components/Form Elements/RadioButtonGroup Bordered Row 1`] =
     id="with-radio-button-group-3"
   >
     <legend
-      className="InputLabel"
+      className="InputLegend"
       htmlFor="radio-button-group"
     >
-      Label
+      Legend
       <span
-        className="InputLabel__helper-text"
+        className="InputLegend__helper-text"
       >
          (
         helper text
@@ -5416,12 +5416,12 @@ exports[`Storyshots Components/Form Elements/RadioButtonGroup Default 1`] = `
     id="with-radio-button-group"
   >
     <legend
-      className="InputLabel"
+      className="InputLegend"
       htmlFor="radio-button-group"
     >
-      Label
+      Legend
       <span
-        className="InputLabel__helper-text"
+        className="InputLegend__helper-text"
       >
          (
         use the knobs to try out different variations
@@ -5510,12 +5510,12 @@ exports[`Storyshots Components/Form Elements/RadioButtonGroup Default Row 1`] = 
     id="with-radio-button-group-2"
   >
     <legend
-      className="InputLabel"
+      className="InputLegend"
       htmlFor="radio-button-group"
     >
-      Label
+      Legend
       <span
-        className="InputLabel__helper-text"
+        className="InputLegend__helper-text"
       >
          (
         helper text
@@ -5604,12 +5604,12 @@ exports[`Storyshots Components/Form Elements/RadioButtonGroup Description 1`] = 
     id="with-radio-button-group-4"
   >
     <legend
-      className="InputLabel"
+      className="InputLegend"
       htmlFor="radio-button-group"
     >
-      Label
+      Legend
       <span
-        className="InputLabel__helper-text"
+        className="InputLegend__helper-text"
       >
          (
         helper text
@@ -5734,12 +5734,12 @@ exports[`Storyshots Components/Form Elements/RadioButtonGroup Description Row 1`
     id="with-radio-button-group-5"
   >
     <legend
-      className="InputLabel"
+      className="InputLegend"
       htmlFor="radio-button-group"
     >
-      Label
+      Legend
       <span
-        className="InputLabel__helper-text"
+        className="InputLegend__helper-text"
       >
          (
         helper text

--- a/src/CheckboxButtonGroup/CheckboxButtonGroup.stories.jsx
+++ b/src/CheckboxButtonGroup/CheckboxButtonGroup.stories.jsx
@@ -25,10 +25,10 @@ const CheckboxButtonGroupComponent = ({
   bordered,
   children,
   defaultValue,
+  elementType,
   fullWidth,
   id,
   inline,
-  inputType,
   label,
   labelHelperText,
   orientation,
@@ -39,9 +39,9 @@ const CheckboxButtonGroupComponent = ({
   return (
     <FormGroup
       bordered={bordered}
+      elementType={elementType}
       id={id}
       inline={inline}
-      inputType={inputType}
       label={label}
       labelHelperText={labelHelperText}
       labelHtmlFor={labelHtmlFor}
@@ -72,10 +72,10 @@ export const Default = () => {
     <CheckboxButtonGroupComponent
       bordered={boolean('Bordered Form Group', false)}
       defaultValue={[]}
+      elementType="fieldset"
       fullWidth={boolean('Full width', false)}
       id="with-checkbox-button-group"
-      inputType="checkbox"
-      label="Label"
+      label="Legend"
       labelHelperText="use the knobs to try out different variations"
       labelHtmlFor="checkbox-button-group"
       orientation={orientation}
@@ -109,11 +109,11 @@ export const DefaultRow = () => (
   <CheckboxButtonGroupComponent
     bordered={false}
     defaultValue={[]}
+    elementType="fieldset"
     fullWidth={false}
     id="with-checkbox-button-group-1"
     inline
-    inputType="checkbox"
-    label="Label"
+    label="Legend"
     labelHelperText="helper text"
     labelHtmlFor="checkbox-button-group"
     orientation={ORIENTATIONS.ROW}
@@ -146,10 +146,10 @@ export const BorderedRow = () => (
   <CheckboxButtonGroupComponent
     bordered={false}
     defaultValue={[]}
+    elementType="fieldset"
     fullWidth={false}
     id="with-checkbox-button-group-2"
-    inputType="checkbox"
-    label="Label"
+    label="Legend"
     labelHelperText="helper text"
     labelHtmlFor="checkbox-button-group"
     orientation={ORIENTATIONS.ROW}
@@ -182,10 +182,10 @@ export const Description = () => (
   <CheckboxButtonGroupComponent
     bordered={false}
     defaultValue={[]}
+    elementType="fieldset"
     fullWidth
     id="with-checkbox-button-group-3"
-    inputType="checkbox"
-    label="Label"
+    label="Legend"
     labelHelperText="helper text"
     labelHtmlFor="checkbox-button-group"
     orientation={ORIENTATIONS.COLUMN}
@@ -227,10 +227,10 @@ export const DescriptionRow = () => (
   <CheckboxButtonGroupComponent
     bordered={false}
     defaultValue={[]}
+    elementType="fieldset"
     fullWidth
     id="with-checkbox-button-group-4"
-    inputType="checkbox"
-    label="Label"
+    label="Legend"
     labelHelperText="helper text"
     labelHtmlFor="checkbox-button-group"
     orientation={ORIENTATIONS.ROW}

--- a/src/FormGroup/FormGroup.jsx
+++ b/src/FormGroup/FormGroup.jsx
@@ -1,12 +1,16 @@
-import React from 'react';
+import React, { createElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import InputLabel from 'src/InputLabel';
+import InputLegend from 'src/InputLegend';
 
 import 'scss/forms/form_group.scss';
 
-const FORM_GROUP_INPUT_TYPES = ['input', 'radio', 'checkbox'];
+// For accessibility purposes, FormGroups with radio or checkbox groups
+// should be rendered as a <fieldset> element.
+// All other FormGroups will be rendered as a normal <div> by default.
+const FORM_GROUP_ELEMENT_TYPES = ['div', 'fieldset'];
 
 function renderErrors(errors) {
   if (typeof errors === 'string') {
@@ -40,49 +44,27 @@ export default function FormGroup(props) {
   const errorMessage = buildErrorMessage(errors[inputKey], props.label);
   const hasErrors = errorMessage && errorMessage.length > 0;
 
-  const isCheckboxOrRadioInputType = props.inputType === 'radio' || props.inputType === 'checkbox';
-
-  // For accessibility purposes, FormGroups with radio or checkbox groups
-  // will be rendered as a <fieldset>
-  const renderFieldset = () => (
-    <fieldset
-      className={classNames(
-        'FormGroup',
-        props.className, {
-          'FormGroup--is-invalid': hasErrors,
-          'FormGroup--bordered': props.bordered,
-          'FormGroup--inline': props.inline,
-        },
-      )}
-      id={props.id}
-    >
-      {formGroupChildren}
-    </fieldset>
-  );
-
-  // All other FormGroups will be rendered in a normal div
-  const renderDiv = () => (
-    <div
-      className={classNames(
-        'FormGroup',
-        props.className, {
-          'FormGroup--is-invalid': hasErrors,
-          'FormGroup--bordered': props.bordered,
-          'FormGroup--inline': props.inline,
-        },
-      )}
-      id={props.id}
-    >
-      {formGroupChildren}
-    </div>
-  );
+  const isElementTypeFieldset = props.elementType === 'fieldset';
+  const isElementTypeDiv = props.elementType === 'div';
 
   const formGroupChildren = (
     <>
-      {props.label && (
+      {isElementTypeFieldset && props.label && (
+        <InputLegend
+          className={props.labelClassName}
+          elementType={props.elementType}
+          labelHelperText={props.labelHelperText}
+          labelHtmlFor={props.labelHtmlFor}
+          required={props.required}
+          text={props.label}
+          tooltipText={props.labelTooltip}
+        />
+      )}
+
+      {isElementTypeDiv && props.label && (
         <InputLabel
           className={props.labelClassName}
-          elementType={props.inputType}
+          elementType={props.elementType}
           labelHelperText={props.labelHelperText}
           labelHtmlFor={props.labelHtmlFor}
           required={props.required}
@@ -112,10 +94,21 @@ export default function FormGroup(props) {
     </>
   );
 
-  if (isCheckboxOrRadioInputType) {
-    return renderFieldset();
-  }
-    return renderDiv();
+  return createElement(
+    props.elementType,
+     {
+       className: classNames(
+         'FormGroup',
+         props.className, {
+           'FormGroup--is-invalid': hasErrors,
+           'FormGroup--bordered': props.bordered,
+           'FormGroup--inline': props.inline,
+         },
+       ),
+       id: props.id,
+     },
+     formGroupChildren,
+   );
 }
 
 FormGroup.propTypes = {
@@ -123,12 +116,12 @@ FormGroup.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   displayErrorText: PropTypes.bool,
+  elementType: PropTypes.oneOf(FORM_GROUP_ELEMENT_TYPES),
   errors: PropTypes.object,
   helperText: PropTypes.string,
   id: PropTypes.string.isRequired,
   inline: PropTypes.bool,
   inputKey: PropTypes.string,
-  inputType: PropTypes.oneOf(FORM_GROUP_INPUT_TYPES),
   label: PropTypes.string,
   labelClassName: PropTypes.string,
   labelHelperText: PropTypes.string,
@@ -142,11 +135,11 @@ FormGroup.defaultProps = {
   children: undefined,
   className: '',
   displayErrorText: true,
+  elementType: 'div',
   errors: {},
   helperText: undefined,
   inline: false,
   inputKey: null,
-  inputType: undefined,
   label: '',
   labelClassName: '',
   labelHelperText: undefined,

--- a/src/FormGroup/FormGroup.stories.jsx
+++ b/src/FormGroup/FormGroup.stories.jsx
@@ -183,7 +183,7 @@ const ButtonGroupComponent = ({
   bordered,
   children,
   defaultValue,
-  inputType,
+  elementType,
   fullWidth,
   id,
   label,
@@ -197,8 +197,8 @@ const ButtonGroupComponent = ({
   return (
     <FormGroup
       bordered={bordered}
+      elementType={elementType}
       id={id}
-      inputType={inputType}
       label={label}
       labelHelperText={labelHelperText}
       labelHtmlFor={labelHtmlFor}
@@ -233,9 +233,9 @@ export const WithRadioButtonGroup = () => {
       bordered={boolean('Bordered Form Group', true)}
       ButtonGroup={RadioButtonGroup}
       defaultValue="1"
+      elementType="fieldset"
       fullWidth={boolean('Full width', false)}
       id="with-radio-button-group"
-      inputType="radio"
       label="Form Group with radio button group"
       labelHelperText="with some helper text"
       labelHtmlFor="radio-button-group"

--- a/src/InputLabel/InputLabel.scss
+++ b/src/InputLabel/InputLabel.scss
@@ -1,5 +1,0 @@
-legend {
-  // Ensure <legend> does not default to width: 100% 
-  // when creating inline FormGroup
-  width: unset;
-}

--- a/src/InputLegend/InputLegend.jsx
+++ b/src/InputLegend/InputLegend.jsx
@@ -4,9 +4,10 @@ import classNames from 'classnames';
 
 import Tooltip from 'src/Tooltip';
 
+import './InputLegend.scss';
 import 'scss/forms/input_label.scss';
 
-const InputLabel = ({
+const InputLegend = ({
   className,
   elementType,
   labelHtmlFor,
@@ -16,27 +17,27 @@ const InputLabel = ({
   tooltipText,
   ...props
 }) => {
-  const inputLabelChildren = (
+  const inputLegendChildren = (
     <>
       {text}
-      {required && <span className="InputLabel__helper-text">&nbsp;(Required)</span>}
-      {labelHelperText && <span className="InputLabel__helper-text">&nbsp;({labelHelperText})</span>}
+      {required && <span className="InputLegend__helper-text">&nbsp;(Required)</span>}
+      {labelHelperText && <span className="InputLegend__helper-text">&nbsp;({labelHelperText})</span>}
       {tooltipText && <Tooltip iconClasses="Tooltip__icon--gray" placement="right" text={tooltipText} />}
     </>
   );
 
   return (
-    <label
-      className={classNames('InputLabel', className)}
+    <legend
+      className={classNames('InputLegend', className)}
       htmlFor={labelHtmlFor}
       {...props}
     >
-      {inputLabelChildren}
-    </label>
+      {inputLegendChildren}
+    </legend>
   );
 };
 
-InputLabel.propTypes = {
+InputLegend.propTypes = {
   className: PropTypes.string,
   elementType: PropTypes.string,
   labelHelperText: PropTypes.string,
@@ -46,7 +47,7 @@ InputLabel.propTypes = {
   tooltipText: PropTypes.string,
 };
 
-InputLabel.defaultProps = {
+InputLegend.defaultProps = {
   className: '',
   elementType: undefined,
   labelHelperText: undefined,
@@ -55,4 +56,4 @@ InputLabel.defaultProps = {
   tooltipText: undefined,
 };
 
-export default InputLabel;
+export default InputLegend;

--- a/src/InputLegend/InputLegend.scss
+++ b/src/InputLegend/InputLegend.scss
@@ -1,0 +1,6 @@
+.InputLegend {
+    // Ensure <legend> does not default to width: 100% 
+    // when creating inline FormGroup
+    width: unset;
+    margin-right: 0.75rem;
+}

--- a/src/InputLegend/index.js
+++ b/src/InputLegend/index.js
@@ -1,0 +1,1 @@
+export { default } from './InputLegend';

--- a/src/RadioButtonGroup/RadioButtonGroup.stories.jsx
+++ b/src/RadioButtonGroup/RadioButtonGroup.stories.jsx
@@ -25,9 +25,9 @@ const RadioButtonGroupComponent = ({
   bordered,
   children,
   defaultValue,
+  elementType,
   fullWidth,
   id,
-  inputType,
   inline,
   label,
   labelHelperText,
@@ -39,9 +39,9 @@ const RadioButtonGroupComponent = ({
   return (
     <FormGroup
       bordered={bordered}
+      elementType={elementType}
       id={id}
       inline={inline}
-      inputType={inputType}
       label={label}
       labelHelperText={labelHelperText}
       labelHtmlFor={labelHtmlFor}
@@ -72,10 +72,10 @@ export const Default = () => {
     <RadioButtonGroupComponent
       bordered={boolean('Bordered Form Group', false)}
       defaultValue={null}
+      elementType="fieldset"
       fullWidth={boolean('Full width', false)}
       id="with-radio-button-group"
-      inputType="radio"
-      label="Label"
+      label="Legend"
       labelHelperText="use the knobs to try out different variations"
       labelHtmlFor="radio-button-group"
       orientation={orientation}
@@ -109,11 +109,11 @@ export const DefaultRow = () => (
   <RadioButtonGroupComponent
     bordered={false}
     defaultValue={null}
+    elementType="fieldset"
     fullWidth={false}
     id="with-radio-button-group-2"
     inline
-    inputType="radio"
-    label="Label"
+    label="Legend"
     labelHelperText="helper text"
     labelHtmlFor="radio-button-group"
     orientation={ORIENTATIONS.ROW}
@@ -146,10 +146,10 @@ export const BorderedRow = () => (
   <RadioButtonGroupComponent
     bordered={false}
     defaultValue={null}
+    elementType="fieldset"
     fullWidth={false}
     id="with-radio-button-group-3"
-    inputType="radio"
-    label="Label"
+    label="Legend"
     labelHelperText="helper text"
     labelHtmlFor="radio-button-group"
     orientation={ORIENTATIONS.ROW}
@@ -182,10 +182,10 @@ export const Description = () => (
   <RadioButtonGroupComponent
     bordered={false}
     defaultValue={null}
+    elementType="fieldset"
     fullWidth
     id="with-radio-button-group-4"
-    inputType="radio"
-    label="Label"
+    label="Legend"
     labelHelperText="helper text"
     labelHtmlFor="radio-button-group"
     orientation={ORIENTATIONS.COLUMN}
@@ -227,10 +227,10 @@ export const DescriptionRow = () => (
   <RadioButtonGroupComponent
     bordered={false}
     defaultValue={null}
+    elementType="fieldset"
     fullWidth
     id="with-radio-button-group-5"
-    inputType="radio"
-    label="Label"
+    label="Legend"
     labelHelperText="helper text"
     labelHtmlFor="radio-button-group"
     orientation={ORIENTATIONS.ROW}

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import FormGroup from 'src/FormGroup';
 import IconCell from 'src/IconCell';
 import Input from 'src/Input';
 import InputLabel from 'src/InputLabel';
+import InputLegend from 'src/InputLegend';
 import LoadingOverlay from 'src/LoadingOverlay';
 import {
   Modal,
@@ -94,6 +95,7 @@ export {
   IconCell,
   Input,
   InputLabel,
+  InputLegend,
   LoadingOverlay,
   MessageTypes,
   Modal,


### PR DESCRIPTION
closes #631

Continuing from my initial [PR-616](https://github.com/user-interviews/ui-design-system/pull/616), I think this could possibly be one / easiest? path forward to supporting `<fieldset>` and `<legend>` with our existing FormGroup with an initial cutover in order to be screen reader accessible on some key flows that need it.

- Adds `inputType` prop on `<FormGroup>` that is set to a string of 'radio' or 'checkbox'. If `inputType` == 'radio' or 'checkbox', the `<FormGroup>` is rendered as a `<fieldset>` otherwise it renders our normal `<div>`
- That `inputType` gets passed down to the `<InputLabel>` which will determine whether the default `<label>` is changed to a `<legend>`.

I tested it out locally on RS and it seems to work okay if given the correct `inputType` on a given `<FormGroup>`. Also checked after running our tests and there doesn't seem to be a difference / any breaking tests as it relates to `getByLabelText` ... at least what I saw when `label` gets switched out for legend (or the tests were not relevant to these changes currently). My thinking is that when the switch does happen (only when we decide to set `inputType`) and it does happen to break a test, I think we could just change `getByLabelText` to something like `getByRole("group", { name: "Some legend that acts as label for radio or checkbox groups" }));` 

Example on `app/javascript/researcher/surveys/survey_form/survey_question_form_group.jsx` when applied:

https://user-images.githubusercontent.com/37383785/170340225-20792243-091e-4bc4-905b-c1d3b7ea35c7.mov

 Possible iteration? -> Updating `RadioButtonGroup` and `CheckboxButtonGroup` to handle the setting `legend` instead of the `FormGroup`?