### PR TITLE
update Option to allow for indeterminate CheckboxButton

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -9031,7 +9031,7 @@ exports[`Storyshots Components/Selects/Single Custom Option With Checkbox 1`] = 
 </div>
 `;
 
-exports[`Storyshots Components/Selects/Single Custom Value Container 1`] = `
+exports[`Storyshots Components/Selects/Single Custom Option With Indeterminate Checkbox 1`] = `
 <div
   style={
     Object {
@@ -9040,14 +9040,14 @@ exports[`Storyshots Components/Selects/Single Custom Value Container 1`] = `
   }
 >
   <label
-    htmlFor="custom-value-container-select"
-    id="select-label-custom-value-container"
+    htmlFor="multi-select"
+    id="select-label-custom-option"
   >
-    Custom value container
+    Custom option with indeterminate checkbox
   </label>
   <div
     className="SingleSelect css-b62m3t-container"
-    id="custom-value-container-select"
+    id="multi-select"
     onKeyDown={[Function]}
   >
     <span
@@ -9084,6 +9084,99 @@ exports[`Storyshots Components/Selects/Single Custom Value Container 1`] = `
           className="css-mohuvp-dummyInput-DummyInput"
           disabled={false}
           id="react-select-13-input"
+          inputMode="none"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          role="combobox"
+          tabIndex={0}
+          value=""
+        />
+      </div>
+      <div
+        className=" css-1hb7zxy-IndicatorsContainer"
+      >
+        <span
+          className=" css-43ykx9-indicatorSeparator"
+        />
+        <div
+          aria-hidden="true"
+          className=" css-7sl878-indicatorContainer"
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+        >
+          <svg
+            aria-hidden="true"
+            className="css-tj5bde-Svg"
+            focusable="false"
+            height={20}
+            viewBox="0 0 20 20"
+            width={20}
+          >
+            <path
+              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Components/Selects/Single Custom Value Container 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <label
+    htmlFor="custom-value-container-select"
+    id="select-label-custom-value-container"
+  >
+    Custom value container
+  </label>
+  <div
+    className="SingleSelect css-b62m3t-container"
+    id="custom-value-container-select"
+    onKeyDown={[Function]}
+  >
+    <span
+      className="css-1f43avz-a11yText-A11yText"
+      id="react-select-14-live-region"
+    />
+    <span
+      aria-atomic="false"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className="css-1f43avz-a11yText-A11yText"
+    />
+    <div
+      className=" css-15ub2n0-control"
+      onMouseDown={[Function]}
+      onTouchEnd={[Function]}
+    >
+      <div
+        className=" css-319lph-ValueContainer"
+      >
+        <div
+          className=" css-858797-placeholder"
+          id="react-select-14-placeholder"
+        >
+          Select...
+        </div>
+        <input
+          aria-autocomplete="list"
+          aria-describedby="react-select-14-placeholder"
+          aria-expanded={false}
+          aria-haspopup={true}
+          aria-labelledby="select-label"
+          aria-readonly={true}
+          className="css-mohuvp-dummyInput-DummyInput"
+          disabled={false}
+          id="react-select-14-input"
           inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -9041,7 +9041,7 @@ exports[`Storyshots Components/Selects/Single Custom Option With Indeterminate C
 >
   <label
     htmlFor="multi-select"
-    id="select-label-custom-option"
+    id="select-label-custom-option-indeterminate"
   >
     Custom option with indeterminate checkbox
   </label>

--- a/src/Select/Option.jsx
+++ b/src/Select/Option.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { components } from 'react-select';
 
 import CheckboxButton from 'src/CheckboxButton';
@@ -13,18 +13,20 @@ import './Option.scss';
 // See: https://react-select.com/components#replaceable-components
 
 /* eslint-disable react/prop-types */
-const Option = ({ ...props }) => (
+const Option = forwardRef(({ indeterminate, ...props }, ref) => (
   <components.Option {...props}>
     <div className="Option">
       <label>{props.label}</label>
       <CheckboxButton
         checked={props.isSelected}
         id={props.label}
+        indeterminate={indeterminate}
+        ref={ref}
         onChange={() => null}
       />
     </div>
   </components.Option>
-);
+  ));
 /* eslint-enable react/prop-types */
 
 export default Option;

--- a/src/Select/SingleSelect.mdx
+++ b/src/Select/SingleSelect.mdx
@@ -53,6 +53,12 @@ A base select input. Flexible and comes with multiselect, clearable, searchable,
   <Story id="components-selects-single--custom-option-with-checkbox" />
 </Preview>
 
+### Custom Option With Indeterminate Checkbox
+
+<Preview>
+  <Story id="components-selects-single--custom-option-with-indeterminate-checkbox" />
+</Preview>
+
 ### Custom Value Container
 
 <Preview>

--- a/src/Select/SingleSelect.stories.jsx
+++ b/src/Select/SingleSelect.stories.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useRef } from 'react';
 import { action } from '@storybook/addon-actions';
 
 import {
@@ -116,6 +116,34 @@ export const CustomOptionWithCheckbox = () => (
     />
   </Fragment>
 );
+
+export const CustomOptionWithIndeterminateCheckbox = () => {
+  const inputEl = useRef(null);
+
+  return (
+    <Fragment>
+      <label htmlFor="multi-select" id="select-label-custom-option">Custom option with indeterminate checkbox</label>
+      <SingleSelect
+        aria-labelledby="select-label"
+        closeMenuOnSelect={false}
+        components={{
+          Option: (props) => (
+            <Option
+              {...props}
+              indeterminate
+              ref={inputEl}
+            />
+          ),
+        }}
+        hideSelectedOptions={false}
+        id="multi-select"
+        isMulti
+        options={options}
+        onChange={onChange}
+      />
+    </Fragment>
+  );
+};
 
 export const CustomValueContainer = () => (
   <Fragment>

--- a/src/Select/SingleSelect.stories.jsx
+++ b/src/Select/SingleSelect.stories.jsx
@@ -118,11 +118,24 @@ export const CustomOptionWithCheckbox = () => (
 );
 
 export const CustomOptionWithIndeterminateCheckbox = () => {
-  const inputEl = useRef(null);
+  const optionsArr = [
+    { label: 'Riley Researcher', value: 1 },
+    { label: 'Patty Participant', value: 2 },
+    { label: 'Patrick Participant (indeterminate)', value: 3 },
+    { label: 'Polly Participant (indeterminate)', value: 4 },
+  ];
+
+  let inputRef;
+
+  const createInputRef = () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    inputRef = useRef();
+    return inputRef;
+  };
 
   return (
     <Fragment>
-      <label htmlFor="multi-select" id="select-label-custom-option">Custom option with indeterminate checkbox</label>
+      <label htmlFor="multi-select" id="select-label-custom-option-indeterminate">Custom option with indeterminate checkbox</label>
       <SingleSelect
         aria-labelledby="select-label"
         closeMenuOnSelect={false}
@@ -130,15 +143,16 @@ export const CustomOptionWithIndeterminateCheckbox = () => {
           Option: (props) => (
             <Option
               {...props}
-              indeterminate
-              ref={inputEl}
+              // eslint-disable-next-line react/prop-types
+              indeterminate={props.value > 2}
+              ref={createInputRef()}
             />
           ),
         }}
         hideSelectedOptions={false}
         id="multi-select"
         isMulti
-        options={options}
+        options={optionsArr}
         onChange={onChange}
       />
     </Fragment>


### PR DESCRIPTION
closes #726 

You should be able to set an `indeterminate` state on the `CheckboxButton` that is used in the custom `Option` component. 

<img width="570" alt="Screen Shot 2022-08-30 at 2 58 42 PM" src="https://user-images.githubusercontent.com/37383785/187551172-ca03685d-27ed-4b80-bf44-fb68bfe620d2.png">


Context exploration for an upcoming effort on Hub pod (this effort hasn't started yet, just fyi):
![image](https://user-images.githubusercontent.com/37383785/187487671-8b82c869-2c18-458b-bf72-ac4871943281.png)
