### PR TITLE
add Link variant to Button component

### DIFF
--- a/cypress/integration/button_spec.js
+++ b/cypress/integration/button_spec.js
@@ -24,6 +24,12 @@ const buttons = [
     match: 'Skip',
   },
   {
+    name: 'Link',
+    path: 'components-button--link',
+    class: '.Button',
+    match: 'Send',
+  },
+  {
     name: 'Brands',
     path: 'components-button--brands',
     class: '.Button',

--- a/scss/buttons.scss
+++ b/scss/buttons.scss
@@ -436,3 +436,46 @@ $warning: $ux-yellow-400;
     }
   }
 
+  @mixin btn-link {
+    $btn-link-background: transparent;
+    $btn-link-border: transparent;
+    $btn-link-color: $ux-blue;
+    
+    $btn-link-hover-background: transparent;
+    $btn-link-hover-border: transparent;
+    $btn-link-hover-color: $ux-blue-600;
+    
+    $btn-link-active-background: transparent;
+    $btn-link-active-border: transparent;
+    $btn-link-active-color: $ux-blue-600;
+  
+    @include button-variant(
+      $btn-link-background, 
+      $btn-link-border,
+      $btn-link-color,
+      
+      $btn-link-hover-background,
+      $btn-link-hover-border,
+      $btn-link-hover-color,
+      
+      $btn-link-active-background,
+      $btn-link-active-border,
+      $btn-link-active-color,
+    );
+
+    text-decoration: none;
+
+    &:disabled {
+      color: $ux-blue;
+      opacity: 0.5;
+    }
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+    &:focus, &:active {
+      @include btn-focus-outline;
+    }
+  }
+

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -7268,74 +7268,79 @@ exports[`Storyshots Components/Selects/Async Default 1`] = `
   }
 >
   <div
-    className="AsyncSelect css-b62m3t-container"
+    className="AsyncSelect css-2b097c-container"
     onKeyDown={[Function]}
   >
-    <span
-      className="css-1f43avz-a11yText-A11yText"
-      id="react-select-3-live-region"
-    />
-    <span
-      aria-atomic="false"
-      aria-live="polite"
-      aria-relevant="additions text"
-      className="css-1f43avz-a11yText-A11yText"
-    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-319lph-ValueContainer"
+        className=" css-g1d714-ValueContainer"
       >
         <div
-          className=" css-858797-placeholder"
-          id="react-select-3-placeholder"
+          className=" css-1269n2i-placeholder"
         >
           Select...
         </div>
         <div
-          className=" css-6j8wv5-Input"
-          data-value=""
+          className="css-b8ldur-Input"
         >
-          <input
-            aria-autocomplete="list"
-            aria-describedby="react-select-3-placeholder"
-            aria-expanded={false}
-            aria-haspopup={true}
-            aria-label="Async select"
-            autoCapitalize="none"
-            autoComplete="off"
-            autoCorrect="off"
+          <div
             className=""
-            disabled={false}
-            id="react-select-3-input"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            role="combobox"
-            spellCheck="false"
             style={
               Object {
-                "background": 0,
-                "border": 0,
-                "color": "inherit",
-                "font": "inherit",
-                "gridArea": "1 / 2",
-                "label": "input",
-                "margin": 0,
-                "minWidth": "2px",
-                "opacity": 1,
-                "outline": 0,
-                "padding": 0,
-                "width": "100%",
+                "display": "inline-block",
               }
             }
-            tabIndex={0}
-            type="text"
-            value=""
-          />
+          >
+            <input
+              aria-autocomplete="list"
+              aria-label="Async select"
+              autoCapitalize="none"
+              autoComplete="off"
+              autoCorrect="off"
+              disabled={false}
+              id="react-select-3-input"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              spellCheck="false"
+              style={
+                Object {
+                  "background": 0,
+                  "border": 0,
+                  "boxSizing": "content-box",
+                  "color": "inherit",
+                  "fontSize": "inherit",
+                  "label": "input",
+                  "opacity": 1,
+                  "outline": 0,
+                  "padding": 0,
+                  "width": "1px",
+                }
+              }
+              tabIndex="0"
+              type="text"
+              value=""
+            />
+            <div
+              style={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "overflow": "scroll",
+                  "position": "absolute",
+                  "top": 0,
+                  "visibility": "hidden",
+                  "whiteSpace": "pre",
+                }
+              }
+            >
+              
+            </div>
+          </div>
         </div>
       </div>
       <div
@@ -7352,7 +7357,7 @@ exports[`Storyshots Components/Selects/Async Default 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-tj5bde-Svg"
+            className="css-6q0nyr-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -7384,75 +7389,80 @@ exports[`Storyshots Components/Selects/Async Labeled 1`] = `
     A labeled select
   </label>
   <div
-    className="AsyncSelect css-b62m3t-container"
+    className="AsyncSelect css-2b097c-container"
     id="async-select"
     onKeyDown={[Function]}
   >
-    <span
-      className="css-1f43avz-a11yText-A11yText"
-      id="react-select-4-live-region"
-    />
-    <span
-      aria-atomic="false"
-      aria-live="polite"
-      aria-relevant="additions text"
-      className="css-1f43avz-a11yText-A11yText"
-    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-319lph-ValueContainer"
+        className=" css-g1d714-ValueContainer"
       >
         <div
-          className=" css-858797-placeholder"
-          id="react-select-4-placeholder"
+          className=" css-1269n2i-placeholder"
         >
           Select...
         </div>
         <div
-          className=" css-6j8wv5-Input"
-          data-value=""
+          className="css-b8ldur-Input"
         >
-          <input
-            aria-autocomplete="list"
-            aria-describedby="react-select-4-placeholder"
-            aria-expanded={false}
-            aria-haspopup={true}
-            aria-labelledby="async-label"
-            autoCapitalize="none"
-            autoComplete="off"
-            autoCorrect="off"
+          <div
             className=""
-            disabled={false}
-            id="react-select-4-input"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            role="combobox"
-            spellCheck="false"
             style={
               Object {
-                "background": 0,
-                "border": 0,
-                "color": "inherit",
-                "font": "inherit",
-                "gridArea": "1 / 2",
-                "label": "input",
-                "margin": 0,
-                "minWidth": "2px",
-                "opacity": 1,
-                "outline": 0,
-                "padding": 0,
-                "width": "100%",
+                "display": "inline-block",
               }
             }
-            tabIndex={0}
-            type="text"
-            value=""
-          />
+          >
+            <input
+              aria-autocomplete="list"
+              aria-labelledby="async-label"
+              autoCapitalize="none"
+              autoComplete="off"
+              autoCorrect="off"
+              disabled={false}
+              id="react-select-4-input"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              spellCheck="false"
+              style={
+                Object {
+                  "background": 0,
+                  "border": 0,
+                  "boxSizing": "content-box",
+                  "color": "inherit",
+                  "fontSize": "inherit",
+                  "label": "input",
+                  "opacity": 1,
+                  "outline": 0,
+                  "padding": 0,
+                  "width": "1px",
+                }
+              }
+              tabIndex="0"
+              type="text"
+              value=""
+            />
+            <div
+              style={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "overflow": "scroll",
+                  "position": "absolute",
+                  "top": 0,
+                  "visibility": "hidden",
+                  "whiteSpace": "pre",
+                }
+              }
+            >
+              
+            </div>
+          </div>
         </div>
       </div>
       <div
@@ -7469,7 +7479,7 @@ exports[`Storyshots Components/Selects/Async Labeled 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-tj5bde-Svg"
+            className="css-6q0nyr-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -7495,74 +7505,79 @@ exports[`Storyshots Components/Selects/AsyncCreatable Default 1`] = `
   }
 >
   <div
-    className="AsyncSelect css-b62m3t-container"
+    className="AsyncSelect css-2b097c-container"
     onKeyDown={[Function]}
   >
-    <span
-      className="css-1f43avz-a11yText-A11yText"
-      id="react-select-2-live-region"
-    />
-    <span
-      aria-atomic="false"
-      aria-live="polite"
-      aria-relevant="additions text"
-      className="css-1f43avz-a11yText-A11yText"
-    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-319lph-ValueContainer"
+        className=" css-g1d714-ValueContainer"
       >
         <div
-          className=" css-858797-placeholder"
-          id="react-select-2-placeholder"
+          className=" css-1269n2i-placeholder"
         >
           Select...
         </div>
         <div
-          className=" css-6j8wv5-Input"
-          data-value=""
+          className="css-b8ldur-Input"
         >
-          <input
-            aria-autocomplete="list"
-            aria-describedby="react-select-2-placeholder"
-            aria-expanded={false}
-            aria-haspopup={true}
-            aria-label="Async creatable select"
-            autoCapitalize="none"
-            autoComplete="off"
-            autoCorrect="off"
+          <div
             className=""
-            disabled={false}
-            id="react-select-2-input"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            role="combobox"
-            spellCheck="false"
             style={
               Object {
-                "background": 0,
-                "border": 0,
-                "color": "inherit",
-                "font": "inherit",
-                "gridArea": "1 / 2",
-                "label": "input",
-                "margin": 0,
-                "minWidth": "2px",
-                "opacity": 1,
-                "outline": 0,
-                "padding": 0,
-                "width": "100%",
+                "display": "inline-block",
               }
             }
-            tabIndex={0}
-            type="text"
-            value=""
-          />
+          >
+            <input
+              aria-autocomplete="list"
+              aria-label="Async creatable select"
+              autoCapitalize="none"
+              autoComplete="off"
+              autoCorrect="off"
+              disabled={false}
+              id="react-select-2-input"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              spellCheck="false"
+              style={
+                Object {
+                  "background": 0,
+                  "border": 0,
+                  "boxSizing": "content-box",
+                  "color": "inherit",
+                  "fontSize": "inherit",
+                  "label": "input",
+                  "opacity": 1,
+                  "outline": 0,
+                  "padding": 0,
+                  "width": "1px",
+                }
+              }
+              tabIndex="0"
+              type="text"
+              value=""
+            />
+            <div
+              style={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "overflow": "scroll",
+                  "position": "absolute",
+                  "top": 0,
+                  "visibility": "hidden",
+                  "whiteSpace": "pre",
+                }
+              }
+            >
+              
+            </div>
+          </div>
         </div>
       </div>
       <div
@@ -7579,7 +7594,7 @@ exports[`Storyshots Components/Selects/AsyncCreatable Default 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-tj5bde-Svg"
+            className="css-6q0nyr-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -7605,73 +7620,78 @@ exports[`Storyshots Components/Selects/Creatable Default 1`] = `
   }
 >
   <div
-    className="CreatableSelect css-b62m3t-container"
+    className="CreatableSelect css-2b097c-container"
     onKeyDown={[Function]}
   >
-    <span
-      className="css-1f43avz-a11yText-A11yText"
-      id="react-select-5-live-region"
-    />
-    <span
-      aria-atomic="false"
-      aria-live="polite"
-      aria-relevant="additions text"
-      className="css-1f43avz-a11yText-A11yText"
-    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-319lph-ValueContainer"
+        className=" css-g1d714-ValueContainer"
       >
         <div
-          className=" css-858797-placeholder"
-          id="react-select-5-placeholder"
+          className=" css-1269n2i-placeholder"
         >
           Select...
         </div>
         <div
-          className=" css-6j8wv5-Input"
-          data-value=""
+          className="css-b8ldur-Input"
         >
-          <input
-            aria-autocomplete="list"
-            aria-describedby="react-select-5-placeholder"
-            aria-expanded={false}
-            aria-haspopup={true}
-            autoCapitalize="none"
-            autoComplete="off"
-            autoCorrect="off"
+          <div
             className=""
-            disabled={false}
-            id="react-select-5-input"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            role="combobox"
-            spellCheck="false"
             style={
               Object {
-                "background": 0,
-                "border": 0,
-                "color": "inherit",
-                "font": "inherit",
-                "gridArea": "1 / 2",
-                "label": "input",
-                "margin": 0,
-                "minWidth": "2px",
-                "opacity": 1,
-                "outline": 0,
-                "padding": 0,
-                "width": "100%",
+                "display": "inline-block",
               }
             }
-            tabIndex={0}
-            type="text"
-            value=""
-          />
+          >
+            <input
+              aria-autocomplete="list"
+              autoCapitalize="none"
+              autoComplete="off"
+              autoCorrect="off"
+              disabled={false}
+              id="react-select-5-input"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              spellCheck="false"
+              style={
+                Object {
+                  "background": 0,
+                  "border": 0,
+                  "boxSizing": "content-box",
+                  "color": "inherit",
+                  "fontSize": "inherit",
+                  "label": "input",
+                  "opacity": 1,
+                  "outline": 0,
+                  "padding": 0,
+                  "width": "1px",
+                }
+              }
+              tabIndex="0"
+              type="text"
+              value=""
+            />
+            <div
+              style={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "overflow": "scroll",
+                  "position": "absolute",
+                  "top": 0,
+                  "visibility": "hidden",
+                  "whiteSpace": "pre",
+                }
+              }
+            >
+              
+            </div>
+          </div>
         </div>
       </div>
       <div
@@ -7688,7 +7708,7 @@ exports[`Storyshots Components/Selects/Creatable Default 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-tj5bde-Svg"
+            className="css-6q0nyr-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -7720,50 +7740,34 @@ exports[`Storyshots Components/Selects/Single Custom Option With Checkbox 1`] = 
     Custom option with checkbox
   </label>
   <div
-    className="SingleSelect css-b62m3t-container"
+    className="SingleSelect css-2b097c-container"
     id="multi-select"
     onKeyDown={[Function]}
   >
-    <span
-      className="css-1f43avz-a11yText-A11yText"
-      id="react-select-12-live-region"
-    />
-    <span
-      aria-atomic="false"
-      aria-live="polite"
-      aria-relevant="additions text"
-      className="css-1f43avz-a11yText-A11yText"
-    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-319lph-ValueContainer"
+        className=" css-g1d714-ValueContainer"
       >
         <div
-          className=" css-858797-placeholder"
-          id="react-select-12-placeholder"
+          className=" css-1269n2i-placeholder"
         >
           Select...
         </div>
         <input
           aria-autocomplete="list"
-          aria-describedby="react-select-12-placeholder"
-          aria-expanded={false}
-          aria-haspopup={true}
           aria-labelledby="select-label"
-          aria-readonly={true}
-          className="css-mohuvp-dummyInput-DummyInput"
+          className="css-62g3xt-dummyInput"
           disabled={false}
           id="react-select-12-input"
-          inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          role="combobox"
-          tabIndex={0}
+          readOnly={true}
+          tabIndex="0"
           value=""
         />
       </div>
@@ -7781,7 +7785,7 @@ exports[`Storyshots Components/Selects/Single Custom Option With Checkbox 1`] = 
         >
           <svg
             aria-hidden="true"
-            className="css-tj5bde-Svg"
+            className="css-6q0nyr-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -7813,50 +7817,34 @@ exports[`Storyshots Components/Selects/Single Custom Value Container 1`] = `
     Custom value container
   </label>
   <div
-    className="SingleSelect css-b62m3t-container"
+    className="SingleSelect css-2b097c-container"
     id="custom-value-container-select"
     onKeyDown={[Function]}
   >
-    <span
-      className="css-1f43avz-a11yText-A11yText"
-      id="react-select-13-live-region"
-    />
-    <span
-      aria-atomic="false"
-      aria-live="polite"
-      aria-relevant="additions text"
-      className="css-1f43avz-a11yText-A11yText"
-    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-319lph-ValueContainer"
+        className=" css-g1d714-ValueContainer"
       >
         <div
-          className=" css-858797-placeholder"
-          id="react-select-13-placeholder"
+          className=" css-1269n2i-placeholder"
         >
           Select...
         </div>
         <input
           aria-autocomplete="list"
-          aria-describedby="react-select-13-placeholder"
-          aria-expanded={false}
-          aria-haspopup={true}
           aria-labelledby="select-label"
-          aria-readonly={true}
-          className="css-mohuvp-dummyInput-DummyInput"
+          className="css-62g3xt-dummyInput"
           disabled={false}
           id="react-select-13-input"
-          inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          role="combobox"
-          tabIndex={0}
+          readOnly={true}
+          tabIndex="0"
           value=""
         />
       </div>
@@ -7874,7 +7862,7 @@ exports[`Storyshots Components/Selects/Single Custom Value Container 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-tj5bde-Svg"
+            className="css-6q0nyr-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -7900,49 +7888,33 @@ exports[`Storyshots Components/Selects/Single Default 1`] = `
   }
 >
   <div
-    className="SingleSelect css-b62m3t-container"
+    className="SingleSelect css-2b097c-container"
     onKeyDown={[Function]}
   >
-    <span
-      className="css-1f43avz-a11yText-A11yText"
-      id="react-select-6-live-region"
-    />
-    <span
-      aria-atomic="false"
-      aria-live="polite"
-      aria-relevant="additions text"
-      className="css-1f43avz-a11yText-A11yText"
-    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-319lph-ValueContainer"
+        className=" css-g1d714-ValueContainer"
       >
         <div
-          className=" css-858797-placeholder"
-          id="react-select-6-placeholder"
+          className=" css-1269n2i-placeholder"
         >
           Select...
         </div>
         <input
           aria-autocomplete="list"
-          aria-describedby="react-select-6-placeholder"
-          aria-expanded={false}
-          aria-haspopup={true}
           aria-label="Default select"
-          aria-readonly={true}
-          className="css-mohuvp-dummyInput-DummyInput"
+          className="css-62g3xt-dummyInput"
           disabled={false}
           id="react-select-6-input"
-          inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          role="combobox"
-          tabIndex={0}
+          readOnly={true}
+          tabIndex="0"
           value=""
         />
       </div>
@@ -7960,7 +7932,7 @@ exports[`Storyshots Components/Selects/Single Default 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-tj5bde-Svg"
+            className="css-6q0nyr-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -8040,50 +8012,34 @@ exports[`Storyshots Components/Selects/Single In Modal 1`] = `
           A select inside a modal
         </span>
         <div
-          className="SingleSelect css-b62m3t-container"
+          className="SingleSelect css-2b097c-container"
           id="select-in-modal"
           onKeyDown={[Function]}
         >
-          <span
-            className="css-1f43avz-a11yText-A11yText"
-            id="react-select-11-live-region"
-          />
-          <span
-            aria-atomic="false"
-            aria-live="polite"
-            aria-relevant="additions text"
-            className="css-1f43avz-a11yText-A11yText"
-          />
           <div
             className=" css-15ub2n0-control"
             onMouseDown={[Function]}
             onTouchEnd={[Function]}
           >
             <div
-              className=" css-319lph-ValueContainer"
+              className=" css-g1d714-ValueContainer"
             >
               <div
-                className=" css-858797-placeholder"
-                id="react-select-11-placeholder"
+                className=" css-1269n2i-placeholder"
               >
                 Select...
               </div>
               <input
                 aria-autocomplete="list"
-                aria-describedby="react-select-11-placeholder"
-                aria-expanded={false}
-                aria-haspopup={true}
                 aria-labelledby="select-label"
-                aria-readonly={true}
-                className="css-mohuvp-dummyInput-DummyInput"
+                className="css-62g3xt-dummyInput"
                 disabled={false}
                 id="react-select-11-input"
-                inputMode="none"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
-                role="combobox"
-                tabIndex={0}
+                readOnly={true}
+                tabIndex="0"
                 value=""
               />
             </div>
@@ -8101,7 +8057,7 @@ exports[`Storyshots Components/Selects/Single In Modal 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  className="css-tj5bde-Svg"
+                  className="css-6q0nyr-Svg"
                   focusable="false"
                   height={20}
                   viewBox="0 0 20 20"
@@ -8152,50 +8108,34 @@ exports[`Storyshots Components/Selects/Single Labeled 1`] = `
     Labeled select
   </label>
   <div
-    className="SingleSelect css-b62m3t-container"
+    className="SingleSelect css-2b097c-container"
     id="labeled-select"
     onKeyDown={[Function]}
   >
-    <span
-      className="css-1f43avz-a11yText-A11yText"
-      id="react-select-9-live-region"
-    />
-    <span
-      aria-atomic="false"
-      aria-live="polite"
-      aria-relevant="additions text"
-      className="css-1f43avz-a11yText-A11yText"
-    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-319lph-ValueContainer"
+        className=" css-g1d714-ValueContainer"
       >
         <div
-          className=" css-858797-placeholder"
-          id="react-select-9-placeholder"
+          className=" css-1269n2i-placeholder"
         >
           Select...
         </div>
         <input
           aria-autocomplete="list"
-          aria-describedby="react-select-9-placeholder"
-          aria-expanded={false}
-          aria-haspopup={true}
           aria-labelledby="select-label"
-          aria-readonly={true}
-          className="css-mohuvp-dummyInput-DummyInput"
+          className="css-62g3xt-dummyInput"
           disabled={false}
           id="react-select-9-input"
-          inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          role="combobox"
-          tabIndex={0}
+          readOnly={true}
+          tabIndex="0"
           value=""
         />
       </div>
@@ -8213,7 +8153,7 @@ exports[`Storyshots Components/Selects/Single Labeled 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-tj5bde-Svg"
+            className="css-6q0nyr-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -8239,49 +8179,33 @@ exports[`Storyshots Components/Selects/Single Loading 1`] = `
   }
 >
   <div
-    className="SingleSelect css-3iigni-container"
+    className="SingleSelect css-14jk2my-container"
     onKeyDown={[Function]}
   >
-    <span
-      className="css-1f43avz-a11yText-A11yText"
-      id="react-select-8-live-region"
-    />
-    <span
-      aria-atomic="false"
-      aria-live="polite"
-      aria-relevant="additions text"
-      className="css-1f43avz-a11yText-A11yText"
-    />
     <div
       className=" css-1930729-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-319lph-ValueContainer"
+        className=" css-g1d714-ValueContainer"
       >
         <div
-          className=" css-858797-placeholder"
-          id="react-select-8-placeholder"
+          className=" css-1269n2i-placeholder"
         >
           Select...
         </div>
         <input
           aria-autocomplete="list"
-          aria-describedby="react-select-8-placeholder"
-          aria-expanded={false}
-          aria-haspopup={true}
           aria-label="Loading select"
-          aria-readonly={true}
-          className="css-mohuvp-dummyInput-DummyInput"
+          className="css-62g3xt-dummyInput"
           disabled={true}
           id="react-select-8-input"
-          inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          role="combobox"
-          tabIndex={0}
+          readOnly={true}
+          tabIndex="0"
           value=""
         />
       </div>
@@ -8299,7 +8223,7 @@ exports[`Storyshots Components/Selects/Single Loading 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-tj5bde-Svg"
+            className="css-6q0nyr-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -8331,50 +8255,34 @@ exports[`Storyshots Components/Selects/Single Multi Select 1`] = `
     Multi select
   </label>
   <div
-    className="SingleSelect css-b62m3t-container"
+    className="SingleSelect css-2b097c-container"
     id="multi-select"
     onKeyDown={[Function]}
   >
-    <span
-      className="css-1f43avz-a11yText-A11yText"
-      id="react-select-10-live-region"
-    />
-    <span
-      aria-atomic="false"
-      aria-live="polite"
-      aria-relevant="additions text"
-      className="css-1f43avz-a11yText-A11yText"
-    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-319lph-ValueContainer"
+        className=" css-g1d714-ValueContainer"
       >
         <div
-          className=" css-858797-placeholder"
-          id="react-select-10-placeholder"
+          className=" css-1269n2i-placeholder"
         >
           Select...
         </div>
         <input
           aria-autocomplete="list"
-          aria-describedby="react-select-10-placeholder"
-          aria-expanded={false}
-          aria-haspopup={true}
           aria-labelledby="select-label"
-          aria-readonly={true}
-          className="css-mohuvp-dummyInput-DummyInput"
+          className="css-62g3xt-dummyInput"
           disabled={false}
           id="react-select-10-input"
-          inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          role="combobox"
-          tabIndex={0}
+          readOnly={true}
+          tabIndex="0"
           value=""
         />
       </div>
@@ -8392,7 +8300,7 @@ exports[`Storyshots Components/Selects/Single Multi Select 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-tj5bde-Svg"
+            className="css-6q0nyr-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -8418,74 +8326,79 @@ exports[`Storyshots Components/Selects/Single Searchable 1`] = `
   }
 >
   <div
-    className="SingleSelect css-b62m3t-container"
+    className="SingleSelect css-2b097c-container"
     onKeyDown={[Function]}
   >
-    <span
-      className="css-1f43avz-a11yText-A11yText"
-      id="react-select-7-live-region"
-    />
-    <span
-      aria-atomic="false"
-      aria-live="polite"
-      aria-relevant="additions text"
-      className="css-1f43avz-a11yText-A11yText"
-    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-319lph-ValueContainer"
+        className=" css-g1d714-ValueContainer"
       >
         <div
-          className=" css-858797-placeholder"
-          id="react-select-7-placeholder"
+          className=" css-1269n2i-placeholder"
         >
           Select...
         </div>
         <div
-          className=" css-6j8wv5-Input"
-          data-value=""
+          className="css-b8ldur-Input"
         >
-          <input
-            aria-autocomplete="list"
-            aria-describedby="react-select-7-placeholder"
-            aria-expanded={false}
-            aria-haspopup={true}
-            aria-label="Searchable select"
-            autoCapitalize="none"
-            autoComplete="off"
-            autoCorrect="off"
+          <div
             className=""
-            disabled={false}
-            id="react-select-7-input"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            role="combobox"
-            spellCheck="false"
             style={
               Object {
-                "background": 0,
-                "border": 0,
-                "color": "inherit",
-                "font": "inherit",
-                "gridArea": "1 / 2",
-                "label": "input",
-                "margin": 0,
-                "minWidth": "2px",
-                "opacity": 1,
-                "outline": 0,
-                "padding": 0,
-                "width": "100%",
+                "display": "inline-block",
               }
             }
-            tabIndex={0}
-            type="text"
-            value=""
-          />
+          >
+            <input
+              aria-autocomplete="list"
+              aria-label="Searchable select"
+              autoCapitalize="none"
+              autoComplete="off"
+              autoCorrect="off"
+              disabled={false}
+              id="react-select-7-input"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              spellCheck="false"
+              style={
+                Object {
+                  "background": 0,
+                  "border": 0,
+                  "boxSizing": "content-box",
+                  "color": "inherit",
+                  "fontSize": "inherit",
+                  "label": "input",
+                  "opacity": 1,
+                  "outline": 0,
+                  "padding": 0,
+                  "width": "1px",
+                }
+              }
+              tabIndex="0"
+              type="text"
+              value=""
+            />
+            <div
+              style={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "overflow": "scroll",
+                  "position": "absolute",
+                  "top": 0,
+                  "visibility": "hidden",
+                  "whiteSpace": "pre",
+                }
+              }
+            >
+              
+            </div>
+          </div>
         </div>
       </div>
       <div
@@ -8502,7 +8415,7 @@ exports[`Storyshots Components/Selects/Single Searchable 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-tj5bde-Svg"
+            className="css-6q0nyr-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -2345,6 +2345,57 @@ exports[`Storyshots Components/Button Danger 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Button Link 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <button
+    className="Button btn btn-link btn-sm"
+    disabled={false}
+    type="button"
+  >
+    Send
+  </button>
+   
+  <button
+    className="Button btn btn-link btn-sm"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-paper-plane fa-w-16 icon-left"
+      data-icon="paper-plane"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M440 6.5L24 246.4c-34.4 19.9-31.1 70.8 5.7 85.9L144 379.6V464c0 46.4 59.2 65.5 86.6 28.6l43.8-59.1 111.9 46.2c5.9 2.4 12.1 3.6 18.3 3.6 8.2 0 16.3-2.1 23.6-6.2 12.8-7.2 21.6-20 23.9-34.5l59.4-387.2c6.1-40.1-36.9-68.8-71.5-48.9zM192 464v-64.6l36.6 15.1L192 464zm212.6-28.7l-153.8-63.5L391 169.5c10.7-15.5-9.5-33.5-23.7-21.2L155.8 332.6 48 288 464 48l-59.4 387.3z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Send
+  </button>
+   
+  <button
+    className="Button btn btn-link btn-sm"
+    disabled={true}
+    type="button"
+  >
+    Send
+  </button>
+</div>
+`;
+
 exports[`Storyshots Components/Button Primary 1`] = `
 <div
   style={
@@ -7217,79 +7268,74 @@ exports[`Storyshots Components/Selects/Async Default 1`] = `
   }
 >
   <div
-    className="AsyncSelect css-2b097c-container"
+    className="AsyncSelect css-b62m3t-container"
     onKeyDown={[Function]}
   >
+    <span
+      className="css-1f43avz-a11yText-A11yText"
+      id="react-select-3-live-region"
+    />
+    <span
+      aria-atomic="false"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className="css-1f43avz-a11yText-A11yText"
+    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-g1d714-ValueContainer"
+        className=" css-319lph-ValueContainer"
       >
         <div
-          className=" css-1269n2i-placeholder"
+          className=" css-858797-placeholder"
+          id="react-select-3-placeholder"
         >
           Select...
         </div>
         <div
-          className="css-b8ldur-Input"
+          className=" css-6j8wv5-Input"
+          data-value=""
         >
-          <div
+          <input
+            aria-autocomplete="list"
+            aria-describedby="react-select-3-placeholder"
+            aria-expanded={false}
+            aria-haspopup={true}
+            aria-label="Async select"
+            autoCapitalize="none"
+            autoComplete="off"
+            autoCorrect="off"
             className=""
+            disabled={false}
+            id="react-select-3-input"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            role="combobox"
+            spellCheck="false"
             style={
               Object {
-                "display": "inline-block",
+                "background": 0,
+                "border": 0,
+                "color": "inherit",
+                "font": "inherit",
+                "gridArea": "1 / 2",
+                "label": "input",
+                "margin": 0,
+                "minWidth": "2px",
+                "opacity": 1,
+                "outline": 0,
+                "padding": 0,
+                "width": "100%",
               }
             }
-          >
-            <input
-              aria-autocomplete="list"
-              aria-label="Async select"
-              autoCapitalize="none"
-              autoComplete="off"
-              autoCorrect="off"
-              disabled={false}
-              id="react-select-3-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              spellCheck="false"
-              style={
-                Object {
-                  "background": 0,
-                  "border": 0,
-                  "boxSizing": "content-box",
-                  "color": "inherit",
-                  "fontSize": "inherit",
-                  "label": "input",
-                  "opacity": 1,
-                  "outline": 0,
-                  "padding": 0,
-                  "width": "1px",
-                }
-              }
-              tabIndex="0"
-              type="text"
-              value=""
-            />
-            <div
-              style={
-                Object {
-                  "height": 0,
-                  "left": 0,
-                  "overflow": "scroll",
-                  "position": "absolute",
-                  "top": 0,
-                  "visibility": "hidden",
-                  "whiteSpace": "pre",
-                }
-              }
-            >
-              
-            </div>
-          </div>
+            tabIndex={0}
+            type="text"
+            value=""
+          />
         </div>
       </div>
       <div
@@ -7306,7 +7352,7 @@ exports[`Storyshots Components/Selects/Async Default 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-6q0nyr-Svg"
+            className="css-tj5bde-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -7338,80 +7384,75 @@ exports[`Storyshots Components/Selects/Async Labeled 1`] = `
     A labeled select
   </label>
   <div
-    className="AsyncSelect css-2b097c-container"
+    className="AsyncSelect css-b62m3t-container"
     id="async-select"
     onKeyDown={[Function]}
   >
+    <span
+      className="css-1f43avz-a11yText-A11yText"
+      id="react-select-4-live-region"
+    />
+    <span
+      aria-atomic="false"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className="css-1f43avz-a11yText-A11yText"
+    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-g1d714-ValueContainer"
+        className=" css-319lph-ValueContainer"
       >
         <div
-          className=" css-1269n2i-placeholder"
+          className=" css-858797-placeholder"
+          id="react-select-4-placeholder"
         >
           Select...
         </div>
         <div
-          className="css-b8ldur-Input"
+          className=" css-6j8wv5-Input"
+          data-value=""
         >
-          <div
+          <input
+            aria-autocomplete="list"
+            aria-describedby="react-select-4-placeholder"
+            aria-expanded={false}
+            aria-haspopup={true}
+            aria-labelledby="async-label"
+            autoCapitalize="none"
+            autoComplete="off"
+            autoCorrect="off"
             className=""
+            disabled={false}
+            id="react-select-4-input"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            role="combobox"
+            spellCheck="false"
             style={
               Object {
-                "display": "inline-block",
+                "background": 0,
+                "border": 0,
+                "color": "inherit",
+                "font": "inherit",
+                "gridArea": "1 / 2",
+                "label": "input",
+                "margin": 0,
+                "minWidth": "2px",
+                "opacity": 1,
+                "outline": 0,
+                "padding": 0,
+                "width": "100%",
               }
             }
-          >
-            <input
-              aria-autocomplete="list"
-              aria-labelledby="async-label"
-              autoCapitalize="none"
-              autoComplete="off"
-              autoCorrect="off"
-              disabled={false}
-              id="react-select-4-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              spellCheck="false"
-              style={
-                Object {
-                  "background": 0,
-                  "border": 0,
-                  "boxSizing": "content-box",
-                  "color": "inherit",
-                  "fontSize": "inherit",
-                  "label": "input",
-                  "opacity": 1,
-                  "outline": 0,
-                  "padding": 0,
-                  "width": "1px",
-                }
-              }
-              tabIndex="0"
-              type="text"
-              value=""
-            />
-            <div
-              style={
-                Object {
-                  "height": 0,
-                  "left": 0,
-                  "overflow": "scroll",
-                  "position": "absolute",
-                  "top": 0,
-                  "visibility": "hidden",
-                  "whiteSpace": "pre",
-                }
-              }
-            >
-              
-            </div>
-          </div>
+            tabIndex={0}
+            type="text"
+            value=""
+          />
         </div>
       </div>
       <div
@@ -7428,7 +7469,7 @@ exports[`Storyshots Components/Selects/Async Labeled 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-6q0nyr-Svg"
+            className="css-tj5bde-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -7454,79 +7495,74 @@ exports[`Storyshots Components/Selects/AsyncCreatable Default 1`] = `
   }
 >
   <div
-    className="AsyncSelect css-2b097c-container"
+    className="AsyncSelect css-b62m3t-container"
     onKeyDown={[Function]}
   >
+    <span
+      className="css-1f43avz-a11yText-A11yText"
+      id="react-select-2-live-region"
+    />
+    <span
+      aria-atomic="false"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className="css-1f43avz-a11yText-A11yText"
+    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-g1d714-ValueContainer"
+        className=" css-319lph-ValueContainer"
       >
         <div
-          className=" css-1269n2i-placeholder"
+          className=" css-858797-placeholder"
+          id="react-select-2-placeholder"
         >
           Select...
         </div>
         <div
-          className="css-b8ldur-Input"
+          className=" css-6j8wv5-Input"
+          data-value=""
         >
-          <div
+          <input
+            aria-autocomplete="list"
+            aria-describedby="react-select-2-placeholder"
+            aria-expanded={false}
+            aria-haspopup={true}
+            aria-label="Async creatable select"
+            autoCapitalize="none"
+            autoComplete="off"
+            autoCorrect="off"
             className=""
+            disabled={false}
+            id="react-select-2-input"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            role="combobox"
+            spellCheck="false"
             style={
               Object {
-                "display": "inline-block",
+                "background": 0,
+                "border": 0,
+                "color": "inherit",
+                "font": "inherit",
+                "gridArea": "1 / 2",
+                "label": "input",
+                "margin": 0,
+                "minWidth": "2px",
+                "opacity": 1,
+                "outline": 0,
+                "padding": 0,
+                "width": "100%",
               }
             }
-          >
-            <input
-              aria-autocomplete="list"
-              aria-label="Async creatable select"
-              autoCapitalize="none"
-              autoComplete="off"
-              autoCorrect="off"
-              disabled={false}
-              id="react-select-2-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              spellCheck="false"
-              style={
-                Object {
-                  "background": 0,
-                  "border": 0,
-                  "boxSizing": "content-box",
-                  "color": "inherit",
-                  "fontSize": "inherit",
-                  "label": "input",
-                  "opacity": 1,
-                  "outline": 0,
-                  "padding": 0,
-                  "width": "1px",
-                }
-              }
-              tabIndex="0"
-              type="text"
-              value=""
-            />
-            <div
-              style={
-                Object {
-                  "height": 0,
-                  "left": 0,
-                  "overflow": "scroll",
-                  "position": "absolute",
-                  "top": 0,
-                  "visibility": "hidden",
-                  "whiteSpace": "pre",
-                }
-              }
-            >
-              
-            </div>
-          </div>
+            tabIndex={0}
+            type="text"
+            value=""
+          />
         </div>
       </div>
       <div
@@ -7543,7 +7579,7 @@ exports[`Storyshots Components/Selects/AsyncCreatable Default 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-6q0nyr-Svg"
+            className="css-tj5bde-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -7569,78 +7605,73 @@ exports[`Storyshots Components/Selects/Creatable Default 1`] = `
   }
 >
   <div
-    className="CreatableSelect css-2b097c-container"
+    className="CreatableSelect css-b62m3t-container"
     onKeyDown={[Function]}
   >
+    <span
+      className="css-1f43avz-a11yText-A11yText"
+      id="react-select-5-live-region"
+    />
+    <span
+      aria-atomic="false"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className="css-1f43avz-a11yText-A11yText"
+    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-g1d714-ValueContainer"
+        className=" css-319lph-ValueContainer"
       >
         <div
-          className=" css-1269n2i-placeholder"
+          className=" css-858797-placeholder"
+          id="react-select-5-placeholder"
         >
           Select...
         </div>
         <div
-          className="css-b8ldur-Input"
+          className=" css-6j8wv5-Input"
+          data-value=""
         >
-          <div
+          <input
+            aria-autocomplete="list"
+            aria-describedby="react-select-5-placeholder"
+            aria-expanded={false}
+            aria-haspopup={true}
+            autoCapitalize="none"
+            autoComplete="off"
+            autoCorrect="off"
             className=""
+            disabled={false}
+            id="react-select-5-input"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            role="combobox"
+            spellCheck="false"
             style={
               Object {
-                "display": "inline-block",
+                "background": 0,
+                "border": 0,
+                "color": "inherit",
+                "font": "inherit",
+                "gridArea": "1 / 2",
+                "label": "input",
+                "margin": 0,
+                "minWidth": "2px",
+                "opacity": 1,
+                "outline": 0,
+                "padding": 0,
+                "width": "100%",
               }
             }
-          >
-            <input
-              aria-autocomplete="list"
-              autoCapitalize="none"
-              autoComplete="off"
-              autoCorrect="off"
-              disabled={false}
-              id="react-select-5-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              spellCheck="false"
-              style={
-                Object {
-                  "background": 0,
-                  "border": 0,
-                  "boxSizing": "content-box",
-                  "color": "inherit",
-                  "fontSize": "inherit",
-                  "label": "input",
-                  "opacity": 1,
-                  "outline": 0,
-                  "padding": 0,
-                  "width": "1px",
-                }
-              }
-              tabIndex="0"
-              type="text"
-              value=""
-            />
-            <div
-              style={
-                Object {
-                  "height": 0,
-                  "left": 0,
-                  "overflow": "scroll",
-                  "position": "absolute",
-                  "top": 0,
-                  "visibility": "hidden",
-                  "whiteSpace": "pre",
-                }
-              }
-            >
-              
-            </div>
-          </div>
+            tabIndex={0}
+            type="text"
+            value=""
+          />
         </div>
       </div>
       <div
@@ -7657,7 +7688,7 @@ exports[`Storyshots Components/Selects/Creatable Default 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-6q0nyr-Svg"
+            className="css-tj5bde-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -7689,34 +7720,50 @@ exports[`Storyshots Components/Selects/Single Custom Option With Checkbox 1`] = 
     Custom option with checkbox
   </label>
   <div
-    className="SingleSelect css-2b097c-container"
+    className="SingleSelect css-b62m3t-container"
     id="multi-select"
     onKeyDown={[Function]}
   >
+    <span
+      className="css-1f43avz-a11yText-A11yText"
+      id="react-select-12-live-region"
+    />
+    <span
+      aria-atomic="false"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className="css-1f43avz-a11yText-A11yText"
+    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-g1d714-ValueContainer"
+        className=" css-319lph-ValueContainer"
       >
         <div
-          className=" css-1269n2i-placeholder"
+          className=" css-858797-placeholder"
+          id="react-select-12-placeholder"
         >
           Select...
         </div>
         <input
           aria-autocomplete="list"
+          aria-describedby="react-select-12-placeholder"
+          aria-expanded={false}
+          aria-haspopup={true}
           aria-labelledby="select-label"
-          className="css-62g3xt-dummyInput"
+          aria-readonly={true}
+          className="css-mohuvp-dummyInput-DummyInput"
           disabled={false}
           id="react-select-12-input"
+          inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          readOnly={true}
-          tabIndex="0"
+          role="combobox"
+          tabIndex={0}
           value=""
         />
       </div>
@@ -7734,7 +7781,7 @@ exports[`Storyshots Components/Selects/Single Custom Option With Checkbox 1`] = 
         >
           <svg
             aria-hidden="true"
-            className="css-6q0nyr-Svg"
+            className="css-tj5bde-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -7766,34 +7813,50 @@ exports[`Storyshots Components/Selects/Single Custom Value Container 1`] = `
     Custom value container
   </label>
   <div
-    className="SingleSelect css-2b097c-container"
+    className="SingleSelect css-b62m3t-container"
     id="custom-value-container-select"
     onKeyDown={[Function]}
   >
+    <span
+      className="css-1f43avz-a11yText-A11yText"
+      id="react-select-13-live-region"
+    />
+    <span
+      aria-atomic="false"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className="css-1f43avz-a11yText-A11yText"
+    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-g1d714-ValueContainer"
+        className=" css-319lph-ValueContainer"
       >
         <div
-          className=" css-1269n2i-placeholder"
+          className=" css-858797-placeholder"
+          id="react-select-13-placeholder"
         >
           Select...
         </div>
         <input
           aria-autocomplete="list"
+          aria-describedby="react-select-13-placeholder"
+          aria-expanded={false}
+          aria-haspopup={true}
           aria-labelledby="select-label"
-          className="css-62g3xt-dummyInput"
+          aria-readonly={true}
+          className="css-mohuvp-dummyInput-DummyInput"
           disabled={false}
           id="react-select-13-input"
+          inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          readOnly={true}
-          tabIndex="0"
+          role="combobox"
+          tabIndex={0}
           value=""
         />
       </div>
@@ -7811,7 +7874,7 @@ exports[`Storyshots Components/Selects/Single Custom Value Container 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-6q0nyr-Svg"
+            className="css-tj5bde-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -7837,33 +7900,49 @@ exports[`Storyshots Components/Selects/Single Default 1`] = `
   }
 >
   <div
-    className="SingleSelect css-2b097c-container"
+    className="SingleSelect css-b62m3t-container"
     onKeyDown={[Function]}
   >
+    <span
+      className="css-1f43avz-a11yText-A11yText"
+      id="react-select-6-live-region"
+    />
+    <span
+      aria-atomic="false"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className="css-1f43avz-a11yText-A11yText"
+    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-g1d714-ValueContainer"
+        className=" css-319lph-ValueContainer"
       >
         <div
-          className=" css-1269n2i-placeholder"
+          className=" css-858797-placeholder"
+          id="react-select-6-placeholder"
         >
           Select...
         </div>
         <input
           aria-autocomplete="list"
+          aria-describedby="react-select-6-placeholder"
+          aria-expanded={false}
+          aria-haspopup={true}
           aria-label="Default select"
-          className="css-62g3xt-dummyInput"
+          aria-readonly={true}
+          className="css-mohuvp-dummyInput-DummyInput"
           disabled={false}
           id="react-select-6-input"
+          inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          readOnly={true}
-          tabIndex="0"
+          role="combobox"
+          tabIndex={0}
           value=""
         />
       </div>
@@ -7881,7 +7960,7 @@ exports[`Storyshots Components/Selects/Single Default 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-6q0nyr-Svg"
+            className="css-tj5bde-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -7961,34 +8040,50 @@ exports[`Storyshots Components/Selects/Single In Modal 1`] = `
           A select inside a modal
         </span>
         <div
-          className="SingleSelect css-2b097c-container"
+          className="SingleSelect css-b62m3t-container"
           id="select-in-modal"
           onKeyDown={[Function]}
         >
+          <span
+            className="css-1f43avz-a11yText-A11yText"
+            id="react-select-11-live-region"
+          />
+          <span
+            aria-atomic="false"
+            aria-live="polite"
+            aria-relevant="additions text"
+            className="css-1f43avz-a11yText-A11yText"
+          />
           <div
             className=" css-15ub2n0-control"
             onMouseDown={[Function]}
             onTouchEnd={[Function]}
           >
             <div
-              className=" css-g1d714-ValueContainer"
+              className=" css-319lph-ValueContainer"
             >
               <div
-                className=" css-1269n2i-placeholder"
+                className=" css-858797-placeholder"
+                id="react-select-11-placeholder"
               >
                 Select...
               </div>
               <input
                 aria-autocomplete="list"
+                aria-describedby="react-select-11-placeholder"
+                aria-expanded={false}
+                aria-haspopup={true}
                 aria-labelledby="select-label"
-                className="css-62g3xt-dummyInput"
+                aria-readonly={true}
+                className="css-mohuvp-dummyInput-DummyInput"
                 disabled={false}
                 id="react-select-11-input"
+                inputMode="none"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
-                readOnly={true}
-                tabIndex="0"
+                role="combobox"
+                tabIndex={0}
                 value=""
               />
             </div>
@@ -8006,7 +8101,7 @@ exports[`Storyshots Components/Selects/Single In Modal 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  className="css-6q0nyr-Svg"
+                  className="css-tj5bde-Svg"
                   focusable="false"
                   height={20}
                   viewBox="0 0 20 20"
@@ -8057,34 +8152,50 @@ exports[`Storyshots Components/Selects/Single Labeled 1`] = `
     Labeled select
   </label>
   <div
-    className="SingleSelect css-2b097c-container"
+    className="SingleSelect css-b62m3t-container"
     id="labeled-select"
     onKeyDown={[Function]}
   >
+    <span
+      className="css-1f43avz-a11yText-A11yText"
+      id="react-select-9-live-region"
+    />
+    <span
+      aria-atomic="false"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className="css-1f43avz-a11yText-A11yText"
+    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-g1d714-ValueContainer"
+        className=" css-319lph-ValueContainer"
       >
         <div
-          className=" css-1269n2i-placeholder"
+          className=" css-858797-placeholder"
+          id="react-select-9-placeholder"
         >
           Select...
         </div>
         <input
           aria-autocomplete="list"
+          aria-describedby="react-select-9-placeholder"
+          aria-expanded={false}
+          aria-haspopup={true}
           aria-labelledby="select-label"
-          className="css-62g3xt-dummyInput"
+          aria-readonly={true}
+          className="css-mohuvp-dummyInput-DummyInput"
           disabled={false}
           id="react-select-9-input"
+          inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          readOnly={true}
-          tabIndex="0"
+          role="combobox"
+          tabIndex={0}
           value=""
         />
       </div>
@@ -8102,7 +8213,7 @@ exports[`Storyshots Components/Selects/Single Labeled 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-6q0nyr-Svg"
+            className="css-tj5bde-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -8128,33 +8239,49 @@ exports[`Storyshots Components/Selects/Single Loading 1`] = `
   }
 >
   <div
-    className="SingleSelect css-14jk2my-container"
+    className="SingleSelect css-3iigni-container"
     onKeyDown={[Function]}
   >
+    <span
+      className="css-1f43avz-a11yText-A11yText"
+      id="react-select-8-live-region"
+    />
+    <span
+      aria-atomic="false"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className="css-1f43avz-a11yText-A11yText"
+    />
     <div
       className=" css-1930729-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-g1d714-ValueContainer"
+        className=" css-319lph-ValueContainer"
       >
         <div
-          className=" css-1269n2i-placeholder"
+          className=" css-858797-placeholder"
+          id="react-select-8-placeholder"
         >
           Select...
         </div>
         <input
           aria-autocomplete="list"
+          aria-describedby="react-select-8-placeholder"
+          aria-expanded={false}
+          aria-haspopup={true}
           aria-label="Loading select"
-          className="css-62g3xt-dummyInput"
+          aria-readonly={true}
+          className="css-mohuvp-dummyInput-DummyInput"
           disabled={true}
           id="react-select-8-input"
+          inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          readOnly={true}
-          tabIndex="0"
+          role="combobox"
+          tabIndex={0}
           value=""
         />
       </div>
@@ -8172,7 +8299,7 @@ exports[`Storyshots Components/Selects/Single Loading 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-6q0nyr-Svg"
+            className="css-tj5bde-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -8204,34 +8331,50 @@ exports[`Storyshots Components/Selects/Single Multi Select 1`] = `
     Multi select
   </label>
   <div
-    className="SingleSelect css-2b097c-container"
+    className="SingleSelect css-b62m3t-container"
     id="multi-select"
     onKeyDown={[Function]}
   >
+    <span
+      className="css-1f43avz-a11yText-A11yText"
+      id="react-select-10-live-region"
+    />
+    <span
+      aria-atomic="false"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className="css-1f43avz-a11yText-A11yText"
+    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-g1d714-ValueContainer"
+        className=" css-319lph-ValueContainer"
       >
         <div
-          className=" css-1269n2i-placeholder"
+          className=" css-858797-placeholder"
+          id="react-select-10-placeholder"
         >
           Select...
         </div>
         <input
           aria-autocomplete="list"
+          aria-describedby="react-select-10-placeholder"
+          aria-expanded={false}
+          aria-haspopup={true}
           aria-labelledby="select-label"
-          className="css-62g3xt-dummyInput"
+          aria-readonly={true}
+          className="css-mohuvp-dummyInput-DummyInput"
           disabled={false}
           id="react-select-10-input"
+          inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          readOnly={true}
-          tabIndex="0"
+          role="combobox"
+          tabIndex={0}
           value=""
         />
       </div>
@@ -8249,7 +8392,7 @@ exports[`Storyshots Components/Selects/Single Multi Select 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-6q0nyr-Svg"
+            className="css-tj5bde-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"
@@ -8275,79 +8418,74 @@ exports[`Storyshots Components/Selects/Single Searchable 1`] = `
   }
 >
   <div
-    className="SingleSelect css-2b097c-container"
+    className="SingleSelect css-b62m3t-container"
     onKeyDown={[Function]}
   >
+    <span
+      className="css-1f43avz-a11yText-A11yText"
+      id="react-select-7-live-region"
+    />
+    <span
+      aria-atomic="false"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className="css-1f43avz-a11yText-A11yText"
+    />
     <div
       className=" css-15ub2n0-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
-        className=" css-g1d714-ValueContainer"
+        className=" css-319lph-ValueContainer"
       >
         <div
-          className=" css-1269n2i-placeholder"
+          className=" css-858797-placeholder"
+          id="react-select-7-placeholder"
         >
           Select...
         </div>
         <div
-          className="css-b8ldur-Input"
+          className=" css-6j8wv5-Input"
+          data-value=""
         >
-          <div
+          <input
+            aria-autocomplete="list"
+            aria-describedby="react-select-7-placeholder"
+            aria-expanded={false}
+            aria-haspopup={true}
+            aria-label="Searchable select"
+            autoCapitalize="none"
+            autoComplete="off"
+            autoCorrect="off"
             className=""
+            disabled={false}
+            id="react-select-7-input"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            role="combobox"
+            spellCheck="false"
             style={
               Object {
-                "display": "inline-block",
+                "background": 0,
+                "border": 0,
+                "color": "inherit",
+                "font": "inherit",
+                "gridArea": "1 / 2",
+                "label": "input",
+                "margin": 0,
+                "minWidth": "2px",
+                "opacity": 1,
+                "outline": 0,
+                "padding": 0,
+                "width": "100%",
               }
             }
-          >
-            <input
-              aria-autocomplete="list"
-              aria-label="Searchable select"
-              autoCapitalize="none"
-              autoComplete="off"
-              autoCorrect="off"
-              disabled={false}
-              id="react-select-7-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              spellCheck="false"
-              style={
-                Object {
-                  "background": 0,
-                  "border": 0,
-                  "boxSizing": "content-box",
-                  "color": "inherit",
-                  "fontSize": "inherit",
-                  "label": "input",
-                  "opacity": 1,
-                  "outline": 0,
-                  "padding": 0,
-                  "width": "1px",
-                }
-              }
-              tabIndex="0"
-              type="text"
-              value=""
-            />
-            <div
-              style={
-                Object {
-                  "height": 0,
-                  "left": 0,
-                  "overflow": "scroll",
-                  "position": "absolute",
-                  "top": 0,
-                  "visibility": "hidden",
-                  "whiteSpace": "pre",
-                }
-              }
-            >
-              
-            </div>
-          </div>
+            tabIndex={0}
+            type="text"
+            value=""
+          />
         </div>
       </div>
       <div
@@ -8364,7 +8502,7 @@ exports[`Storyshots Components/Selects/Single Searchable 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="css-6q0nyr-Svg"
+            className="css-tj5bde-Svg"
             focusable="false"
             height={20}
             viewBox="0 0 20 20"

--- a/src/Button/Button.mdx
+++ b/src/Button/Button.mdx
@@ -80,6 +80,13 @@ import { ArgsTable, Story, Canvas } from '@storybook/addon-docs/blocks';
   <Story id="components-button--transparent" />
 </Preview>
 
+### Link
+- A button that is styled like a link
+
+<Preview>
+  <Story id="components-button--link" />
+</Preview>
+
 ### Brands
 - Usually used for authentication purposes with different brands
 

--- a/src/Button/Button.scss
+++ b/src/Button/Button.scss
@@ -64,4 +64,8 @@
   &.btn-brand-twitter {
     @include btn-brand-twitter;
   }
+
+  &.btn-link {
+    @include btn-link;
+  }
 }

--- a/src/Button/Buttons.stories.jsx
+++ b/src/Button/Buttons.stories.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import Button from 'src/Button';
-import { faFileAlt, faCaretDown } from '@fortawesome/pro-regular-svg-icons';
+import { faFileAlt, faCaretDown, faPaperPlane } from '@fortawesome/pro-regular-svg-icons';
 import {
  faGoogle, faFacebook, faLinkedin, faTwitter,
 } from '@fortawesome/free-brands-svg-icons';
@@ -253,6 +253,33 @@ export const Transparent = () => (
       variant="transparent"
     >
       Skip
+    </Button>
+  </>
+);
+
+export const Link = () => (
+  <>
+    <Button
+      size="sm"
+      variant="link"
+    >
+      Send
+    </Button>
+    {' '}
+    <Button
+      leadingIcon={faPaperPlane}
+      size="sm"
+      variant="link"
+    >
+      Send
+    </Button>
+    {' '}
+    <Button
+      disabled
+      size="sm"
+      variant="link"
+    >
+      Send
     </Button>
   </>
 );


### PR DESCRIPTION
closes #653 

Added a "Link" variant to the Button component. For cases where you need a `button` but just needed it styled like a link. Similar to adding a className of `btn-link` to a `<button>` on rails-server

By default:
- no underline
- underline appears only on hover
- `color: $ux-blue`
- hover color: `color: $ux-blue-600`
- disabled state: `opacity: 0.5`

https://user-images.githubusercontent.com/37383785/177643505-416cb658-1397-462f-857d-c2e743c2fdad.mov

`