### PR TITLE
updates to Accordion v2

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -996,6 +996,462 @@ exports[`Storyshots Components/Accordion Flush 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Accordion In Card 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <p>
+    This Accordion is wrapped in a 
+    <code>
+      noPadding
+    </code>
+     Card
+  </p>
+  <p>
+    The Accordion has borders by default
+  </p>
+  <section
+    className="Card Card--lg Card--no-padding"
+  >
+    <div
+      className="Accordion accordion"
+    >
+      <div
+        className="AccordionItem accordion-item"
+      >
+        <button
+          className="AccordionToggle collapsed"
+          onClick={[Function]}
+          type="button"
+        >
+          <div
+            className="AccordionToggle__container"
+          >
+            <div
+              className="AccordionToggle__container--left"
+            >
+              <span
+                className="AccordionToggle__leading-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-credit-card fa-w-18 "
+                  data-icon="credit-card"
+                  data-prefix="far"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 576 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M527.9 32H48.1C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48.1 48h479.8c26.6 0 48.1-21.5 48.1-48V80c0-26.5-21.5-48-48.1-48zM54.1 80h467.8c3.3 0 6 2.7 6 6v42H48.1V86c0-3.3 2.7-6 6-6zm467.8 352H54.1c-3.3 0-6-2.7-6-6V256h479.8v170c0 3.3-2.7 6-6 6zM192 332v40c0 6.6-5.4 12-12 12h-72c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h72c6.6 0 12 5.4 12 12zm192 0v40c0 6.6-5.4 12-12 12H236c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h136c6.6 0 12 5.4 12 12z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
+              <span
+                className="AccordionToggle__title"
+              >
+                Accordion Toggle #1
+              </span>
+              <span
+                className="AccordionToggle__helper-text"
+              >
+                (
+                helper text
+                )
+              </span>
+            </div>
+            <div
+              className="AccordionToggle__container--right"
+            >
+              <span
+                className="AccordionToggle__label"
+              >
+                3 Items Selected
+              </span>
+              <span
+                className="AccordionToggle__chevron-right"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-chevron-up fa-w-14 "
+                  data-icon="chevron-up"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </button>
+        <div
+          aria-expanded={null}
+          className="AccordionCollapse accordion-collapse collapse"
+        >
+          <div
+            className="AccordionCollapse__container"
+          >
+            <ul>
+              <li>
+                Item 1
+              </li>
+              <li>
+                Item 2
+              </li>
+              <li>
+                Item 3
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div
+        className="AccordionItem accordion-item"
+      >
+        <button
+          className="AccordionToggle collapsed"
+          onClick={[Function]}
+          type="button"
+        >
+          <div
+            className="AccordionToggle__container"
+          >
+            <div
+              className="AccordionToggle__container--left"
+            >
+              <span
+                className="AccordionToggle__leading-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-credit-card fa-w-18 "
+                  data-icon="credit-card"
+                  data-prefix="far"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 576 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M527.9 32H48.1C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48.1 48h479.8c26.6 0 48.1-21.5 48.1-48V80c0-26.5-21.5-48-48.1-48zM54.1 80h467.8c3.3 0 6 2.7 6 6v42H48.1V86c0-3.3 2.7-6 6-6zm467.8 352H54.1c-3.3 0-6-2.7-6-6V256h479.8v170c0 3.3-2.7 6-6 6zM192 332v40c0 6.6-5.4 12-12 12h-72c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h72c6.6 0 12 5.4 12 12zm192 0v40c0 6.6-5.4 12-12 12H236c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h136c6.6 0 12 5.4 12 12z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
+              <span
+                className="AccordionToggle__title"
+              >
+                Accordion Toggle #2
+              </span>
+              <span
+                className="AccordionToggle__helper-text"
+              >
+                (
+                helper text
+                )
+              </span>
+            </div>
+            <div
+              className="AccordionToggle__container--right"
+            >
+              <span
+                className="AccordionToggle__label"
+              >
+                3 Items Selected
+              </span>
+              <span
+                className="AccordionToggle__chevron-right"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-chevron-up fa-w-14 "
+                  data-icon="chevron-up"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </button>
+        <div
+          aria-expanded={null}
+          className="AccordionCollapse accordion-collapse collapse"
+        >
+          <div
+            className="AccordionCollapse__container"
+          >
+            <ul>
+              <li>
+                Item 1
+              </li>
+              <li>
+                Item 2
+              </li>
+              <li>
+                Item 3
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <br />
+  <p>
+    This Accordion is wrapped in a 
+    <code>
+      noPadding
+    </code>
+     Card
+  </p>
+  <p>
+    The Accordion has a 
+    <code>
+      flush
+    </code>
+     prop, so no borders and is edge to edge with the parent Card
+  </p>
+  <section
+    className="Card Card--lg Card--no-padding"
+  >
+    <div
+      className="Accordion accordion accordion-flush"
+    >
+      <div
+        className="AccordionItem accordion-item"
+      >
+        <button
+          className="AccordionToggle collapsed"
+          onClick={[Function]}
+          type="button"
+        >
+          <div
+            className="AccordionToggle__container"
+          >
+            <div
+              className="AccordionToggle__container--left"
+            >
+              <span
+                className="AccordionToggle__leading-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-credit-card fa-w-18 "
+                  data-icon="credit-card"
+                  data-prefix="far"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 576 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M527.9 32H48.1C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48.1 48h479.8c26.6 0 48.1-21.5 48.1-48V80c0-26.5-21.5-48-48.1-48zM54.1 80h467.8c3.3 0 6 2.7 6 6v42H48.1V86c0-3.3 2.7-6 6-6zm467.8 352H54.1c-3.3 0-6-2.7-6-6V256h479.8v170c0 3.3-2.7 6-6 6zM192 332v40c0 6.6-5.4 12-12 12h-72c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h72c6.6 0 12 5.4 12 12zm192 0v40c0 6.6-5.4 12-12 12H236c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h136c6.6 0 12 5.4 12 12z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
+              <span
+                className="AccordionToggle__title"
+              >
+                Accordion Toggle #1
+              </span>
+              <span
+                className="AccordionToggle__helper-text"
+              >
+                (
+                helper text
+                )
+              </span>
+            </div>
+            <div
+              className="AccordionToggle__container--right"
+            >
+              <span
+                className="AccordionToggle__label"
+              >
+                3 Items Selected
+              </span>
+              <span
+                className="AccordionToggle__chevron-right"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-chevron-up fa-w-14 "
+                  data-icon="chevron-up"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </button>
+        <div
+          aria-expanded={null}
+          className="AccordionCollapse accordion-collapse collapse"
+        >
+          <div
+            className="AccordionCollapse__container"
+          >
+            <ul>
+              <li>
+                Item 1
+              </li>
+              <li>
+                Item 2
+              </li>
+              <li>
+                Item 3
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div
+        className="AccordionItem accordion-item"
+      >
+        <button
+          className="AccordionToggle collapsed"
+          onClick={[Function]}
+          type="button"
+        >
+          <div
+            className="AccordionToggle__container"
+          >
+            <div
+              className="AccordionToggle__container--left"
+            >
+              <span
+                className="AccordionToggle__leading-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-credit-card fa-w-18 "
+                  data-icon="credit-card"
+                  data-prefix="far"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 576 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M527.9 32H48.1C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48.1 48h479.8c26.6 0 48.1-21.5 48.1-48V80c0-26.5-21.5-48-48.1-48zM54.1 80h467.8c3.3 0 6 2.7 6 6v42H48.1V86c0-3.3 2.7-6 6-6zm467.8 352H54.1c-3.3 0-6-2.7-6-6V256h479.8v170c0 3.3-2.7 6-6 6zM192 332v40c0 6.6-5.4 12-12 12h-72c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h72c6.6 0 12 5.4 12 12zm192 0v40c0 6.6-5.4 12-12 12H236c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h136c6.6 0 12 5.4 12 12z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
+              <span
+                className="AccordionToggle__title"
+              >
+                Accordion Toggle #2
+              </span>
+              <span
+                className="AccordionToggle__helper-text"
+              >
+                (
+                helper text
+                )
+              </span>
+            </div>
+            <div
+              className="AccordionToggle__container--right"
+            >
+              <span
+                className="AccordionToggle__label"
+              >
+                3 Items Selected
+              </span>
+              <span
+                className="AccordionToggle__chevron-right"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-chevron-up fa-w-14 "
+                  data-icon="chevron-up"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </button>
+        <div
+          aria-expanded={null}
+          className="AccordionCollapse accordion-collapse collapse"
+        >
+          <div
+            className="AccordionCollapse__container"
+          >
+            <ul>
+              <li>
+                Item 1
+              </li>
+              <li>
+                Item 2
+              </li>
+              <li>
+                Item 3
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+`;
+
 exports[`Storyshots Components/Accordion Separate 1`] = `
 <div
   style={

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -1,5 +1,222 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Components/Accordion Borderless 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="Accordion accordion"
+  >
+    <div
+      className="AccordionItem AccordionItem--borderless accordion-item"
+    >
+      <button
+        className="AccordionToggle collapsed"
+        onClick={[Function]}
+        type="button"
+      >
+        <div
+          className="AccordionToggle__container"
+        >
+          <div
+            className="AccordionToggle__container--left"
+          >
+            <span
+              className="AccordionToggle__leading-icon"
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-credit-card fa-w-18 "
+                data-icon="credit-card"
+                data-prefix="far"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 576 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M527.9 32H48.1C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48.1 48h479.8c26.6 0 48.1-21.5 48.1-48V80c0-26.5-21.5-48-48.1-48zM54.1 80h467.8c3.3 0 6 2.7 6 6v42H48.1V86c0-3.3 2.7-6 6-6zm467.8 352H54.1c-3.3 0-6-2.7-6-6V256h479.8v170c0 3.3-2.7 6-6 6zM192 332v40c0 6.6-5.4 12-12 12h-72c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h72c6.6 0 12 5.4 12 12zm192 0v40c0 6.6-5.4 12-12 12H236c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h136c6.6 0 12 5.4 12 12z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </span>
+            <span
+              className="AccordionToggle__title"
+            >
+              Accordion Toggle #1
+            </span>
+            <span
+              className="AccordionToggle__helper-text"
+            >
+              (
+              helper text
+              )
+            </span>
+          </div>
+          <div
+            className="AccordionToggle__container--right"
+          >
+            <span
+              className="AccordionToggle__label"
+            >
+              3 Items Selected
+            </span>
+            <span
+              className="AccordionToggle__chevron-right"
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-chevron-up fa-w-14 "
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </span>
+          </div>
+        </div>
+      </button>
+      <div
+        aria-expanded={null}
+        className="AccordionCollapse accordion-collapse collapse"
+      >
+        <div
+          className="AccordionCollapse__container"
+        >
+          <ul>
+            <li>
+              Item 1
+            </li>
+            <li>
+              Item 2
+            </li>
+            <li>
+              Item 3
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div
+      className="AccordionItem AccordionItem--borderless accordion-item"
+    >
+      <button
+        className="AccordionToggle collapsed"
+        onClick={[Function]}
+        type="button"
+      >
+        <div
+          className="AccordionToggle__container"
+        >
+          <div
+            className="AccordionToggle__container--left"
+          >
+            <span
+              className="AccordionToggle__leading-icon"
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-credit-card fa-w-18 "
+                data-icon="credit-card"
+                data-prefix="far"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 576 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M527.9 32H48.1C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48.1 48h479.8c26.6 0 48.1-21.5 48.1-48V80c0-26.5-21.5-48-48.1-48zM54.1 80h467.8c3.3 0 6 2.7 6 6v42H48.1V86c0-3.3 2.7-6 6-6zm467.8 352H54.1c-3.3 0-6-2.7-6-6V256h479.8v170c0 3.3-2.7 6-6 6zM192 332v40c0 6.6-5.4 12-12 12h-72c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h72c6.6 0 12 5.4 12 12zm192 0v40c0 6.6-5.4 12-12 12H236c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h136c6.6 0 12 5.4 12 12z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </span>
+            <span
+              className="AccordionToggle__title"
+            >
+              Accordion Toggle #2
+            </span>
+            <span
+              className="AccordionToggle__helper-text"
+            >
+              (
+              helper text
+              )
+            </span>
+          </div>
+          <div
+            className="AccordionToggle__container--right"
+          >
+            <span
+              className="AccordionToggle__label"
+            >
+              3 Items Selected
+            </span>
+            <span
+              className="AccordionToggle__chevron-right"
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-chevron-up fa-w-14 "
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </span>
+          </div>
+        </div>
+      </button>
+      <div
+        aria-expanded={null}
+        className="AccordionCollapse accordion-collapse collapse"
+      >
+        <div
+          className="AccordionCollapse__container"
+        >
+          <ul>
+            <li>
+              Item 1
+            </li>
+            <li>
+              Item 2
+            </li>
+            <li>
+              Item 3
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Components/Accordion Chevron Left 1`] = `
 <div
   style={
@@ -779,223 +996,6 @@ exports[`Storyshots Components/Accordion Disabled 1`] = `
 </div>
 `;
 
-exports[`Storyshots Components/Accordion Flush 1`] = `
-<div
-  style={
-    Object {
-      "padding": "1rem",
-    }
-  }
->
-  <div
-    className="Accordion accordion accordion-flush"
-  >
-    <div
-      className="AccordionItem accordion-item"
-    >
-      <button
-        className="AccordionToggle collapsed"
-        onClick={[Function]}
-        type="button"
-      >
-        <div
-          className="AccordionToggle__container"
-        >
-          <div
-            className="AccordionToggle__container--left"
-          >
-            <span
-              className="AccordionToggle__leading-icon"
-            >
-              <svg
-                aria-hidden="true"
-                className="svg-inline--fa fa-credit-card fa-w-18 "
-                data-icon="credit-card"
-                data-prefix="far"
-                focusable="false"
-                role="img"
-                style={Object {}}
-                viewBox="0 0 576 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M527.9 32H48.1C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48.1 48h479.8c26.6 0 48.1-21.5 48.1-48V80c0-26.5-21.5-48-48.1-48zM54.1 80h467.8c3.3 0 6 2.7 6 6v42H48.1V86c0-3.3 2.7-6 6-6zm467.8 352H54.1c-3.3 0-6-2.7-6-6V256h479.8v170c0 3.3-2.7 6-6 6zM192 332v40c0 6.6-5.4 12-12 12h-72c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h72c6.6 0 12 5.4 12 12zm192 0v40c0 6.6-5.4 12-12 12H236c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h136c6.6 0 12 5.4 12 12z"
-                  fill="currentColor"
-                  style={Object {}}
-                />
-              </svg>
-            </span>
-            <span
-              className="AccordionToggle__title"
-            >
-              Accordion Toggle #1
-            </span>
-            <span
-              className="AccordionToggle__helper-text"
-            >
-              (
-              helper text
-              )
-            </span>
-          </div>
-          <div
-            className="AccordionToggle__container--right"
-          >
-            <span
-              className="AccordionToggle__label"
-            >
-              3 Items Selected
-            </span>
-            <span
-              className="AccordionToggle__chevron-right"
-            >
-              <svg
-                aria-hidden="true"
-                className="svg-inline--fa fa-chevron-up fa-w-14 "
-                data-icon="chevron-up"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                style={Object {}}
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
-                  fill="currentColor"
-                  style={Object {}}
-                />
-              </svg>
-            </span>
-          </div>
-        </div>
-      </button>
-      <div
-        aria-expanded={null}
-        className="AccordionCollapse accordion-collapse collapse"
-      >
-        <div
-          className="AccordionCollapse__container"
-        >
-          <ul>
-            <li>
-              Item 1
-            </li>
-            <li>
-              Item 2
-            </li>
-            <li>
-              Item 3
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
-    <div
-      className="AccordionItem accordion-item"
-    >
-      <button
-        className="AccordionToggle collapsed"
-        onClick={[Function]}
-        type="button"
-      >
-        <div
-          className="AccordionToggle__container"
-        >
-          <div
-            className="AccordionToggle__container--left"
-          >
-            <span
-              className="AccordionToggle__leading-icon"
-            >
-              <svg
-                aria-hidden="true"
-                className="svg-inline--fa fa-credit-card fa-w-18 "
-                data-icon="credit-card"
-                data-prefix="far"
-                focusable="false"
-                role="img"
-                style={Object {}}
-                viewBox="0 0 576 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M527.9 32H48.1C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48.1 48h479.8c26.6 0 48.1-21.5 48.1-48V80c0-26.5-21.5-48-48.1-48zM54.1 80h467.8c3.3 0 6 2.7 6 6v42H48.1V86c0-3.3 2.7-6 6-6zm467.8 352H54.1c-3.3 0-6-2.7-6-6V256h479.8v170c0 3.3-2.7 6-6 6zM192 332v40c0 6.6-5.4 12-12 12h-72c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h72c6.6 0 12 5.4 12 12zm192 0v40c0 6.6-5.4 12-12 12H236c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h136c6.6 0 12 5.4 12 12z"
-                  fill="currentColor"
-                  style={Object {}}
-                />
-              </svg>
-            </span>
-            <span
-              className="AccordionToggle__title"
-            >
-              Accordion Toggle #2
-            </span>
-            <span
-              className="AccordionToggle__helper-text"
-            >
-              (
-              helper text
-              )
-            </span>
-          </div>
-          <div
-            className="AccordionToggle__container--right"
-          >
-            <span
-              className="AccordionToggle__label"
-            >
-              3 Items Selected
-            </span>
-            <span
-              className="AccordionToggle__chevron-right"
-            >
-              <svg
-                aria-hidden="true"
-                className="svg-inline--fa fa-chevron-up fa-w-14 "
-                data-icon="chevron-up"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                style={Object {}}
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
-                  fill="currentColor"
-                  style={Object {}}
-                />
-              </svg>
-            </span>
-          </div>
-        </div>
-      </button>
-      <div
-        aria-expanded={null}
-        className="AccordionCollapse accordion-collapse collapse"
-      >
-        <div
-          className="AccordionCollapse__container"
-        >
-          <ul>
-            <li>
-              Item 1
-            </li>
-            <li>
-              Item 2
-            </li>
-            <li>
-              Item 3
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Storyshots Components/Accordion In Card 1`] = `
 <div
   style={
@@ -1004,16 +1004,6 @@ exports[`Storyshots Components/Accordion In Card 1`] = `
     }
   }
 >
-  <p>
-    This Accordion is wrapped in a 
-    <code>
-      noPadding
-    </code>
-     Card
-  </p>
-  <p>
-    The Accordion has borders by default
-  </p>
   <section
     className="Card Card--lg Card--no-padding"
   >
@@ -1021,7 +1011,7 @@ exports[`Storyshots Components/Accordion In Card 1`] = `
       className="Accordion accordion"
     >
       <div
-        className="AccordionItem accordion-item"
+        className="AccordionItem AccordionItem--borderless accordion-item"
       >
         <button
           className="AccordionToggle collapsed"
@@ -1059,332 +1049,6 @@ exports[`Storyshots Components/Accordion In Card 1`] = `
                 className="AccordionToggle__title"
               >
                 Accordion Toggle #1
-              </span>
-              <span
-                className="AccordionToggle__helper-text"
-              >
-                (
-                helper text
-                )
-              </span>
-            </div>
-            <div
-              className="AccordionToggle__container--right"
-            >
-              <span
-                className="AccordionToggle__label"
-              >
-                3 Items Selected
-              </span>
-              <span
-                className="AccordionToggle__chevron-right"
-              >
-                <svg
-                  aria-hidden="true"
-                  className="svg-inline--fa fa-chevron-up fa-w-14 "
-                  data-icon="chevron-up"
-                  data-prefix="fas"
-                  focusable="false"
-                  role="img"
-                  style={Object {}}
-                  viewBox="0 0 448 512"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
-                    fill="currentColor"
-                    style={Object {}}
-                  />
-                </svg>
-              </span>
-            </div>
-          </div>
-        </button>
-        <div
-          aria-expanded={null}
-          className="AccordionCollapse accordion-collapse collapse"
-        >
-          <div
-            className="AccordionCollapse__container"
-          >
-            <ul>
-              <li>
-                Item 1
-              </li>
-              <li>
-                Item 2
-              </li>
-              <li>
-                Item 3
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
-      <div
-        className="AccordionItem accordion-item"
-      >
-        <button
-          className="AccordionToggle collapsed"
-          onClick={[Function]}
-          type="button"
-        >
-          <div
-            className="AccordionToggle__container"
-          >
-            <div
-              className="AccordionToggle__container--left"
-            >
-              <span
-                className="AccordionToggle__leading-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  className="svg-inline--fa fa-credit-card fa-w-18 "
-                  data-icon="credit-card"
-                  data-prefix="far"
-                  focusable="false"
-                  role="img"
-                  style={Object {}}
-                  viewBox="0 0 576 512"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M527.9 32H48.1C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48.1 48h479.8c26.6 0 48.1-21.5 48.1-48V80c0-26.5-21.5-48-48.1-48zM54.1 80h467.8c3.3 0 6 2.7 6 6v42H48.1V86c0-3.3 2.7-6 6-6zm467.8 352H54.1c-3.3 0-6-2.7-6-6V256h479.8v170c0 3.3-2.7 6-6 6zM192 332v40c0 6.6-5.4 12-12 12h-72c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h72c6.6 0 12 5.4 12 12zm192 0v40c0 6.6-5.4 12-12 12H236c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h136c6.6 0 12 5.4 12 12z"
-                    fill="currentColor"
-                    style={Object {}}
-                  />
-                </svg>
-              </span>
-              <span
-                className="AccordionToggle__title"
-              >
-                Accordion Toggle #2
-              </span>
-              <span
-                className="AccordionToggle__helper-text"
-              >
-                (
-                helper text
-                )
-              </span>
-            </div>
-            <div
-              className="AccordionToggle__container--right"
-            >
-              <span
-                className="AccordionToggle__label"
-              >
-                3 Items Selected
-              </span>
-              <span
-                className="AccordionToggle__chevron-right"
-              >
-                <svg
-                  aria-hidden="true"
-                  className="svg-inline--fa fa-chevron-up fa-w-14 "
-                  data-icon="chevron-up"
-                  data-prefix="fas"
-                  focusable="false"
-                  role="img"
-                  style={Object {}}
-                  viewBox="0 0 448 512"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
-                    fill="currentColor"
-                    style={Object {}}
-                  />
-                </svg>
-              </span>
-            </div>
-          </div>
-        </button>
-        <div
-          aria-expanded={null}
-          className="AccordionCollapse accordion-collapse collapse"
-        >
-          <div
-            className="AccordionCollapse__container"
-          >
-            <ul>
-              <li>
-                Item 1
-              </li>
-              <li>
-                Item 2
-              </li>
-              <li>
-                Item 3
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-  <br />
-  <p>
-    This Accordion is wrapped in a 
-    <code>
-      noPadding
-    </code>
-     Card
-  </p>
-  <p>
-    The Accordion has a 
-    <code>
-      flush
-    </code>
-     prop, so no borders and is edge to edge with the parent Card
-  </p>
-  <section
-    className="Card Card--lg Card--no-padding"
-  >
-    <div
-      className="Accordion accordion accordion-flush"
-    >
-      <div
-        className="AccordionItem accordion-item"
-      >
-        <button
-          className="AccordionToggle collapsed"
-          onClick={[Function]}
-          type="button"
-        >
-          <div
-            className="AccordionToggle__container"
-          >
-            <div
-              className="AccordionToggle__container--left"
-            >
-              <span
-                className="AccordionToggle__leading-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  className="svg-inline--fa fa-credit-card fa-w-18 "
-                  data-icon="credit-card"
-                  data-prefix="far"
-                  focusable="false"
-                  role="img"
-                  style={Object {}}
-                  viewBox="0 0 576 512"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M527.9 32H48.1C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48.1 48h479.8c26.6 0 48.1-21.5 48.1-48V80c0-26.5-21.5-48-48.1-48zM54.1 80h467.8c3.3 0 6 2.7 6 6v42H48.1V86c0-3.3 2.7-6 6-6zm467.8 352H54.1c-3.3 0-6-2.7-6-6V256h479.8v170c0 3.3-2.7 6-6 6zM192 332v40c0 6.6-5.4 12-12 12h-72c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h72c6.6 0 12 5.4 12 12zm192 0v40c0 6.6-5.4 12-12 12H236c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h136c6.6 0 12 5.4 12 12z"
-                    fill="currentColor"
-                    style={Object {}}
-                  />
-                </svg>
-              </span>
-              <span
-                className="AccordionToggle__title"
-              >
-                Accordion Toggle #1
-              </span>
-              <span
-                className="AccordionToggle__helper-text"
-              >
-                (
-                helper text
-                )
-              </span>
-            </div>
-            <div
-              className="AccordionToggle__container--right"
-            >
-              <span
-                className="AccordionToggle__label"
-              >
-                3 Items Selected
-              </span>
-              <span
-                className="AccordionToggle__chevron-right"
-              >
-                <svg
-                  aria-hidden="true"
-                  className="svg-inline--fa fa-chevron-up fa-w-14 "
-                  data-icon="chevron-up"
-                  data-prefix="fas"
-                  focusable="false"
-                  role="img"
-                  style={Object {}}
-                  viewBox="0 0 448 512"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
-                    fill="currentColor"
-                    style={Object {}}
-                  />
-                </svg>
-              </span>
-            </div>
-          </div>
-        </button>
-        <div
-          aria-expanded={null}
-          className="AccordionCollapse accordion-collapse collapse"
-        >
-          <div
-            className="AccordionCollapse__container"
-          >
-            <ul>
-              <li>
-                Item 1
-              </li>
-              <li>
-                Item 2
-              </li>
-              <li>
-                Item 3
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
-      <div
-        className="AccordionItem accordion-item"
-      >
-        <button
-          className="AccordionToggle collapsed"
-          onClick={[Function]}
-          type="button"
-        >
-          <div
-            className="AccordionToggle__container"
-          >
-            <div
-              className="AccordionToggle__container--left"
-            >
-              <span
-                className="AccordionToggle__leading-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  className="svg-inline--fa fa-credit-card fa-w-18 "
-                  data-icon="credit-card"
-                  data-prefix="far"
-                  focusable="false"
-                  role="img"
-                  style={Object {}}
-                  viewBox="0 0 576 512"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M527.9 32H48.1C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48.1 48h479.8c26.6 0 48.1-21.5 48.1-48V80c0-26.5-21.5-48-48.1-48zM54.1 80h467.8c3.3 0 6 2.7 6 6v42H48.1V86c0-3.3 2.7-6 6-6zm467.8 352H54.1c-3.3 0-6-2.7-6-6V256h479.8v170c0 3.3-2.7 6-6 6zM192 332v40c0 6.6-5.4 12-12 12h-72c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h72c6.6 0 12 5.4 12 12zm192 0v40c0 6.6-5.4 12-12 12H236c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h136c6.6 0 12 5.4 12 12z"
-                    fill="currentColor"
-                    style={Object {}}
-                  />
-                </svg>
-              </span>
-              <span
-                className="AccordionToggle__title"
-              >
-                Accordion Toggle #2
               </span>
               <span
                 className="AccordionToggle__helper-text"

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -9,7 +9,7 @@ exports[`Storyshots Components/Accordion Borderless 1`] = `
   }
 >
   <div
-    className="Accordion accordion"
+    className="Accordion accordion accordion-flush"
   >
     <div
       className="AccordionItem AccordionItem--borderless accordion-item"
@@ -1008,7 +1008,7 @@ exports[`Storyshots Components/Accordion In Card 1`] = `
     className="Card Card--lg Card--no-padding"
   >
     <div
-      className="Accordion accordion"
+      className="Accordion accordion accordion-flush"
     >
       <div
         className="AccordionItem AccordionItem--borderless accordion-item"

--- a/src/Accordion/Accordion.mdx
+++ b/src/Accordion/Accordion.mdx
@@ -43,10 +43,17 @@ import Accordion from './Accordion';
   <Story id="components-accordion--chevron-left" />
 </Canvas>
 
-### Flush
+### Borderless
 
 <Canvas>
-  <Story id="components-accordion--flush" />
+  <Story id="components-accordion--borderless" />
+</Canvas>
+
+### In Card
+- When wrapping `Accordion` in `Card`, make sure to provide a `borderless` prop to every `AccordionItem`
+
+<Canvas>
+  <Story id="components-accordion--in-card" />
 </Canvas>
 
 ### Separate

--- a/src/Accordion/Accordion.stories.jsx
+++ b/src/Accordion/Accordion.stories.jsx
@@ -7,6 +7,8 @@ import {
   AccordionCollapse,
 } from 'src/Accordion';
 
+import Card from 'src/Card';
+
 import { faCreditCard } from '@fortawesome/pro-regular-svg-icons';
 
 import mdx from './Accordion.mdx';
@@ -168,6 +170,90 @@ export const Flush = () => (
       </AccordionCollapse>
     </AccordionItem>
   </Accordion>
+);
+
+export const InCard = () => (
+  <>
+    <p>This Accordion is wrapped in a <code>noPadding</code> Card</p>
+    <p>The Accordion has borders by default</p>
+    <Card noPadding>
+      <Accordion>
+        <AccordionItem>
+          <AccordionToggle
+            eventKey="0"
+            helperText="helper text"
+            label="3 Items Selected"
+            leadingIcon={faCreditCard}
+            title="Accordion Toggle #1"
+          />
+          <AccordionCollapse eventKey="0">
+            <ul>
+              <li>Item 1</li>
+              <li>Item 2</li>
+              <li>Item 3</li>
+            </ul>
+          </AccordionCollapse>
+        </AccordionItem>
+        <AccordionItem>
+          <AccordionToggle
+            eventKey="1"
+            helperText="helper text"
+            label="3 Items Selected"
+            leadingIcon={faCreditCard}
+            title="Accordion Toggle #2"
+          />
+          <AccordionCollapse eventKey="1">
+            <ul>
+              <li>Item 1</li>
+              <li>Item 2</li>
+              <li>Item 3</li>
+            </ul>
+          </AccordionCollapse>
+        </AccordionItem>
+      </Accordion>
+    </Card>
+    <br />
+    <p>This Accordion is wrapped in a <code>noPadding</code> Card</p>
+    <p>The Accordion has a <code>flush</code> prop,
+      so no borders and is edge to edge with the parent Card
+    </p>
+    <Card noPadding>
+      <Accordion flush>
+        <AccordionItem>
+          <AccordionToggle
+            eventKey="0"
+            helperText="helper text"
+            label="3 Items Selected"
+            leadingIcon={faCreditCard}
+            title="Accordion Toggle #1"
+          />
+          <AccordionCollapse eventKey="0">
+            <ul>
+              <li>Item 1</li>
+              <li>Item 2</li>
+              <li>Item 3</li>
+            </ul>
+          </AccordionCollapse>
+        </AccordionItem>
+        <AccordionItem>
+          <AccordionToggle
+            eventKey="1"
+            helperText="helper text"
+            label="3 Items Selected"
+            leadingIcon={faCreditCard}
+            title="Accordion Toggle #2"
+          />
+          <AccordionCollapse eventKey="1">
+            <ul>
+              <li>Item 1</li>
+              <li>Item 2</li>
+              <li>Item 3</li>
+            </ul>
+          </AccordionCollapse>
+        </AccordionItem>
+      </Accordion>
+    </Card>
+  </>
 );
 
 export const Separate = () => (

--- a/src/Accordion/Accordion.stories.jsx
+++ b/src/Accordion/Accordion.stories.jsx
@@ -135,9 +135,9 @@ export const ChevronLeft = () => (
   </Accordion>
 );
 
-export const Flush = () => (
-  <Accordion flush>
-    <AccordionItem>
+export const Borderless = () => (
+  <Accordion>
+    <AccordionItem borderless>
       <AccordionToggle
         eventKey="0"
         helperText="helper text"
@@ -153,7 +153,7 @@ export const Flush = () => (
         </ul>
       </AccordionCollapse>
     </AccordionItem>
-    <AccordionItem>
+    <AccordionItem borderless>
       <AccordionToggle
         eventKey="1"
         helperText="helper text"
@@ -173,87 +173,26 @@ export const Flush = () => (
 );
 
 export const InCard = () => (
-  <>
-    <p>This Accordion is wrapped in a <code>noPadding</code> Card</p>
-    <p>The Accordion has borders by default</p>
-    <Card noPadding>
-      <Accordion>
-        <AccordionItem>
-          <AccordionToggle
-            eventKey="0"
-            helperText="helper text"
-            label="3 Items Selected"
-            leadingIcon={faCreditCard}
-            title="Accordion Toggle #1"
-          />
-          <AccordionCollapse eventKey="0">
-            <ul>
-              <li>Item 1</li>
-              <li>Item 2</li>
-              <li>Item 3</li>
-            </ul>
-          </AccordionCollapse>
-        </AccordionItem>
-        <AccordionItem>
-          <AccordionToggle
-            eventKey="1"
-            helperText="helper text"
-            label="3 Items Selected"
-            leadingIcon={faCreditCard}
-            title="Accordion Toggle #2"
-          />
-          <AccordionCollapse eventKey="1">
-            <ul>
-              <li>Item 1</li>
-              <li>Item 2</li>
-              <li>Item 3</li>
-            </ul>
-          </AccordionCollapse>
-        </AccordionItem>
-      </Accordion>
-    </Card>
-    <br />
-    <p>This Accordion is wrapped in a <code>noPadding</code> Card</p>
-    <p>The Accordion has a <code>flush</code> prop,
-      so no borders and is edge to edge with the parent Card
-    </p>
-    <Card noPadding>
-      <Accordion flush>
-        <AccordionItem>
-          <AccordionToggle
-            eventKey="0"
-            helperText="helper text"
-            label="3 Items Selected"
-            leadingIcon={faCreditCard}
-            title="Accordion Toggle #1"
-          />
-          <AccordionCollapse eventKey="0">
-            <ul>
-              <li>Item 1</li>
-              <li>Item 2</li>
-              <li>Item 3</li>
-            </ul>
-          </AccordionCollapse>
-        </AccordionItem>
-        <AccordionItem>
-          <AccordionToggle
-            eventKey="1"
-            helperText="helper text"
-            label="3 Items Selected"
-            leadingIcon={faCreditCard}
-            title="Accordion Toggle #2"
-          />
-          <AccordionCollapse eventKey="1">
-            <ul>
-              <li>Item 1</li>
-              <li>Item 2</li>
-              <li>Item 3</li>
-            </ul>
-          </AccordionCollapse>
-        </AccordionItem>
-      </Accordion>
-    </Card>
-  </>
+  <Card noPadding>
+    <Accordion>
+      <AccordionItem borderless>
+        <AccordionToggle
+          eventKey="0"
+          helperText="helper text"
+          label="3 Items Selected"
+          leadingIcon={faCreditCard}
+          title="Accordion Toggle #1"
+        />
+        <AccordionCollapse eventKey="0">
+          <ul>
+            <li>Item 1</li>
+            <li>Item 2</li>
+            <li>Item 3</li>
+          </ul>
+        </AccordionCollapse>
+      </AccordionItem>
+    </Accordion>
+  </Card>
 );
 
 export const Separate = () => (

--- a/src/Accordion/Accordion.stories.jsx
+++ b/src/Accordion/Accordion.stories.jsx
@@ -136,7 +136,7 @@ export const ChevronLeft = () => (
 );
 
 export const Borderless = () => (
-  <Accordion>
+  <Accordion flush>
     <AccordionItem borderless>
       <AccordionToggle
         eventKey="0"
@@ -174,7 +174,7 @@ export const Borderless = () => (
 
 export const InCard = () => (
   <Card noPadding>
-    <Accordion>
+    <Accordion flush>
       <AccordionItem borderless>
         <AccordionToggle
           eventKey="0"

--- a/src/Accordion/AccordionCollapse.scss
+++ b/src/Accordion/AccordionCollapse.scss
@@ -2,6 +2,8 @@
 
 .AccordionCollapse {
 
+  border-top: 1px solid $ux-gray-400;
+
   &__container {
     padding: 1rem;
   }

--- a/src/Accordion/AccordionItem.jsx
+++ b/src/Accordion/AccordionItem.jsx
@@ -6,9 +6,15 @@ import RBAccordionItem from 'react-bootstrap/AccordionItem';
 
 import './AccordionItem.scss';
 
-const AccordionItem = ({ children, className, ...props }) => (
+const AccordionItem = ({
+ borderless, children, className, ...props
+}) => (
   <RBAccordionItem
-    className={classNames(className, 'AccordionItem')}
+    className={classNames(
+      className,
+      'AccordionItem',
+      borderless && 'AccordionItem--borderless',
+    )}
     {...props}
   >
     { children }
@@ -16,10 +22,12 @@ const AccordionItem = ({ children, className, ...props }) => (
 );
 
 AccordionItem.propTypes = {
+  borderless: PropTypes.bool,
   className: PropTypes.string,
 };
 
 AccordionItem.defaultProps = {
+  borderless: undefined,
   className: undefined,
 };
 export default AccordionItem;

--- a/src/Accordion/AccordionItem.jsx
+++ b/src/Accordion/AccordionItem.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 
 import RBAccordionItem from 'react-bootstrap/AccordionItem';
 
+import './AccordionItem.scss';
+
 const AccordionItem = ({ children, className, ...props }) => (
   <RBAccordionItem
     className={classNames(className, 'AccordionItem')}

--- a/src/Accordion/AccordionItem.scss
+++ b/src/Accordion/AccordionItem.scss
@@ -13,4 +13,8 @@
     border-bottom-left-radius: $ux-border-radius;
     border-bottom-right-radius: $ux-border-radius;
   }
+
+  &--borderless {
+    border: none;
+  }
 }

--- a/src/Accordion/AccordionItem.scss
+++ b/src/Accordion/AccordionItem.scss
@@ -1,0 +1,16 @@
+@import '../../scss/theme';
+
+.AccordionItem {
+  background-color: $ux-white;
+  border: 1px solid $ux-gray-400;
+
+  &:first-of-type {
+    border-top-left-radius: $ux-border-radius;
+    border-top-right-radius: $ux-border-radius;
+  }
+
+  &:last-of-type {
+    border-bottom-left-radius: $ux-border-radius;
+    border-bottom-right-radius: $ux-border-radius;
+  }
+}

--- a/src/Accordion/AccordionToggle.scss
+++ b/src/Accordion/AccordionToggle.scss
@@ -9,7 +9,6 @@
     justify-content: space-between;
    
     padding: 1rem;
-    border-bottom: 1px solid $ux-gray-400;
 
     &--right {
       display: flex;


### PR DESCRIPTION
closes #670 

Some updates to the Accordion
- added story for wrapping Accordion in Card
- update borderless prop

*some weirdness with bootstrap overrides with `flush` prop when used on rails-server. Added `borderless` to handle our use case and works fine on `rails-server`. Just using `flush` here to showcase correctly on Storybook.

Build 23
https://www.chromatic.com/build?appId=62d040e741710e4f085e0647&number=23