### PR TITLE
custom DropdownCard

### DIFF
--- a/scss/cards.scss
+++ b/scss/cards.scss
@@ -1,0 +1,7 @@
+$card-xs-spacing: 1rem;
+$card-sm-spacing: 1.25rem;
+$card-spacing: 1.5rem;
+$card-width: 56rem;
+$card-width-md: 40rem;
+$card-width-sm: 32rem;
+$card-width-xs: 15rem;

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -3,6 +3,7 @@
 @import './borders';
 @import './box_shadow';
 @import './buttons';
+@import './cards';
 @import './colors';
 @import './elevations';
 @import './inputs';

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -5045,7 +5045,7 @@ exports[`Storyshots Components/Dropdown Default 1`] = `
 </div>
 `;
 
-exports[`Storyshots Components/Dropdown Dropdown Menu Custom 1`] = `
+exports[`Storyshots Components/Dropdown Dropdown Menu Card 1`] = `
 <div
   style={
     Object {
@@ -5057,8 +5057,7 @@ exports[`Storyshots Components/Dropdown Dropdown Menu Custom 1`] = `
     style={
       Object {
         "display": "flex",
-        "flexDirection": "row",
-        "float": "right",
+        "justifyContent": "center",
       }
     }
   >
@@ -5068,14 +5067,9 @@ exports[`Storyshots Components/Dropdown Dropdown Menu Custom 1`] = `
       <button
         aria-expanded={false}
         aria-label="dropdown-toggle"
-        className="DropdownToggle DropdownToggle--no-caret btn btn-transparent"
+        className="DropdownToggle DropdownToggle--no-caret btn btn-outline-primary"
         disabled={false}
         onClick={[Function]}
-        style={
-          Object {
-            "color": "#158D71",
-          }
-        }
         type="button"
       >
         <svg
@@ -5096,78 +5090,6 @@ exports[`Storyshots Components/Dropdown Dropdown Menu Custom 1`] = `
           />
         </svg>
         Filter (8)
-      </button>
-    </div>
-    <div
-      className="Dropdown dropdown"
-    >
-      <button
-        aria-expanded={false}
-        aria-label="dropdown-toggle"
-        className="DropdownToggle dropdown-toggle btn btn-transparent"
-        disabled={false}
-        onClick={[Function]}
-        style={
-          Object {
-            "color": "#158D71",
-          }
-        }
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          className="svg-inline--fa fa-users fa-w-20 icon-left"
-          data-icon="users"
-          data-prefix="fas"
-          focusable="false"
-          role="img"
-          style={Object {}}
-          viewBox="0 0 640 512"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M96 224c35.3 0 64-28.7 64-64s-28.7-64-64-64-64 28.7-64 64 28.7 64 64 64zm448 0c35.3 0 64-28.7 64-64s-28.7-64-64-64-64 28.7-64 64 28.7 64 64 64zm32 32h-64c-17.6 0-33.5 7.1-45.1 18.6 40.3 22.1 68.9 62 75.1 109.4h66c17.7 0 32-14.3 32-32v-32c0-35.3-28.7-64-64-64zm-256 0c61.9 0 112-50.1 112-112S381.9 32 320 32 208 82.1 208 144s50.1 112 112 112zm76.8 32h-8.3c-20.8 10-43.9 16-68.5 16s-47.6-6-68.5-16h-8.3C179.6 288 128 339.6 128 403.2V432c0 26.5 21.5 48 48 48h288c26.5 0 48-21.5 48-48v-28.8c0-63.6-51.6-115.2-115.2-115.2zm-223.7-13.4C161.5 263.1 145.6 256 128 256H64c-35.3 0-64 28.7-64 64v32c0 17.7 14.3 32 32 32h65.9c6.3-47.4 34.9-87.3 75.2-109.4z"
-            fill="currentColor"
-            style={Object {}}
-          />
-        </svg>
-        Build
-      </button>
-    </div>
-    <div
-      className="Dropdown dropdown"
-    >
-      <button
-        aria-expanded={false}
-        aria-label="dropdown-toggle"
-        className="DropdownToggle dropdown-toggle btn btn-transparent"
-        disabled={false}
-        onClick={[Function]}
-        style={
-          Object {
-            "color": "#158D71",
-          }
-        }
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          className="svg-inline--fa fa-cog fa-w-16 icon-left"
-          data-icon="cog"
-          data-prefix="fas"
-          focusable="false"
-          role="img"
-          style={Object {}}
-          viewBox="0 0 512 512"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M487.4 315.7l-42.6-24.6c4.3-23.2 4.3-47 0-70.2l42.6-24.6c4.9-2.8 7.1-8.6 5.5-14-11.1-35.6-30-67.8-54.7-94.6-3.8-4.1-10-5.1-14.8-2.3L380.8 110c-17.9-15.4-38.5-27.3-60.8-35.1V25.8c0-5.6-3.9-10.5-9.4-11.7-36.7-8.2-74.3-7.8-109.2 0-5.5 1.2-9.4 6.1-9.4 11.7V75c-22.2 7.9-42.8 19.8-60.8 35.1L88.7 85.5c-4.9-2.8-11-1.9-14.8 2.3-24.7 26.7-43.6 58.9-54.7 94.6-1.7 5.4.6 11.2 5.5 14L67.3 221c-4.3 23.2-4.3 47 0 70.2l-42.6 24.6c-4.9 2.8-7.1 8.6-5.5 14 11.1 35.6 30 67.8 54.7 94.6 3.8 4.1 10 5.1 14.8 2.3l42.6-24.6c17.9 15.4 38.5 27.3 60.8 35.1v49.2c0 5.6 3.9 10.5 9.4 11.7 36.7 8.2 74.3 7.8 109.2 0 5.5-1.2 9.4-6.1 9.4-11.7v-49.2c22.2-7.9 42.8-19.8 60.8-35.1l42.6 24.6c4.9 2.8 11 1.9 14.8-2.3 24.7-26.7 43.6-58.9 54.7-94.6 1.5-5.5-.7-11.3-5.6-14.1zM256 336c-44.1 0-80-35.9-80-80s35.9-80 80-80 80 35.9 80 80-35.9 80-80 80z"
-            fill="currentColor"
-            style={Object {}}
-          />
-        </svg>
-        Manage
       </button>
     </div>
   </div>

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -5045,6 +5045,135 @@ exports[`Storyshots Components/Dropdown Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Dropdown Dropdown Menu Custom 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "display": "flex",
+        "flexDirection": "row",
+        "float": "right",
+      }
+    }
+  >
+    <div
+      className="Dropdown dropdown"
+    >
+      <button
+        aria-expanded={false}
+        aria-label="dropdown-toggle"
+        className="DropdownToggle DropdownToggle--no-caret btn btn-transparent"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          Object {
+            "color": "#158D71",
+          }
+        }
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-filter fa-w-16 icon-left"
+          data-icon="filter"
+          data-prefix="far"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M463.952 0H48.057C5.419 0-16.094 51.731 14.116 81.941L176 243.882V416c0 15.108 7.113 29.335 19.2 40l64 47.066c31.273 21.855 76.8 1.538 76.8-38.4V243.882L497.893 81.941C528.042 51.792 506.675 0 463.952 0zM288 224v240l-64-48V224L48 48h416L288 224z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+        Filter (8)
+      </button>
+    </div>
+    <div
+      className="Dropdown dropdown"
+    >
+      <button
+        aria-expanded={false}
+        aria-label="dropdown-toggle"
+        className="DropdownToggle dropdown-toggle btn btn-transparent"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          Object {
+            "color": "#158D71",
+          }
+        }
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-users fa-w-20 icon-left"
+          data-icon="users"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 640 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M96 224c35.3 0 64-28.7 64-64s-28.7-64-64-64-64 28.7-64 64 28.7 64 64 64zm448 0c35.3 0 64-28.7 64-64s-28.7-64-64-64-64 28.7-64 64 28.7 64 64 64zm32 32h-64c-17.6 0-33.5 7.1-45.1 18.6 40.3 22.1 68.9 62 75.1 109.4h66c17.7 0 32-14.3 32-32v-32c0-35.3-28.7-64-64-64zm-256 0c61.9 0 112-50.1 112-112S381.9 32 320 32 208 82.1 208 144s50.1 112 112 112zm76.8 32h-8.3c-20.8 10-43.9 16-68.5 16s-47.6-6-68.5-16h-8.3C179.6 288 128 339.6 128 403.2V432c0 26.5 21.5 48 48 48h288c26.5 0 48-21.5 48-48v-28.8c0-63.6-51.6-115.2-115.2-115.2zm-223.7-13.4C161.5 263.1 145.6 256 128 256H64c-35.3 0-64 28.7-64 64v32c0 17.7 14.3 32 32 32h65.9c6.3-47.4 34.9-87.3 75.2-109.4z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+        Build
+      </button>
+    </div>
+    <div
+      className="Dropdown dropdown"
+    >
+      <button
+        aria-expanded={false}
+        aria-label="dropdown-toggle"
+        className="DropdownToggle dropdown-toggle btn btn-transparent"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          Object {
+            "color": "#158D71",
+          }
+        }
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-cog fa-w-16 icon-left"
+          data-icon="cog"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M487.4 315.7l-42.6-24.6c4.3-23.2 4.3-47 0-70.2l42.6-24.6c4.9-2.8 7.1-8.6 5.5-14-11.1-35.6-30-67.8-54.7-94.6-3.8-4.1-10-5.1-14.8-2.3L380.8 110c-17.9-15.4-38.5-27.3-60.8-35.1V25.8c0-5.6-3.9-10.5-9.4-11.7-36.7-8.2-74.3-7.8-109.2 0-5.5 1.2-9.4 6.1-9.4 11.7V75c-22.2 7.9-42.8 19.8-60.8 35.1L88.7 85.5c-4.9-2.8-11-1.9-14.8 2.3-24.7 26.7-43.6 58.9-54.7 94.6-1.7 5.4.6 11.2 5.5 14L67.3 221c-4.3 23.2-4.3 47 0 70.2l-42.6 24.6c-4.9 2.8-7.1 8.6-5.5 14 11.1 35.6 30 67.8 54.7 94.6 3.8 4.1 10 5.1 14.8 2.3l42.6-24.6c17.9 15.4 38.5 27.3 60.8 35.1v49.2c0 5.6 3.9 10.5 9.4 11.7 36.7 8.2 74.3 7.8 109.2 0 5.5-1.2 9.4-6.1 9.4-11.7v-49.2c22.2-7.9 42.8-19.8 60.8-35.1l42.6 24.6c4.9 2.8 11 1.9 14.8-2.3 24.7-26.7 43.6-58.9 54.7-94.6 1.5-5.5-.7-11.3-5.6-14.1zM256 336c-44.1 0-80-35.9-80-80s35.9-80 80-80 80 35.9 80 80-35.9 80-80 80z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+        Manage
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Components/Dropdown Icon Default 1`] = `
 <div
   style={

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -1,13 +1,5 @@
 @import '../../scss/theme';
 
-$card-xs-spacing: 1rem;
-$card-sm-spacing: 1.25rem;
-$card-spacing: 1.5rem;
-$card-width: 56rem;
-$card-width-md: 40rem;
-$card-width-sm: 32rem;
-$card-width-xs: 15rem;
-
 .Card {
   background-color: $ux-white;
   border: none;

--- a/src/Dropdown/Dropdown.mdx
+++ b/src/Dropdown/Dropdown.mdx
@@ -37,6 +37,7 @@ Avoid the Dropdown component if:
 </Canvas>
 
 ### Sizes
+- Determines the size of the `<DropdownToggle>`
 
 <Canvas>
   <Story id="components-dropdown--sizes" />
@@ -60,6 +61,7 @@ Avoid the Dropdown component if:
 ### Dropdown Menu Card
 - Use when needing a dropdown menu with custom content.
 - Use the `align` prop to align the dropdown menu to a specified side of the container.
+- The `size` prop uses the same sizes as the `Card` component. 
 - Set `autoClose` to `false` if you want to keep the menu open and close only when clicking the dropdown toggle.
 
 <Canvas>

--- a/src/Dropdown/Dropdown.mdx
+++ b/src/Dropdown/Dropdown.mdx
@@ -57,6 +57,15 @@ Avoid the Dropdown component if:
   <Story id="components-dropdown--icon-swap" />
 </Canvas>
 
+### Dropdown Menu Card
+- Use when needing a dropdown menu with custom content.
+- Use the `align` prop to align the dropdown menu to a specified side of the container.
+- Set `autoClose` to `false` if you want to keep the menu open and close only when clicking the dropdown toggle.
+
+<Canvas>
+  <Story id="components-dropdown--dropdown-menu-card" />
+</Canvas>
+
 
 ## Formatting
 

--- a/src/Dropdown/Dropdown.stories.jsx
+++ b/src/Dropdown/Dropdown.stories.jsx
@@ -122,7 +122,6 @@ const DropdownMenuCustomContent = () => {
 
   return (
     <div style={{ minWidth: '450px' }}>
-      <p style={{ fontWeight: 700 }}>Filter on participants</p>
       <SingleSelect options={options1} />
       <div style={{ marginTop: '16px' }}>
         <SingleSelect options={options2} placeholder="Before" style={{ marginTop: '8px' }} />
@@ -152,7 +151,7 @@ export const DropdownMenuCard = () => (
         align={select('align', ['start', 'end'], 'end')}
         noPadding
       >
-        <DropdownCard>
+        <DropdownCard title="Filter on participants">
           {DropdownMenuCustomContent()}
         </DropdownCard>
       </DropdownMenu>

--- a/src/Dropdown/Dropdown.stories.jsx
+++ b/src/Dropdown/Dropdown.stories.jsx
@@ -3,9 +3,14 @@ import React from 'react';
 import {
  Dropdown, DropdownToggle, DropdownItem, DropdownMenu,
 } from 'src/Dropdown';
-import { faEllipsisV, faFileAlt } from '@fortawesome/pro-solid-svg-icons';
+import { SingleSelect } from 'src/Select';
+
+import {
+ faCog, faEllipsisV, faFileAlt, faUsers,
+} from '@fortawesome/pro-solid-svg-icons';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faFilter } from '@fortawesome/pro-regular-svg-icons';
 import mdx from './Dropdown.mdx';
 
 export default {
@@ -100,4 +105,64 @@ export const IconSwap = () => (
       </DropdownMenu>
     </Dropdown>
   </>
+);
+
+const DropdownMenuCustomContent = () => {
+  const options1 = [
+    { label: 'First project launched', value: 1 },
+    { label: 'Last project launched', value: 2 },
+  ];
+
+  const options2 = [
+    { label: 'Before', value: 1 },
+    { label: 'After', value: 2 },
+  ];
+
+  return (
+    <div style={{ padding: '24px', minWidth: '500px' }}>
+      <p style={{ fontWeight: 700 }}>Filter on participants</p>
+      <SingleSelect options={options1} />
+      <div style={{ marginTop: '16px' }}>
+        <SingleSelect options={options2} placeholder="Before" style={{ marginTop: '8px' }} />
+        <div style={{ marginTop: '16px' }}>...misc. content</div>
+        <div>Anything can be put in this custom DropdownMenu</div>
+      </div>
+    </div>
+  );
+};
+
+export const DropdownMenuCustom = () => (
+  <div style={{ display: 'flex', flexDirection: 'row', float: 'right' }}>
+    <Dropdown>
+      <DropdownToggle
+        removeCaret
+        style={{ color: '#158D71' }}
+        variant="transparent"
+      >
+        <FontAwesomeIcon className="icon-left" icon={faFilter} />
+        Filter (8)
+      </DropdownToggle>
+      <DropdownMenu
+        align="end"
+        style={{
+          border: '1px solid #e1e1e1',
+          boxShadow: '0rem 0.13rem 0.3rem rgba(0, 0, 0, 0.1)',
+        }}
+      >
+        {DropdownMenuCustomContent()}
+      </DropdownMenu>
+    </Dropdown>
+    <Dropdown>
+      <DropdownToggle style={{ color: '#158D71' }} variant="transparent">
+        <FontAwesomeIcon className="icon-left" icon={faUsers} />
+        Build
+      </DropdownToggle>
+    </Dropdown>
+    <Dropdown>
+      <DropdownToggle style={{ color: '#158D71' }} variant="transparent">
+        <FontAwesomeIcon className="icon-left" icon={faCog} />
+        Manage
+      </DropdownToggle>
+    </Dropdown>
+  </div>
 );

--- a/src/Dropdown/Dropdown.stories.jsx
+++ b/src/Dropdown/Dropdown.stories.jsx
@@ -2,11 +2,10 @@ import React from 'react';
 
 import { boolean, select, withKnobs } from '@storybook/addon-knobs';
 
-import Button from 'src/Button';
+import { CardSizes } from 'src/Card';
 import {
  Dropdown, DropdownToggle, DropdownItem, DropdownMenu, DropdownCard,
 } from 'src/Dropdown';
-import { SingleSelect } from 'src/Select';
 
 import { faEllipsisV, faFileAlt } from '@fortawesome/pro-solid-svg-icons';
 
@@ -109,34 +108,6 @@ export const IconSwap = () => (
   </>
 );
 
-const DropdownMenuCustomContent = () => {
-  const options1 = [
-    { label: 'First project launched', value: 1 },
-    { label: 'Last project launched', value: 2 },
-  ];
-
-  const options2 = [
-    { label: 'Before', value: 1 },
-    { label: 'After', value: 2 },
-  ];
-
-  return (
-    <div style={{ minWidth: '450px' }}>
-      <SingleSelect options={options1} />
-      <div style={{ marginTop: '16px' }}>
-        <SingleSelect options={options2} placeholder="Before" style={{ marginTop: '8px' }} />
-        <div style={{
- display: 'flex', flexDirection: 'row', float: 'right', padding: '16px 0',
-}}
-        >
-          <Button variant="transparent">Cancel</Button>
-          <Button style={{ marginLeft: '8px' }} variant="primary">Apply</Button>
-        </div>
-      </div>
-    </div>
-  );
-};
-
 export const DropdownMenuCard = () => (
   <div style={{ display: 'flex', justifyContent: 'center' }}>
     <Dropdown autoClose={boolean('autoClose', true)}>
@@ -151,8 +122,21 @@ export const DropdownMenuCard = () => (
         align={select('align', ['start', 'end'], 'end')}
         noPadding
       >
-        <DropdownCard title="Filter on participants">
-          {DropdownMenuCustomContent()}
+        <DropdownCard
+          size={select('size', Object.values(CardSizes), 'sm')}
+          title="DropdownCard title"
+        >
+          <div style={{ fontSize: '0.875rem' }}>
+            <b>
+              Our all-in-one research platform is your source of
+              truth for participant management and replaces 5+ tools.
+            </b>
+            <ul>
+              <li>Automate scheduling, messages, and annoying logistics</li>
+              <li>Build your own panel to recruit for user research projects</li>
+              <li>Track participant research activity in one place</li>
+            </ul>
+          </div>
         </DropdownCard>
       </DropdownMenu>
     </Dropdown>

--- a/src/Dropdown/Dropdown.stories.jsx
+++ b/src/Dropdown/Dropdown.stories.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
 
+import { boolean, select, withKnobs } from '@storybook/addon-knobs';
+
+import Button from 'src/Button';
 import {
- Dropdown, DropdownToggle, DropdownItem, DropdownMenu,
+ Dropdown, DropdownToggle, DropdownItem, DropdownMenu, DropdownCard,
 } from 'src/Dropdown';
 import { SingleSelect } from 'src/Select';
 
-import {
- faCog, faEllipsisV, faFileAlt, faUsers,
-} from '@fortawesome/pro-solid-svg-icons';
+import { faEllipsisV, faFileAlt } from '@fortawesome/pro-solid-svg-icons';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFilter } from '@fortawesome/pro-regular-svg-icons';
@@ -16,8 +17,9 @@ import mdx from './Dropdown.mdx';
 export default {
   title: 'Components/Dropdown',
   component: Dropdown,
+  decorators: [withKnobs],
   subcomponents: {
-    DropdownToggle, DropdownItem, DropdownMenu,
+    DropdownToggle, DropdownItem, DropdownMenu, DropdownCard,
   },
   parameters: {
     docs: {
@@ -119,50 +121,41 @@ const DropdownMenuCustomContent = () => {
   ];
 
   return (
-    <div style={{ padding: '24px', minWidth: '500px' }}>
+    <div style={{ minWidth: '450px' }}>
       <p style={{ fontWeight: 700 }}>Filter on participants</p>
       <SingleSelect options={options1} />
       <div style={{ marginTop: '16px' }}>
         <SingleSelect options={options2} placeholder="Before" style={{ marginTop: '8px' }} />
-        <div style={{ marginTop: '16px' }}>...misc. content</div>
-        <div>Anything can be put in this custom DropdownMenu</div>
+        <div style={{
+ display: 'flex', flexDirection: 'row', float: 'right', padding: '16px 0',
+}}
+        >
+          <Button variant="transparent">Cancel</Button>
+          <Button style={{ marginLeft: '8px' }} variant="primary">Apply</Button>
+        </div>
       </div>
     </div>
   );
 };
 
-export const DropdownMenuCustom = () => (
-  <div style={{ display: 'flex', flexDirection: 'row', float: 'right' }}>
-    <Dropdown>
+export const DropdownMenuCard = () => (
+  <div style={{ display: 'flex', justifyContent: 'center' }}>
+    <Dropdown autoClose={boolean('autoClose', true)}>
       <DropdownToggle
         removeCaret
-        style={{ color: '#158D71' }}
-        variant="transparent"
+        variant="outline-primary"
       >
         <FontAwesomeIcon className="icon-left" icon={faFilter} />
         Filter (8)
       </DropdownToggle>
       <DropdownMenu
-        align="end"
-        style={{
-          border: '1px solid #e1e1e1',
-          boxShadow: '0rem 0.13rem 0.3rem rgba(0, 0, 0, 0.1)',
-        }}
+        align={select('align', ['start', 'end'], 'end')}
+        noPadding
       >
-        {DropdownMenuCustomContent()}
+        <DropdownCard>
+          {DropdownMenuCustomContent()}
+        </DropdownCard>
       </DropdownMenu>
     </Dropdown>
-    <Dropdown>
-      <DropdownToggle style={{ color: '#158D71' }} variant="transparent">
-        <FontAwesomeIcon className="icon-left" icon={faUsers} />
-        Build
-      </DropdownToggle>
-    </Dropdown>
-    <Dropdown>
-      <DropdownToggle style={{ color: '#158D71' }} variant="transparent">
-        <FontAwesomeIcon className="icon-left" icon={faCog} />
-        Manage
-      </DropdownToggle>
-    </Dropdown>
   </div>
-);
+  );

--- a/src/Dropdown/DropdownCard.jsx
+++ b/src/Dropdown/DropdownCard.jsx
@@ -2,16 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+import { CardSizes } from 'src/Card';
+
 import './DropdownCard.scss';
 
 const DropdownCard = ({
   className,
   children,
+  size,
   title,
  }) => (
    <div className={classNames(
       className,
       'DropdownCard',
+      `DropdownCard--${size}`,
       )}
    >
      { title && <h2 className="DropdownCard__title">{title}</h2> }
@@ -21,11 +25,13 @@ const DropdownCard = ({
 
 DropdownCard.propTypes = {
   className: PropTypes.string,
+  size: PropTypes.oneOf(Object.values(CardSizes)),
   title: PropTypes.string,
 };
 
 DropdownCard.defaultProps = {
   className: undefined,
+  size: 'sm',
   title: undefined,
 };
 

--- a/src/Dropdown/DropdownCard.jsx
+++ b/src/Dropdown/DropdownCard.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import './DropdownCard.scss';
+
+const DropdownCard = ({ className, children }) => (
+  <div className={classNames(
+      className,
+      'DropdownCard',
+      )}
+  >
+    {children}
+  </div>
+  );
+
+DropdownCard.propTypes = {
+  className: PropTypes.string,
+};
+
+DropdownCard.defaultProps = {
+  className: undefined,
+};
+
+export default DropdownCard;

--- a/src/Dropdown/DropdownCard.jsx
+++ b/src/Dropdown/DropdownCard.jsx
@@ -4,22 +4,29 @@ import classNames from 'classnames';
 
 import './DropdownCard.scss';
 
-const DropdownCard = ({ className, children }) => (
-  <div className={classNames(
+const DropdownCard = ({
+  className,
+  children,
+  title,
+ }) => (
+   <div className={classNames(
       className,
       'DropdownCard',
       )}
-  >
-    {children}
-  </div>
+   >
+     { title && <h2 className="DropdownCard__title">{title}</h2> }
+     { children }
+   </div>
   );
 
 DropdownCard.propTypes = {
   className: PropTypes.string,
+  title: PropTypes.string,
 };
 
 DropdownCard.defaultProps = {
   className: undefined,
+  title: undefined,
 };
 
 export default DropdownCard;

--- a/src/Dropdown/DropdownCard.scss
+++ b/src/Dropdown/DropdownCard.scss
@@ -2,10 +2,29 @@
 
 .DropdownCard {
   padding: 1.5rem;
-  white-space: nowrap;
 
+  @include media-breakpoint-down(sm) {
+    max-width: calc(100vw - 2rem);
+  }
+  
   &__title {
     @include font-type-60--bold;
     margin-bottom: 0.5rem;
+  }
+
+  &--xs {
+    width: $card-width-xs;
+  }
+
+  &--sm {
+   width: $card-width-sm;
+  }
+
+  &--md {
+    width: $card-width-md;
+  }
+
+  &--lg {
+    width: $card-width;
   }
 }

--- a/src/Dropdown/DropdownCard.scss
+++ b/src/Dropdown/DropdownCard.scss
@@ -3,4 +3,9 @@
 .DropdownCard {
   padding: 1.5rem;
   white-space: nowrap;
+
+  &__title {
+    @include font-type-60--bold;
+    margin-bottom: 0.5rem;
+  }
 }

--- a/src/Dropdown/DropdownCard.scss
+++ b/src/Dropdown/DropdownCard.scss
@@ -1,0 +1,6 @@
+@import '../../scss/theme';
+
+.DropdownCard {
+  padding: 1.5rem;
+  white-space: nowrap;
+}

--- a/src/Dropdown/DropdownMenu.jsx
+++ b/src/Dropdown/DropdownMenu.jsx
@@ -5,12 +5,15 @@ import classNames from 'classnames';
 import { Dropdown as RBDropdown } from 'react-bootstrap';
 import { DROPDOWN_ALIGN_PROP_TYPE } from './Dropdown.types';
 
+import './DropdownMenu.scss';
+
 const DropdownMenu = ({
   align,
   as,
   children,
   className,
   flip,
+  noPadding,
   onSelect,
   popperConfig,
   renderOnMount,
@@ -24,7 +27,11 @@ const DropdownMenu = ({
     align={align}
     as={as}
     bsPrefix={bsPrefix}
-    className={classNames('DropdownMenu', className)}
+    className={classNames(
+      'DropdownMenu',
+      className,
+      noPadding && 'DropdownMenu--no-padding',
+    )}
     flip={flip}
     popperConfig={popperConfig}
     renderOnMount={renderOnMount}
@@ -61,6 +68,10 @@ DropdownMenu.propTypes = {
    */
   flip: PropTypes.bool,
   /**
+    If true, removes default padding on DropdownMenu.
+   */
+  noPadding: PropTypes.bool,
+  /**
    A set of popper options and props passed directly to Popper.
    */
   popperConfig: PropTypes.object,
@@ -93,6 +104,7 @@ DropdownMenu.defaultProps = {
   as: undefined,
   className: undefined,
   flip: true,
+  noPadding: undefined,
   onSelect: undefined,
   popperConfig: undefined,
   renderOnMount: undefined,

--- a/src/Dropdown/DropdownMenu.scss
+++ b/src/Dropdown/DropdownMenu.scss
@@ -1,0 +1,10 @@
+@import '../../scss/theme.scss';
+
+.DropdownMenu {
+  border: 1px solid $ux-gray-300;
+  box-shadow: $ux-elevations-30;
+
+  &--no-padding {
+    padding: 0;
+  }
+}

--- a/src/Dropdown/index.js
+++ b/src/Dropdown/index.js
@@ -2,10 +2,12 @@ import Dropdown from './Dropdown';
 import DropdownToggle from './DropdownToggle';
 import DropdownItem from './DropdownItem';
 import DropdownMenu from './DropdownMenu';
+import DropdownCard from './DropdownCard';
 
 export {
   Dropdown,
   DropdownToggle,
   DropdownItem,
   DropdownMenu,
+  DropdownCard,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import {
   DropdownToggle,
   DropdownItem,
   DropdownMenu,
+  DropdownCard,
 } from 'src/Dropdown';
 import FadeTransition from 'src/FadeTransition';
 import Form from 'src/Form';
@@ -99,6 +100,7 @@ export {
   DropdownToggle,
   DropdownItem,
   DropdownMenu,
+  DropdownCard,
   FadeTransition,
   Form,
   FormControlLabel,


### PR DESCRIPTION
closes #702 

- Create a `DropdownCard` subcomponent of the `Dropdown`. This is a custom use case (potentially for [Hub dropdown filters](https://www.figma.com/file/4dZK7ZVFYWN5d26p0nm1JI/Hub---Table-UX-and-Segments?node-id=2019%3A75606)). 
- The `DropdownCard` has the same sizes as the `Card` component. One limitation is that when viewing the `DropdownCard` on mobile, we won't be able to center it properly. I assume for the first use case we would only be using this component variant on desktop for Hub. 

Chromatic: https://62d040e741710e4f085e0647-cmarbdvfhi.chromatic.com/?path=/story/components-dropdown--dropdown-menu-card

* if you need the invite link to Chromatic, reach out to me and I can send it to you.

