### PR TITLE
change Select option color to $ux-gray-900

### DIFF
--- a/src/Select/styles.js
+++ b/src/Select/styles.js
@@ -91,7 +91,7 @@ const defaultStyles = ({ size }) => ({
     }) => ({
         ...styles,
         backgroundColor: isSelected ? systemColors.UX_BLUE_200 : styles.backgroundColor,
-        color: systemColors.UX_BLACK,
+        color: systemColors.UX_GRAY_900,
         fontWeight: fontWeights.light,
         fontSize: '0.875rem',
         cursor: 'pointer',


### PR DESCRIPTION
closes #683 

Just getting to this! Select option text color should now be using `$ux-gray-900`

![Screen Shot 2022-08-12 at 10 01 44 AM](https://user-images.githubusercontent.com/37383785/184408954-7b10dce4-fa65-420a-9c7e-aa0297f58af0.png)

