### PR TITLE
text-decoration none on DropdownItem hover

### DIFF
--- a/src/Dropdown/DropdownItem.scss
+++ b/src/Dropdown/DropdownItem.scss
@@ -6,6 +6,7 @@
 
   &:hover {
     background-color: $ux-blue-100;
+    text-decoration: none;
   }
 
   &:focus {


### PR DESCRIPTION
closes #705 

💅 when used on RS, the DropdownItem hover state gets overridden by `body.scss` which underlines all `a` tags on hover so just doing this here.

