### PR TITLE
remove prop spread on Accordion and ToggleInput

### DIFF
--- a/src/Accordion/Accordion.jsx
+++ b/src/Accordion/Accordion.jsx
@@ -5,25 +5,65 @@ import PropTypes from 'prop-types';
 import RBAccordion from 'react-bootstrap/Accordion';
 
 const Accordion = ({
+  activeKey,
+  alwaysOpen,
+  as,
+  defaultActiveKey,
   children,
+  flush,
+  onSelect,
   // eslint-disable-next-line camelcase
   UNSAFE_className,
-  ...props
 }) => (
   <RBAccordion
+    activeKey={activeKey}
+    alwaysOpen={alwaysOpen}
+    as={as}
     className={classNames(UNSAFE_className, 'Accordion')}
-    {...props}
+    defaultActiveKey={defaultActiveKey}
+    flush={flush}
+    onSelect={onSelect}
   >
     { children }
   </RBAccordion>
   );
 
 Accordion.propTypes = {
+  /**
+    The current active key that corresponds to the currently expanded accordion
+  */
+  activeKey: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+  /**
+    Allow accordion items to stay open when another item is opened
+  */
+  alwaysOpen: PropTypes.bool,
+  /**
+    Sets a custom element for this component
+  */
+  as: PropTypes.elementType,
+  /**
+    The default active key that is expanded on start
+  */
+  defaultActiveKey: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+  /**
+    Renders accordion edge-to-edge with its parent container
+  */
+  flush: PropTypes.bool,
   UNSAFE_className: PropTypes.string,
+  /**
+    Callback fired when the active item changes
+  */
+  onSelect: PropTypes.func,
 };
 
 Accordion.defaultProps = {
+  activeKey: undefined,
+  alwaysOpen: undefined,
+  as: undefined,
+  defaultActiveKey: undefined,
+  flush: undefined,
   UNSAFE_className: undefined,
+  onSelect: undefined,
 };
 
 export default Accordion;

--- a/src/Accordion/AccordionItem.jsx
+++ b/src/Accordion/AccordionItem.jsx
@@ -7,30 +7,38 @@ import RBAccordionItem from 'react-bootstrap/AccordionItem';
 import './AccordionItem.scss';
 
 const AccordionItem = ({
+  as,
   borderless,
   children,
   // eslint-disable-next-line camelcase
   UNSAFE_className,
-  ...props
 }) => (
   <RBAccordionItem
+    as={as}
     className={classNames(
       UNSAFE_className,
       'AccordionItem',
       borderless && 'AccordionItem--borderless',
     )}
-    {...props}
   >
     { children }
   </RBAccordionItem>
 );
 
 AccordionItem.propTypes = {
+  /**
+    Sets a custom element for this component
+  */
+  as: PropTypes.elementType,
+  /**
+    Removes border from accordion item
+  */
   borderless: PropTypes.bool,
   UNSAFE_className: PropTypes.string,
 };
 
 AccordionItem.defaultProps = {
+  as: undefined,
   borderless: undefined,
   UNSAFE_className: undefined,
 };

--- a/src/Accordion/AccordionToggle.jsx
+++ b/src/Accordion/AccordionToggle.jsx
@@ -21,7 +21,6 @@ const AccordionToggle = ({
   title,
   // eslint-disable-next-line camelcase
   UNSAFE_className,
-  ...props
 }) => {
   const { activeEventKey } = React.useContext(AccordionContext);
 
@@ -61,7 +60,6 @@ const AccordionToggle = ({
       disabled={disabled}
       type="button"
       onClick={decoratedOnClick}
-      {...props}
     >
       <div className="AccordionToggle__container">
         <div className="AccordionToggle__container--content">

--- a/src/ToggleInput/ToggleInput.jsx
+++ b/src/ToggleInput/ToggleInput.jsx
@@ -17,7 +17,6 @@ const ToggleInput = ({
   onToggle,
   // eslint-disable-next-line camelcase
   UNSAFE_className,
-  ...props
 }) => (
   <label
     className={classNames(
@@ -38,7 +37,6 @@ const ToggleInput = ({
       name={name}
       value={String(isChecked)}
       onChange={onToggle}
-      {...props}
     />
     {!labelLeft ? <span>{labelText}</span> : null}
   </label>


### PR DESCRIPTION
closes #723 

Also exposes additional props instead of prop spread.

As much as I like the flexibility, it seems like prop spread should be used sparingly according to the [React docs](https://reactjs.org/docs/jsx-in-depth.html#spread-attributes). 

`"Spread attributes can be useful but they also make it easy to pass unnecessary props to components that don’t care about them or to pass invalid HTML attributes to the DOM. We recommend using this syntax sparingly." `
 