### PR TITLE
add custom variant to DropdownToggle

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -4971,92 +4971,6 @@ exports[`Storyshots Components/Copy To Clipboard Default 1`] = `
 </div>
 `;
 
-exports[`Storyshots Components/Dropdown Custom Toggle 1`] = `
-<div
-  style={
-    Object {
-      "padding": "1rem",
-    }
-  }
->
-  <div
-    className="Dropdown dropdown"
-  >
-    <button
-      aria-expanded={false}
-      aria-label="dropdown-toggle"
-      className="DropdownToggle DropdownToggle--custom DropdownToggle--no-caret btn btn-primary"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      <div
-        style={
-          Object {
-            "alignItems": "center",
-            "backgroundColor": "#444444",
-            "display": "flex",
-            "flexDirection": "row",
-            "justifyContent": "space-between",
-            "padding": "12px",
-            "width": "200px",
-          }
-        }
-      >
-        <div>
-          <div
-            style={
-              Object {
-                "fontSize": "18px",
-                "fontWeight": "700",
-              }
-            }
-          >
-            Team A
-          </div>
-          <div
-            style={
-              Object {
-                "backgroundColor": "#444444",
-                "fontSize": "12px",
-                "fontWeight": "400",
-              }
-            }
-          >
-            Organization
-          </div>
-        </div>
-        <div
-          style={
-            Object {
-              "marginRight": "4px",
-            }
-          }
-        >
-          <svg
-            aria-hidden="true"
-            className="svg-inline--fa fa-chevron-down fa-w-14 "
-            data-icon="chevron-down"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            style={Object {}}
-            viewBox="0 0 448 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
-              fill="currentColor"
-              style={Object {}}
-            />
-          </svg>
-        </div>
-      </div>
-    </button>
-  </div>
-</div>
-`;
-
 exports[`Storyshots Components/Dropdown Default 1`] = `
 <div
   style={
@@ -5230,6 +5144,92 @@ exports[`Storyshots Components/Dropdown Sizes 1`] = `
       type="button"
     >
       Medium toggle
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Components/Dropdown Unstyled Toggle 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="Dropdown dropdown"
+  >
+    <button
+      aria-expanded={false}
+      aria-label="dropdown-toggle"
+      className="DropdownToggle DropdownToggle--unstyled DropdownToggle--no-caret btn btn-primary"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#444444",
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "padding": "12px",
+            "width": "200px",
+          }
+        }
+      >
+        <div>
+          <div
+            style={
+              Object {
+                "fontSize": "18px",
+                "fontWeight": "700",
+              }
+            }
+          >
+            Team A
+          </div>
+          <div
+            style={
+              Object {
+                "backgroundColor": "#444444",
+                "fontSize": "12px",
+                "fontWeight": "400",
+              }
+            }
+          >
+            Organization
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "marginRight": "4px",
+            }
+          }
+        >
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-chevron-down fa-w-14 "
+            data-icon="chevron-down"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={Object {}}
+            viewBox="0 0 448 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+        </div>
+      </div>
     </button>
   </div>
 </div>

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -4971,6 +4971,92 @@ exports[`Storyshots Components/Copy To Clipboard Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Dropdown Custom Toggle 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="Dropdown dropdown"
+  >
+    <button
+      aria-expanded={false}
+      aria-label="dropdown-toggle"
+      className="DropdownToggle DropdownToggle--custom DropdownToggle--no-caret btn btn-primary"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#444444",
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "padding": "12px",
+            "width": "200px",
+          }
+        }
+      >
+        <div>
+          <div
+            style={
+              Object {
+                "fontSize": "18px",
+                "fontWeight": "700",
+              }
+            }
+          >
+            Team A
+          </div>
+          <div
+            style={
+              Object {
+                "backgroundColor": "#444444",
+                "fontSize": "12px",
+                "fontWeight": "400",
+              }
+            }
+          >
+            Organization
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "marginRight": "4px",
+            }
+          }
+        >
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-chevron-down fa-w-14 "
+            data-icon="chevron-down"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={Object {}}
+            viewBox="0 0 448 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+        </div>
+      </div>
+    </button>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Components/Dropdown Default 1`] = `
 <div
   style={
@@ -19601,6 +19687,249 @@ exports[`Storyshots Components/Toast Toast With Action 1`] = `
       Submit
     </button>
   </div>
+</div>
+`;
+
+exports[`Storyshots Components/ToggleInput Checked 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <label
+    className="ToggleInput__label"
+    htmlFor="1"
+  >
+    <div
+      className="react-toggle react-toggle--checked"
+      onClick={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+    >
+      <div
+        className="react-toggle-track"
+      >
+        <div
+          className="react-toggle-track-check"
+        >
+          <svg
+            height="11"
+            viewBox="0 0 14 11"
+            width="14"
+          >
+            <title>
+              switch-check
+            </title>
+            <path
+              d="M11.264 0L5.26 6.004 2.103 2.847 0 4.95l5.26 5.26 8.108-8.107L11.264 0"
+              fill="#fff"
+              fillRule="evenodd"
+            />
+          </svg>
+        </div>
+        <div
+          className="react-toggle-track-x"
+        >
+          <svg
+            height="10"
+            viewBox="0 0 10 10"
+            width="10"
+          >
+            <title>
+              switch-x
+            </title>
+            <path
+              d="M9.9 2.12L7.78 0 4.95 2.828 2.12 0 0 2.12l2.83 2.83L0 7.776 2.123 9.9 4.95 7.07 7.78 9.9 9.9 7.776 7.072 4.95 9.9 2.12"
+              fill="#fff"
+              fillRule="evenodd"
+            />
+          </svg>
+        </div>
+      </div>
+      <div
+        className="react-toggle-thumb"
+      />
+      <input
+        checked={true}
+        className="react-toggle-screenreader-only"
+        disabled={false}
+        id="1"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        type="checkbox"
+        value="true"
+      />
+    </div>
+    <span>
+      Label
+    </span>
+  </label>
+</div>
+`;
+
+exports[`Storyshots Components/ToggleInput Default 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <label
+    className="ToggleInput__label"
+    htmlFor="1"
+  >
+    <div
+      className="react-toggle"
+      onClick={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+    >
+      <div
+        className="react-toggle-track"
+      >
+        <div
+          className="react-toggle-track-check"
+        >
+          <svg
+            height="11"
+            viewBox="0 0 14 11"
+            width="14"
+          >
+            <title>
+              switch-check
+            </title>
+            <path
+              d="M11.264 0L5.26 6.004 2.103 2.847 0 4.95l5.26 5.26 8.108-8.107L11.264 0"
+              fill="#fff"
+              fillRule="evenodd"
+            />
+          </svg>
+        </div>
+        <div
+          className="react-toggle-track-x"
+        >
+          <svg
+            height="10"
+            viewBox="0 0 10 10"
+            width="10"
+          >
+            <title>
+              switch-x
+            </title>
+            <path
+              d="M9.9 2.12L7.78 0 4.95 2.828 2.12 0 0 2.12l2.83 2.83L0 7.776 2.123 9.9 4.95 7.07 7.78 9.9 9.9 7.776 7.072 4.95 9.9 2.12"
+              fill="#fff"
+              fillRule="evenodd"
+            />
+          </svg>
+        </div>
+      </div>
+      <div
+        className="react-toggle-thumb"
+      />
+      <input
+        checked={false}
+        className="react-toggle-screenreader-only"
+        disabled={false}
+        id="1"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        type="checkbox"
+        value="false"
+      />
+    </div>
+    <span>
+      Label
+    </span>
+  </label>
+</div>
+`;
+
+exports[`Storyshots Components/ToggleInput Label Left 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <label
+    className="ToggleInput__label"
+    htmlFor="1"
+  >
+    <span>
+      Label
+    </span>
+    <div
+      className="react-toggle"
+      onClick={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+    >
+      <div
+        className="react-toggle-track"
+      >
+        <div
+          className="react-toggle-track-check"
+        >
+          <svg
+            height="11"
+            viewBox="0 0 14 11"
+            width="14"
+          >
+            <title>
+              switch-check
+            </title>
+            <path
+              d="M11.264 0L5.26 6.004 2.103 2.847 0 4.95l5.26 5.26 8.108-8.107L11.264 0"
+              fill="#fff"
+              fillRule="evenodd"
+            />
+          </svg>
+        </div>
+        <div
+          className="react-toggle-track-x"
+        >
+          <svg
+            height="10"
+            viewBox="0 0 10 10"
+            width="10"
+          >
+            <title>
+              switch-x
+            </title>
+            <path
+              d="M9.9 2.12L7.78 0 4.95 2.828 2.12 0 0 2.12l2.83 2.83L0 7.776 2.123 9.9 4.95 7.07 7.78 9.9 9.9 7.776 7.072 4.95 9.9 2.12"
+              fill="#fff"
+              fillRule="evenodd"
+            />
+          </svg>
+        </div>
+      </div>
+      <div
+        className="react-toggle-thumb"
+      />
+      <input
+        checked={false}
+        className="react-toggle-screenreader-only"
+        disabled={false}
+        id="1"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        type="checkbox"
+        value="false"
+      />
+    </div>
+  </label>
 </div>
 `;
 

--- a/src/Dropdown/Dropdown.mdx
+++ b/src/Dropdown/Dropdown.mdx
@@ -57,6 +57,13 @@ Avoid the Dropdown component if:
   <Story id="components-dropdown--icon-swap" />
 </Canvas>
 
+### Custom Toggle
+- Use the `custom` and `removeCaret` prop on `DropdownToggle` to remove default styling.
+
+<Canvas>
+  <Story id="components-dropdown--custom-toggle" />
+</Canvas>
+
 
 ## Formatting
 

--- a/src/Dropdown/Dropdown.mdx
+++ b/src/Dropdown/Dropdown.mdx
@@ -57,11 +57,11 @@ Avoid the Dropdown component if:
   <Story id="components-dropdown--icon-swap" />
 </Canvas>
 
-### Custom Toggle
-- Use the `custom` and `removeCaret` prop on `DropdownToggle` to remove default styling.
+### Unstyled Toggle
+- Use the `unstyled` and `removeCaret` prop on `DropdownToggle` to remove default styling.
 
 <Canvas>
-  <Story id="components-dropdown--custom-toggle" />
+  <Story id="components-dropdown--unstyled-toggle" />
 </Canvas>
 
 

--- a/src/Dropdown/Dropdown.stories.jsx
+++ b/src/Dropdown/Dropdown.stories.jsx
@@ -5,8 +5,6 @@ import {
 } from 'src/Dropdown';
 import { faEllipsisV, faFileAlt, faChevronDown } from '@fortawesome/pro-solid-svg-icons';
 
-import Avatar from 'src/Avatar';
-
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import mdx from './Dropdown.mdx';
 
@@ -104,13 +102,19 @@ export const IconSwap = () => (
   </>
 );
 
-export const CustomPOC = () => (
+export const CustomToggle = () => (
   <>
     <Dropdown>
       <DropdownToggle custom removeCaret>
         <div style={{
- padding: '12px', backgroundColor: '#444444', width: '200px', display: 'flex', flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
-}}
+          padding: '12px',
+          backgroundColor: '#444444',
+          width: '200px',
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          }}
         >
           <div>
             <div style={{ fontSize: '18px', fontWeight: '700' }}>Team A</div>
@@ -125,34 +129,6 @@ export const CustomPOC = () => (
         <DropdownItem href="#">Team A</DropdownItem>
         <DropdownItem href="#">Team B</DropdownItem>
         <DropdownItem href="#">Team C</DropdownItem>
-      </DropdownMenu>
-    </Dropdown>
-    <br />
-    <Dropdown>
-      <DropdownToggle custom removeCaret>
-        <div style={{
- padding: '12px', backgroundColor: '#444444', width: '300px', display: 'flex', flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
-}}
-        >
-          <div style={{ display: 'flex', flexDirection: 'row' }}>
-            <Avatar image="https://i.pinimg.com/originals/84/b9/3c/84b93c89b807c6a4917deb49beeaee20.jpg" />
-            <div style={{ flexDirection: 'column', marginLeft: '0.875rem' }}>
-              <div style={{ fontSize: '18px', fontWeight: '700' }}>Dunder Mifflin, Inc.</div>
-              <div style={{ fontSize: '12px', fontWeight: '400', backgroundColor: '#444444' }}>Scranton</div>
-            </div>
-          </div>
-          <div style={{ marginRight: '4px' }}>
-            <FontAwesomeIcon icon={faChevronDown} />
-          </div>
-        </div>
-      </DropdownToggle>
-      <DropdownMenu>
-        <DropdownItem href="#">New York City (HQ)</DropdownItem>
-        <DropdownItem href="#">Akron</DropdownItem>
-        <DropdownItem href="#">Albany</DropdownItem>
-        <DropdownItem href="#">Binghampton</DropdownItem>
-        <DropdownItem href="#">Buffalo</DropdownItem>
-        <DropdownItem href="#">Camden</DropdownItem>
       </DropdownMenu>
     </Dropdown>
   </>

--- a/src/Dropdown/Dropdown.stories.jsx
+++ b/src/Dropdown/Dropdown.stories.jsx
@@ -5,6 +5,8 @@ import {
 } from 'src/Dropdown';
 import { faEllipsisV, faFileAlt, faChevronDown } from '@fortawesome/pro-solid-svg-icons';
 
+import Avatar from 'src/Avatar';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import mdx from './Dropdown.mdx';
 
@@ -123,6 +125,34 @@ export const CustomPOC = () => (
         <DropdownItem href="#">Team A</DropdownItem>
         <DropdownItem href="#">Team B</DropdownItem>
         <DropdownItem href="#">Team C</DropdownItem>
+      </DropdownMenu>
+    </Dropdown>
+    <br />
+    <Dropdown>
+      <DropdownToggle custom removeCaret>
+        <div style={{
+ padding: '12px', backgroundColor: '#444444', width: '300px', display: 'flex', flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+}}
+        >
+          <div style={{ display: 'flex', flexDirection: 'row' }}>
+            <Avatar image="https://i.pinimg.com/originals/84/b9/3c/84b93c89b807c6a4917deb49beeaee20.jpg" />
+            <div style={{ flexDirection: 'column', marginLeft: '0.875rem' }}>
+              <div style={{ fontSize: '18px', fontWeight: '700' }}>Dunder Mifflin, Inc.</div>
+              <div style={{ fontSize: '12px', fontWeight: '400', backgroundColor: '#444444' }}>Scranton</div>
+            </div>
+          </div>
+          <div style={{ marginRight: '4px' }}>
+            <FontAwesomeIcon icon={faChevronDown} />
+          </div>
+        </div>
+      </DropdownToggle>
+      <DropdownMenu>
+        <DropdownItem href="#">New York City (HQ)</DropdownItem>
+        <DropdownItem href="#">Akron</DropdownItem>
+        <DropdownItem href="#">Albany</DropdownItem>
+        <DropdownItem href="#">Binghampton</DropdownItem>
+        <DropdownItem href="#">Buffalo</DropdownItem>
+        <DropdownItem href="#">Camden</DropdownItem>
       </DropdownMenu>
     </Dropdown>
   </>

--- a/src/Dropdown/Dropdown.stories.jsx
+++ b/src/Dropdown/Dropdown.stories.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {
  Dropdown, DropdownToggle, DropdownItem, DropdownMenu,
 } from 'src/Dropdown';
-import { faEllipsisV, faFileAlt } from '@fortawesome/pro-solid-svg-icons';
+import { faEllipsisV, faFileAlt, faChevronDown } from '@fortawesome/pro-solid-svg-icons';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import mdx from './Dropdown.mdx';
@@ -97,6 +97,32 @@ export const IconSwap = () => (
         <DropdownItem href="#">Action</DropdownItem>
         <DropdownItem href="#">Another action</DropdownItem>
         <DropdownItem href="#">Click me</DropdownItem>
+      </DropdownMenu>
+    </Dropdown>
+  </>
+);
+
+export const CustomPOC = () => (
+  <>
+    <Dropdown>
+      <DropdownToggle custom removeCaret>
+        <div style={{
+ padding: '12px', backgroundColor: '#444444', width: '200px', display: 'flex', flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+}}
+        >
+          <div>
+            <div style={{ fontSize: '18px', fontWeight: '700' }}>Team A</div>
+            <div style={{ fontSize: '12px', fontWeight: '400', backgroundColor: '#444444' }}>Organization</div>
+          </div>
+          <div style={{ marginRight: '4px' }}>
+            <FontAwesomeIcon icon={faChevronDown} />
+          </div>
+        </div>
+      </DropdownToggle>
+      <DropdownMenu>
+        <DropdownItem href="#">Team A</DropdownItem>
+        <DropdownItem href="#">Team B</DropdownItem>
+        <DropdownItem href="#">Team C</DropdownItem>
       </DropdownMenu>
     </Dropdown>
   </>

--- a/src/Dropdown/Dropdown.stories.jsx
+++ b/src/Dropdown/Dropdown.stories.jsx
@@ -102,9 +102,9 @@ export const IconSwap = () => (
   </>
 );
 
-export const CustomToggle = () => (
+export const UnstyledToggle = () => (
   <Dropdown>
-    <DropdownToggle custom removeCaret>
+    <DropdownToggle removeCaret unstyled>
       <div style={{
         padding: '12px',
         backgroundColor: '#444444',

--- a/src/Dropdown/Dropdown.stories.jsx
+++ b/src/Dropdown/Dropdown.stories.jsx
@@ -103,33 +103,31 @@ export const IconSwap = () => (
 );
 
 export const CustomToggle = () => (
-  <>
-    <Dropdown>
-      <DropdownToggle custom removeCaret>
-        <div style={{
-          padding: '12px',
-          backgroundColor: '#444444',
-          width: '200px',
-          display: 'flex',
-          flexDirection: 'row',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          }}
-        >
-          <div>
-            <div style={{ fontSize: '18px', fontWeight: '700' }}>Team A</div>
-            <div style={{ fontSize: '12px', fontWeight: '400', backgroundColor: '#444444' }}>Organization</div>
-          </div>
-          <div style={{ marginRight: '4px' }}>
-            <FontAwesomeIcon icon={faChevronDown} />
-          </div>
+  <Dropdown>
+    <DropdownToggle custom removeCaret>
+      <div style={{
+        padding: '12px',
+        backgroundColor: '#444444',
+        width: '200px',
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        }}
+      >
+        <div>
+          <div style={{ fontSize: '18px', fontWeight: '700' }}>Team A</div>
+          <div style={{ fontSize: '12px', fontWeight: '400', backgroundColor: '#444444' }}>Organization</div>
         </div>
-      </DropdownToggle>
-      <DropdownMenu>
-        <DropdownItem href="#">Team A</DropdownItem>
-        <DropdownItem href="#">Team B</DropdownItem>
-        <DropdownItem href="#">Team C</DropdownItem>
-      </DropdownMenu>
-    </Dropdown>
-  </>
+        <div style={{ marginRight: '4px' }}>
+          <FontAwesomeIcon icon={faChevronDown} />
+        </div>
+      </div>
+    </DropdownToggle>
+    <DropdownMenu>
+      <DropdownItem href="#">Team A</DropdownItem>
+      <DropdownItem href="#">Team B</DropdownItem>
+      <DropdownItem href="#">Team C</DropdownItem>
+    </DropdownMenu>
+  </Dropdown>
 );

--- a/src/Dropdown/DropdownItem.scss
+++ b/src/Dropdown/DropdownItem.scss
@@ -5,7 +5,7 @@
   color: $ux-gray-900;
 
   &:hover {
-    background-color: $ux-blue-100;
+    background-color: $ux-blue-200;
   }
 
   &:focus {

--- a/src/Dropdown/DropdownToggle.jsx
+++ b/src/Dropdown/DropdownToggle.jsx
@@ -15,24 +15,44 @@ const DropdownToggle = ({
   childBsPrefix,
   children,
   className,
+  custom,
   id,
   leadingIcon,
   removeCaret,
   ...props
-}) => (
-  <RBDropdown.Toggle
-    aria-label={ariaLabel}
-    as={as}
-    bsPrefix={removeCaret ? 'DropdownToggle--no-caret' : bsPrefix}
-    childBsPrefix={childBsPrefix}
-    className={classNames('DropdownToggle', className)}
-    id={id}
-    {...props}
-  >
-    { leadingIcon && (<FontAwesomeIcon className="icon-left" icon={leadingIcon} />)}
-    { children }
-  </RBDropdown.Toggle>
+}) => {
+  if (!custom) {
+ return (
+   <RBDropdown.Toggle
+     aria-label={ariaLabel}
+     as={as}
+     bsPrefix={removeCaret ? 'DropdownToggle--no-caret' : bsPrefix}
+     childBsPrefix={childBsPrefix}
+     className={classNames('DropdownToggle', className)}
+     id={id}
+     {...props}
+   >
+     { leadingIcon && (<FontAwesomeIcon className="icon-left" icon={leadingIcon} />)}
+     { children }
+   </RBDropdown.Toggle>
   );
+}
+
+  return (
+    <RBDropdown.Toggle
+      aria-label={ariaLabel}
+      as={as}
+      bsPrefix={removeCaret ? 'DropdownToggle--no-caret' : bsPrefix}
+      childBsPrefix={childBsPrefix}
+      className={classNames('DropdownToggle', 'DropdownToggle--custom', className)}
+      id={id}
+      {...props}
+    >
+      { leadingIcon && (<FontAwesomeIcon className="icon-left" icon={leadingIcon} />)}
+      { children }
+    </RBDropdown.Toggle>
+  );
+};
 
 DropdownToggle.propTypes = {
    /**

--- a/src/Dropdown/DropdownToggle.jsx
+++ b/src/Dropdown/DropdownToggle.jsx
@@ -20,39 +20,24 @@ const DropdownToggle = ({
   leadingIcon,
   removeCaret,
   ...props
-}) => {
-  if (!custom) {
- return (
-   <RBDropdown.Toggle
-     aria-label={ariaLabel}
-     as={as}
-     bsPrefix={removeCaret ? 'DropdownToggle--no-caret' : bsPrefix}
-     childBsPrefix={childBsPrefix}
-     className={classNames('DropdownToggle', className)}
-     id={id}
-     {...props}
-   >
-     { leadingIcon && (<FontAwesomeIcon className="icon-left" icon={leadingIcon} />)}
-     { children }
-   </RBDropdown.Toggle>
-  );
-}
-
-  return (
-    <RBDropdown.Toggle
-      aria-label={ariaLabel}
-      as={as}
-      bsPrefix={removeCaret ? 'DropdownToggle--no-caret' : bsPrefix}
-      childBsPrefix={childBsPrefix}
-      className={classNames('DropdownToggle', 'DropdownToggle--custom', className)}
-      id={id}
-      {...props}
-    >
-      { leadingIcon && (<FontAwesomeIcon className="icon-left" icon={leadingIcon} />)}
-      { children }
-    </RBDropdown.Toggle>
-  );
-};
+}) => (
+  <RBDropdown.Toggle
+    aria-label={ariaLabel}
+    as={as}
+    bsPrefix={removeCaret ? 'DropdownToggle--no-caret' : bsPrefix}
+    childBsPrefix={childBsPrefix}
+    className={classNames(
+        'DropdownToggle',
+        className,
+        { 'DropdownToggle--custom': custom },
+      )}
+    id={id}
+    {...props}
+  >
+    { leadingIcon && (<FontAwesomeIcon className="icon-left" icon={leadingIcon} />)}
+    { children }
+  </RBDropdown.Toggle>
+);
 
 DropdownToggle.propTypes = {
    /**

--- a/src/Dropdown/DropdownToggle.jsx
+++ b/src/Dropdown/DropdownToggle.jsx
@@ -15,10 +15,10 @@ const DropdownToggle = ({
   childBsPrefix,
   children,
   className,
-  custom,
   id,
   leadingIcon,
   removeCaret,
+  unstyled,
   ...props
 }) => (
   <RBDropdown.Toggle
@@ -29,7 +29,7 @@ const DropdownToggle = ({
     className={classNames(
         'DropdownToggle',
         className,
-        { 'DropdownToggle--custom': custom },
+        { 'DropdownToggle--unstyled': unstyled },
       )}
     id={id}
     {...props}
@@ -60,10 +60,6 @@ DropdownToggle.propTypes = {
   childBsPrefix: PropTypes.string,
   className: PropTypes.string,
   /**
-    If true, it removes all styling from toggle button. Use for full custom DropdownToggle styling.
-  */
-  custom: PropTypes.bool,
-  /**
     An html id attribute, necessary for assistive technologies, such as screen readers.
   */
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -73,6 +69,10 @@ DropdownToggle.propTypes = {
     This allows you to use a different icon of your choice.
   */
   removeCaret: PropTypes.bool,
+  /**
+    If true, it removes all styling from toggle button. Use for full custom DropdownToggle styling.
+  */
+  unstyled: PropTypes.bool,
 };
 
 DropdownToggle.defaultProps = {
@@ -81,10 +81,10 @@ DropdownToggle.defaultProps = {
   bsPrefix: 'dropdown-toggle',
   className: undefined,
   childBsPrefix: undefined,
-  custom: undefined,
   id: undefined,
   leadingIcon: undefined,
   removeCaret: undefined,
+  unstyled: undefined,
 };
 
 export default DropdownToggle;

--- a/src/Dropdown/DropdownToggle.jsx
+++ b/src/Dropdown/DropdownToggle.jsx
@@ -75,6 +75,10 @@ DropdownToggle.propTypes = {
   childBsPrefix: PropTypes.string,
   className: PropTypes.string,
   /**
+    If true, it removes all styling from toggle button. Use for full custom DropdownToggle styling.
+  */
+  custom: PropTypes.bool,
+  /**
     An html id attribute, necessary for assistive technologies, such as screen readers.
   */
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -92,6 +96,7 @@ DropdownToggle.defaultProps = {
   bsPrefix: 'dropdown-toggle',
   className: undefined,
   childBsPrefix: undefined,
+  custom: undefined,
   id: undefined,
   leadingIcon: undefined,
   removeCaret: undefined,

--- a/src/Dropdown/DropdownToggle.scss
+++ b/src/Dropdown/DropdownToggle.scss
@@ -7,7 +7,7 @@ $warning: $ux-yellow-400;
 .DropdownToggle {
   @include font-type-30--bold;
 
-  &--custom {
+  &--unstyled {
     all: unset;
   }
 

--- a/src/Dropdown/DropdownToggle.scss
+++ b/src/Dropdown/DropdownToggle.scss
@@ -7,6 +7,10 @@ $warning: $ux-yellow-400;
 .DropdownToggle {
   @include font-type-30--bold;
 
+  &--custom {
+    all: unset;
+  }
+
   i, svg {
     &.icon-left {
       margin-right: $ux-spacing-20;


### PR DESCRIPTION
closes #694 

Chromatic: https://62d040e741710e4f085e0647-yqibtaubkj.chromatic.com/?path=/story/components-dropdown--custom-toggle

This is basically a styling escape hatch that TE will be using for the team selector dropdown. Example implementation on RS below:

https://user-images.githubusercontent.com/37383785/184400371-4061fbbe-f4b3-4f68-af3c-027cc4be53ab.mov

What is seen is all custom and can be written in `.scss` to make it like this. Some considerations:
- At current, we’d need to define the width to be exactly the same as what the nav width is if you want it to be centered. Otherwise, the API for the DropdownMenu (which uses popper.js as the library) will ask you … “do you want the menu to align with the start at the end of the toggle?”
- Devs would probably need to account for truncating long text.
- Dev may need to conditionally render this component only for desktop view… because the way we currently handle the mobile menu is 😵‍💫 

![Screen Shot 2022-08-11 at 3 21 57 PM](https://user-images.githubusercontent.com/37383785/184400851-9269003e-cf6f-4103-aed8-2062fbfb6f77.png)

![Screen Shot 2022-08-11 at 3 20 59 PM](https://user-images.githubusercontent.com/37383785/184400772-38fc5dec-2b9f-4fd2-8107-b33166ab9fe2.png)

