### PR TITLE
[UIDS-695] Make labelTooltip prop type node

### DIFF
--- a/src/FormGroup/FormGroup.jsx
+++ b/src/FormGroup/FormGroup.jsx
@@ -126,7 +126,7 @@ FormGroup.propTypes = {
   labelClassName: PropTypes.string,
   labelHelperText: PropTypes.string,
   labelHtmlFor: PropTypes.string,
-  labelTooltip: PropTypes.string,
+  labelTooltip: PropTypes.node,
   required: PropTypes.bool,
 };
 


### PR DESCRIPTION
Closes #695 

It turns out there's a situation where we need type node in the `labelTooltip` prop. See warning in builder. I didn't add it :(
![image](https://user-images.githubusercontent.com/8353434/182156388-f4e36f21-998d-4c60-8c73-b3be2b866a3d.png)
