### PR TITLE
Add label for Pill close button

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -8025,6 +8025,7 @@ exports[`Storyshots Components/Pill With Close 1`] = `
   >
     Text
     <button
+      aria-label="Remove undefined"
       className="Pill__button--close"
       onClick={[Function]}
       type="button"

--- a/src/Pill/Pill.jsx
+++ b/src/Pill/Pill.jsx
@@ -37,7 +37,12 @@ const Pill = ({
     { children }
     { text }
     { onClose && (
-      <button className="Pill__button--close" type="button" onClick={() => onClose(id)}>
+      <button
+        aria-label={`Remove ${text}`}
+        className="Pill__button--close"
+        type="button"
+        onClick={() => onClose(id)}
+      >
         <FontAwesomeIcon icon={faTimes} />
       </button>
         )}


### PR DESCRIPTION
This fixes cypress-axe tests in RS that are failing when looking at pills.