### PR TITLE
CheckboxButtonGroup and RadioButtonGroup state and width updates 

### DIFF
--- a/scss/forms/form_control_label.scss
+++ b/scss/forms/form_control_label.scss
@@ -47,10 +47,13 @@
     padding: 1rem;
     cursor: pointer;
 
-
+    &:hover {
+      background-color: $ux-blue-100;
+    }
+    
     &.FormControlLabel--active {
       background-color: $ux-blue-100;
-      border-color: $ux-blue-200;
+      border-color: $ux-blue-400;
       color: $ux-blue-700;
     }
   }

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -5274,6 +5274,130 @@ exports[`Storyshots Components/Form Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Form Elements/CheckboxButtonGroup Bordered Column Full Width 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <fieldset
+    className="FormGroup"
+    id="with-checkbox-button-group-5"
+  >
+    <legend
+      className="InputLegend"
+      htmlFor="checkbox-button-group"
+    >
+      Legend
+      <span
+        className="InputLegend__helper-text"
+      >
+         (
+        helper text
+        )
+      </span>
+    </legend>
+    <div
+      className="CheckboxButtonGroup CheckboxButtonGroup--column--full-width"
+      id="with-checkbox-button-group-5-button-group"
+    >
+      <label
+        className="FormControlLabel FormControlLabel--bordered FormControlLabel--with-children"
+        htmlFor="value-1-5"
+      >
+        <span
+          className="FormControlLabel__label"
+        >
+          <input
+            checked={false}
+            className="FormControlLabel__control"
+            id="value-1-5"
+            onChange={[Function]}
+            type="checkbox"
+            value="1"
+          />
+          Label 1
+          <span
+            className="FormControlLabel__helper-text"
+          >
+             (
+            helper text
+            )
+          </span>
+        </span>
+        <span
+          className="FormControlLabel__children"
+        >
+          This is where the description goes
+        </span>
+      </label>
+      <label
+        className="FormControlLabel FormControlLabel--bordered FormControlLabel--with-children"
+        htmlFor="value-2-5"
+      >
+        <span
+          className="FormControlLabel__label"
+        >
+          <input
+            checked={false}
+            className="FormControlLabel__control"
+            id="value-2-5"
+            onChange={[Function]}
+            type="checkbox"
+            value="2"
+          />
+          Label 2
+          <span
+            className="FormControlLabel__helper-text"
+          >
+             (
+            helper text
+            )
+          </span>
+        </span>
+        <span
+          className="FormControlLabel__children"
+        >
+          This is where the description goes
+        </span>
+      </label>
+      <label
+        className="FormControlLabel FormControlLabel--bordered FormControlLabel--with-children"
+        htmlFor="value-3-5"
+      >
+        <span
+          className="FormControlLabel__label"
+        >
+          <input
+            checked={false}
+            className="FormControlLabel__control"
+            id="value-3-5"
+            onChange={[Function]}
+            type="checkbox"
+            value="3"
+          />
+          Label 3
+          <span
+            className="FormControlLabel__helper-text"
+          >
+             (
+            helper text
+            )
+          </span>
+        </span>
+        <span
+          className="FormControlLabel__children"
+        >
+          This is where the description goes
+        </span>
+      </label>
+    </div>
+  </fieldset>
+</div>
+`;
+
 exports[`Storyshots Components/Form Elements/CheckboxButtonGroup Bordered Row 1`] = `
 <div
   style={
@@ -5450,95 +5574,7 @@ exports[`Storyshots Components/Form Elements/CheckboxButtonGroup Default 1`] = `
 </div>
 `;
 
-exports[`Storyshots Components/Form Elements/CheckboxButtonGroup Default Row 1`] = `
-<div
-  style={
-    Object {
-      "padding": "1rem",
-    }
-  }
->
-  <fieldset
-    className="FormGroup FormGroup--inline"
-    id="with-checkbox-button-group-1"
-  >
-    <legend
-      className="InputLegend"
-      htmlFor="checkbox-button-group"
-    >
-      Legend
-      <span
-        className="InputLegend__helper-text"
-      >
-         (
-        helper text
-        )
-      </span>
-    </legend>
-    <div
-      className="CheckboxButtonGroup CheckboxButtonGroup--row CheckboxButtonGroup--row--compact"
-      id="with-checkbox-button-group-1-button-group"
-    >
-      <label
-        className="FormControlLabel"
-        htmlFor="value-1-1"
-      >
-        <span
-          className="FormControlLabel__label"
-        >
-          <input
-            checked={false}
-            className="FormControlLabel__control"
-            id="value-1-1"
-            onChange={[Function]}
-            type="checkbox"
-            value="1"
-          />
-          Label 1
-        </span>
-      </label>
-      <label
-        className="FormControlLabel"
-        htmlFor="value-2-1"
-      >
-        <span
-          className="FormControlLabel__label"
-        >
-          <input
-            checked={false}
-            className="FormControlLabel__control"
-            id="value-2-1"
-            onChange={[Function]}
-            type="checkbox"
-            value="2"
-          />
-          Label 2
-        </span>
-      </label>
-      <label
-        className="FormControlLabel"
-        htmlFor="value-3-1"
-      >
-        <span
-          className="FormControlLabel__label"
-        >
-          <input
-            checked={false}
-            className="FormControlLabel__control"
-            id="value-3-1"
-            onChange={[Function]}
-            type="checkbox"
-            value="3"
-          />
-          Label 3
-        </span>
-      </label>
-    </div>
-  </fieldset>
-</div>
-`;
-
-exports[`Storyshots Components/Form Elements/CheckboxButtonGroup Description 1`] = `
+exports[`Storyshots Components/Form Elements/CheckboxButtonGroup Description Column 1`] = `
 <div
   style={
     Object {
@@ -5779,6 +5815,94 @@ exports[`Storyshots Components/Form Elements/CheckboxButtonGroup Description Row
           className="FormControlLabel__children"
         >
           This is where the description goes
+        </span>
+      </label>
+    </div>
+  </fieldset>
+</div>
+`;
+
+exports[`Storyshots Components/Form Elements/CheckboxButtonGroup Row 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <fieldset
+    className="FormGroup FormGroup--inline"
+    id="with-checkbox-button-group-1"
+  >
+    <legend
+      className="InputLegend"
+      htmlFor="checkbox-button-group"
+    >
+      Legend
+      <span
+        className="InputLegend__helper-text"
+      >
+         (
+        helper text
+        )
+      </span>
+    </legend>
+    <div
+      className="CheckboxButtonGroup CheckboxButtonGroup--row CheckboxButtonGroup--row--compact"
+      id="with-checkbox-button-group-1-button-group"
+    >
+      <label
+        className="FormControlLabel"
+        htmlFor="value-1-1"
+      >
+        <span
+          className="FormControlLabel__label"
+        >
+          <input
+            checked={false}
+            className="FormControlLabel__control"
+            id="value-1-1"
+            onChange={[Function]}
+            type="checkbox"
+            value="1"
+          />
+          Label 1
+        </span>
+      </label>
+      <label
+        className="FormControlLabel"
+        htmlFor="value-2-1"
+      >
+        <span
+          className="FormControlLabel__label"
+        >
+          <input
+            checked={false}
+            className="FormControlLabel__control"
+            id="value-2-1"
+            onChange={[Function]}
+            type="checkbox"
+            value="2"
+          />
+          Label 2
+        </span>
+      </label>
+      <label
+        className="FormControlLabel"
+        htmlFor="value-3-1"
+      >
+        <span
+          className="FormControlLabel__label"
+        >
+          <input
+            checked={false}
+            className="FormControlLabel__control"
+            id="value-3-1"
+            onChange={[Function]}
+            type="checkbox"
+            value="3"
+          />
+          Label 3
         </span>
       </label>
     </div>
@@ -6591,6 +6715,136 @@ exports[`Storyshots Components/Form Elements/Form Group With Trailing Icon And B
 </div>
 `;
 
+exports[`Storyshots Components/Form Elements/RadioButtonGroup Bordered Column Full Width 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <fieldset
+    className="FormGroup"
+    id="with-radio-button-group-5"
+  >
+    <legend
+      className="InputLegend"
+      htmlFor="radio-button-group"
+    >
+      Legend
+      <span
+        className="InputLegend__helper-text"
+      >
+         (
+        helper text
+        )
+      </span>
+    </legend>
+    <div
+      className="RadioButtonGroup RadioButtonGroup--column--full-width"
+      name=""
+    >
+      <label
+        className="FormControlLabel FormControlLabel--bordered FormControlLabel--with-children"
+        htmlFor="value-1-6"
+      >
+        <span
+          className="FormControlLabel__label"
+        >
+          <input
+            checked={false}
+            className="FormControlLabel__control"
+            disabled={false}
+            id="value-1-6"
+            name=""
+            onChange={[Function]}
+            type="radio"
+            value="1"
+          />
+          Label 1
+          <span
+            className="FormControlLabel__helper-text"
+          >
+             (
+            helper text
+            )
+          </span>
+        </span>
+        <span
+          className="FormControlLabel__children"
+        >
+          This is where the description goes
+        </span>
+      </label>
+      <label
+        className="FormControlLabel FormControlLabel--bordered FormControlLabel--with-children"
+        htmlFor="value-2-6"
+      >
+        <span
+          className="FormControlLabel__label"
+        >
+          <input
+            checked={false}
+            className="FormControlLabel__control"
+            disabled={false}
+            id="value-2-6"
+            name=""
+            onChange={[Function]}
+            type="radio"
+            value="2"
+          />
+          Label 2
+          <span
+            className="FormControlLabel__helper-text"
+          >
+             (
+            helper text
+            )
+          </span>
+        </span>
+        <span
+          className="FormControlLabel__children"
+        >
+          This is where the description goes
+        </span>
+      </label>
+      <label
+        className="FormControlLabel FormControlLabel--bordered FormControlLabel--with-children"
+        htmlFor="value-3-6"
+      >
+        <span
+          className="FormControlLabel__label"
+        >
+          <input
+            checked={false}
+            className="FormControlLabel__control"
+            disabled={false}
+            id="value-3-6"
+            name=""
+            onChange={[Function]}
+            type="radio"
+            value="3"
+          />
+          Label 3
+          <span
+            className="FormControlLabel__helper-text"
+          >
+             (
+            helper text
+            )
+          </span>
+        </span>
+        <span
+          className="FormControlLabel__children"
+        >
+          This is where the description goes
+        </span>
+      </label>
+    </div>
+  </fieldset>
+</div>
+`;
+
 exports[`Storyshots Components/Form Elements/RadioButtonGroup Bordered Row 1`] = `
 <div
   style={
@@ -6779,101 +7033,7 @@ exports[`Storyshots Components/Form Elements/RadioButtonGroup Default 1`] = `
 </div>
 `;
 
-exports[`Storyshots Components/Form Elements/RadioButtonGroup Default Row 1`] = `
-<div
-  style={
-    Object {
-      "padding": "1rem",
-    }
-  }
->
-  <fieldset
-    className="FormGroup FormGroup--inline"
-    id="with-radio-button-group-2"
-  >
-    <legend
-      className="InputLegend"
-      htmlFor="radio-button-group"
-    >
-      Legend
-      <span
-        className="InputLegend__helper-text"
-      >
-         (
-        helper text
-        )
-      </span>
-    </legend>
-    <div
-      className="RadioButtonGroup RadioButtonGroup--row RadioButtonGroup--row--compact"
-      name=""
-    >
-      <label
-        className="FormControlLabel"
-        htmlFor="value-1-2"
-      >
-        <span
-          className="FormControlLabel__label"
-        >
-          <input
-            checked={false}
-            className="FormControlLabel__control"
-            disabled={false}
-            id="value-1-2"
-            name=""
-            onChange={[Function]}
-            type="radio"
-            value="1"
-          />
-          Label 1
-        </span>
-      </label>
-      <label
-        className="FormControlLabel"
-        htmlFor="value-2-2"
-      >
-        <span
-          className="FormControlLabel__label"
-        >
-          <input
-            checked={false}
-            className="FormControlLabel__control"
-            disabled={false}
-            id="value-2-2"
-            name=""
-            onChange={[Function]}
-            type="radio"
-            value="2"
-          />
-          Label 2
-        </span>
-      </label>
-      <label
-        className="FormControlLabel"
-        htmlFor="value-3-2"
-      >
-        <span
-          className="FormControlLabel__label"
-        >
-          <input
-            checked={false}
-            className="FormControlLabel__control"
-            disabled={false}
-            id="value-3-2"
-            name=""
-            onChange={[Function]}
-            type="radio"
-            value="3"
-          />
-          Label 3
-        </span>
-      </label>
-    </div>
-  </fieldset>
-</div>
-`;
-
-exports[`Storyshots Components/Form Elements/RadioButtonGroup Description 1`] = `
+exports[`Storyshots Components/Form Elements/RadioButtonGroup Description Column 1`] = `
 <div
   style={
     Object {
@@ -7126,6 +7286,100 @@ exports[`Storyshots Components/Form Elements/RadioButtonGroup Description Row 1`
           className="FormControlLabel__children"
         >
           This is where the description goes
+        </span>
+      </label>
+    </div>
+  </fieldset>
+</div>
+`;
+
+exports[`Storyshots Components/Form Elements/RadioButtonGroup Row 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <fieldset
+    className="FormGroup FormGroup--inline"
+    id="with-radio-button-group-2"
+  >
+    <legend
+      className="InputLegend"
+      htmlFor="radio-button-group"
+    >
+      Legend
+      <span
+        className="InputLegend__helper-text"
+      >
+         (
+        helper text
+        )
+      </span>
+    </legend>
+    <div
+      className="RadioButtonGroup RadioButtonGroup--row RadioButtonGroup--row--compact"
+      name=""
+    >
+      <label
+        className="FormControlLabel"
+        htmlFor="value-1-2"
+      >
+        <span
+          className="FormControlLabel__label"
+        >
+          <input
+            checked={false}
+            className="FormControlLabel__control"
+            disabled={false}
+            id="value-1-2"
+            name=""
+            onChange={[Function]}
+            type="radio"
+            value="1"
+          />
+          Label 1
+        </span>
+      </label>
+      <label
+        className="FormControlLabel"
+        htmlFor="value-2-2"
+      >
+        <span
+          className="FormControlLabel__label"
+        >
+          <input
+            checked={false}
+            className="FormControlLabel__control"
+            disabled={false}
+            id="value-2-2"
+            name=""
+            onChange={[Function]}
+            type="radio"
+            value="2"
+          />
+          Label 2
+        </span>
+      </label>
+      <label
+        className="FormControlLabel"
+        htmlFor="value-3-2"
+      >
+        <span
+          className="FormControlLabel__label"
+        >
+          <input
+            checked={false}
+            className="FormControlLabel__control"
+            disabled={false}
+            id="value-3-2"
+            name=""
+            onChange={[Function]}
+            type="radio"
+            value="3"
+          />
+          Label 3
         </span>
       </label>
     </div>

--- a/src/CheckboxButtonGroup/CheckboxButtonGroup.jsx
+++ b/src/CheckboxButtonGroup/CheckboxButtonGroup.jsx
@@ -16,6 +16,7 @@ export default function CheckboxButtonGroup({
   onChange,
 }) {
   const row = orientation === ORIENTATIONS.ROW;
+  const column = orientation === ORIENTATIONS.COLUMN;
 
   const handleChangeValue = (event) => {
     const eventValue = parseInput(event.target.value);
@@ -42,6 +43,7 @@ export default function CheckboxButtonGroup({
         'CheckboxButtonGroup--row': row,
         'CheckboxButtonGroup--row--full-width': row && fullWidth,
         'CheckboxButtonGroup--row--compact': row && !fullWidth,
+        'CheckboxButtonGroup--column--full-width': column && fullWidth,
       })}
       id={id}
     >

--- a/src/CheckboxButtonGroup/CheckboxButtonGroup.mdx
+++ b/src/CheckboxButtonGroup/CheckboxButtonGroup.mdx
@@ -1,6 +1,7 @@
 import { ArgsTable, Story, Canvas } from '@storybook/addon-docs/blocks';
+import CheckboxButtonGroup from './CheckboxButtonGroup';
 
-# Checkbox Button Group
+# CheckboxButtonGroup
 
 ##
 
@@ -12,16 +13,10 @@ import { ArgsTable, Story, Canvas } from '@storybook/addon-docs/blocks';
   <Story id="components-form-elements-checkboxbuttongroup--default"/>
 </Canvas>
 
-### When to use
-- Reason 1
-- Reason 2
-
-### When to not use
-- Reason 1
-- Reason 2
 
 ## Props
-- WIP
+
+<ArgsTable of={CheckboxButtonGroup} />
 
 ## Stories
 
@@ -33,7 +28,13 @@ import { ArgsTable, Story, Canvas } from '@storybook/addon-docs/blocks';
   <Story id="components-form-elements-checkboxbuttongroup--default"/>
 </Canvas>
 
-### Bordered
+### Row
+
+<Canvas>
+  <Story id="components-form-elements-checkboxbuttongroup--row"/>
+</Canvas>
+
+### Bordered Row
 
 - Multi-selection button. Only used in the context of Checkbox FormGroups.
 
@@ -41,12 +42,24 @@ import { ArgsTable, Story, Canvas } from '@storybook/addon-docs/blocks';
   <Story id="components-form-elements-checkboxbuttongroup--bordered-row"/>
 </Canvas>
 
-### Description
+### Description Column
 
 - Multi-selection button. Includes helper text and/or a description in addition to the default label.
 
 <Canvas>
+  <Story id="components-form-elements-checkboxbuttongroup--description-column"/>
+</Canvas>
+
+### Description Row
+
+<Canvas>
   <Story id="components-form-elements-checkboxbuttongroup--description-row"/>
+</Canvas>
+
+### Bordered Column Full Width
+
+<Canvas>
+  <Story id="components-form-elements-checkboxbuttongroup--bordered-column-full-width"/>
 </Canvas>
 
 ## Formatting

--- a/src/CheckboxButtonGroup/CheckboxButtonGroup.scss
+++ b/src/CheckboxButtonGroup/CheckboxButtonGroup.scss
@@ -13,4 +13,8 @@
   &--row {
    @include row-control-group;
   }
+
+  &--column--full-width {
+    width: 100%;
+  }
 }

--- a/src/CheckboxButtonGroup/CheckboxButtonGroup.stories.jsx
+++ b/src/CheckboxButtonGroup/CheckboxButtonGroup.stories.jsx
@@ -276,7 +276,6 @@ export const BorderedColumnFullWidth = () => (
     id="with-checkbox-button-group-5"
     label="Legend"
     labelHelperText="helper text"
-    style={{ width: "100%" }}
     labelHtmlFor="checkbox-button-group"
     orientation={ORIENTATIONS.COLUMN}
   >

--- a/src/CheckboxButtonGroup/CheckboxButtonGroup.stories.jsx
+++ b/src/CheckboxButtonGroup/CheckboxButtonGroup.stories.jsx
@@ -105,7 +105,7 @@ export const Default = () => {
   );
 };
 
-export const DefaultRow = () => (
+export const Row = () => (
   <CheckboxButtonGroupComponent
     bordered={false}
     defaultValue={[]}
@@ -178,12 +178,11 @@ export const BorderedRow = () => (
   </CheckboxButtonGroupComponent>
 );
 
-export const Description = () => (
+export const DescriptionColumn = () => (
   <CheckboxButtonGroupComponent
     bordered={false}
     defaultValue={[]}
     elementType="fieldset"
-    fullWidth
     id="with-checkbox-button-group-3"
     label="Legend"
     labelHelperText="helper text"
@@ -260,6 +259,52 @@ export const DescriptionRow = () => (
       Control={CheckboxButton}
       helperText="helper text"
       id="value-3-4"
+      text="Label 3"
+      value="3"
+    >
+      This is where the description goes
+    </FormControlLabel>
+  </CheckboxButtonGroupComponent>
+);
+
+export const BorderedColumnFullWidth = () => (
+  <CheckboxButtonGroupComponent
+    bordered={false}
+    defaultValue={[]}
+    elementType="fieldset"
+    fullWidth
+    id="with-checkbox-button-group-5"
+    label="Legend"
+    labelHelperText="helper text"
+    style={{ width: "100%" }}
+    labelHtmlFor="checkbox-button-group"
+    orientation={ORIENTATIONS.COLUMN}
+  >
+    <FormControlLabel
+      bordered
+      Control={CheckboxButton}
+      helperText="helper text"
+      id="value-1-5"
+      text="Label 1"
+      value="1"
+    >
+      This is where the description goes
+    </FormControlLabel>
+    <FormControlLabel
+      bordered
+      Control={CheckboxButton}
+      helperText="helper text"
+      id="value-2-5"
+      text="Label 2"
+      value="2"
+    >
+      This is where the description goes
+    </FormControlLabel>
+    <FormControlLabel
+      bordered
+      Control={CheckboxButton}
+      helperText="helper text"
+      id="value-3-5"
       text="Label 3"
       value="3"
     >

--- a/src/RadioButtonGroup/RadioButtonGroup.jsx
+++ b/src/RadioButtonGroup/RadioButtonGroup.jsx
@@ -15,6 +15,7 @@ export default function RadioButtonGroup({
   onChange,
 }) {
   const row = orientation === ORIENTATIONS.ROW;
+  const column = orientation === ORIENTATIONS.COLUMN;
 
   const handleChangeValue = (event) => {
     onChange(event.target.value);
@@ -30,6 +31,7 @@ export default function RadioButtonGroup({
           'RadioButtonGroup--row': row,
           'RadioButtonGroup--row--full-width': row && fullWidth,
           'RadioButtonGroup--row--compact': row && !fullWidth,
+          'RadioButtonGroup--column--full-width': column && fullWidth,
         },
       )}
       name={name}

--- a/src/RadioButtonGroup/RadioButtonGroup.mdx
+++ b/src/RadioButtonGroup/RadioButtonGroup.mdx
@@ -1,6 +1,7 @@
 import { ArgsTable, Story, Canvas } from '@storybook/addon-docs/blocks';
+import RadioButtonGroup from './RadioButtonGroup';
 
-# Radio Button Group
+# RadioButtonGroup
 
 ##
 
@@ -8,13 +9,13 @@ import { ArgsTable, Story, Canvas } from '@storybook/addon-docs/blocks';
   A collections of radio buttons describing a set of related options. Only one option selected at a time.
 </h4>
 
-### When to use 
-- Reason 1
-- Reason 2
+<Canvas>
+  <Story id="components-form-elements-radiobuttongroup--default"/>
+</Canvas>
 
-### When to not use
-- Reason 1
-- Reason 2
+## Props
+
+<ArgsTable of={RadioButtonGroup} />
 
 ## Stories
 
@@ -26,7 +27,13 @@ Single-selection button.
   <Story id="components-form-elements-radiobuttongroup--default"/>
 </Canvas>
 
-### Bordered
+### Row
+
+<Canvas>
+  <Story id="components-form-elements-radiobuttongroup--row"/>
+</Canvas>
+
+### Bordered Row
 
 Single-selection button. Only used in the context of Radio FormGroups.
 
@@ -34,12 +41,26 @@ Single-selection button. Only used in the context of Radio FormGroups.
   <Story id="components-form-elements-radiobuttongroup--bordered-row"/>
 </Canvas>
 
-### Description
+### Description Column
+
+<Canvas>
+  <Story id="components-form-elements-radiobuttongroup--description-column"/>
+</Canvas>
+
+### Description Row
 
 Single-selection button. Includes helper text and/or a description in addition to the default label.
 
 <Canvas>
   <Story id="components-form-elements-radiobuttongroup--description-row"/>
+</Canvas>
+
+### Bordered Column Full Width
+
+Single-selection button. Includes helper text and/or a description in addition to the default label.
+
+<Canvas>
+  <Story id="components-form-elements-radiobuttongroup--bordered-column-full-width"/>
 </Canvas>
 
 

--- a/src/RadioButtonGroup/RadioButtonGroup.scss
+++ b/src/RadioButtonGroup/RadioButtonGroup.scss
@@ -5,4 +5,8 @@
   &--row {
     @include row-control-group;
   }
+
+  &--column--full-width {
+    width: 100%;
+  }
 }

--- a/src/RadioButtonGroup/RadioButtonGroup.stories.jsx
+++ b/src/RadioButtonGroup/RadioButtonGroup.stories.jsx
@@ -105,7 +105,7 @@ export const Default = () => {
   );
 };
 
-export const DefaultRow = () => (
+export const Row = () => (
   <RadioButtonGroupComponent
     bordered={false}
     defaultValue={null}
@@ -178,12 +178,11 @@ export const BorderedRow = () => (
   </RadioButtonGroupComponent>
 );
 
-export const Description = () => (
+export const DescriptionColumn = () => (
   <RadioButtonGroupComponent
     bordered={false}
     defaultValue={null}
     elementType="fieldset"
-    fullWidth
     id="with-radio-button-group-4"
     label="Legend"
     labelHelperText="helper text"
@@ -260,6 +259,51 @@ export const DescriptionRow = () => (
       Control={RadioButton}
       helperText="helper text"
       id="value-3-5"
+      text="Label 3"
+      value="3"
+    >
+      This is where the description goes
+    </FormControlLabel>
+  </RadioButtonGroupComponent>
+);
+
+export const BorderedColumnFullWidth = () => (
+  <RadioButtonGroupComponent
+    bordered={false}
+    defaultValue={null}
+    elementType="fieldset"
+    fullWidth
+    id="with-radio-button-group-5"
+    label="Legend"
+    labelHelperText="helper text"
+    labelHtmlFor="radio-button-group"
+    orientation={ORIENTATIONS.COLUMN}
+  >
+    <FormControlLabel
+      bordered
+      Control={RadioButton}
+      helperText="helper text"
+      id="value-1-6"
+      text="Label 1"
+      value="1"
+    >
+      This is where the description goes
+    </FormControlLabel>
+    <FormControlLabel
+      bordered
+      Control={RadioButton}
+      helperText="helper text"
+      id="value-2-6"
+      text="Label 2"
+      value="2"
+    >
+      This is where the description goes
+    </FormControlLabel>
+    <FormControlLabel
+      bordered
+      Control={RadioButton}
+      helperText="helper text"
+      id="value-3-6"
       text="Label 3"
       value="3"
     >


### PR DESCRIPTION
closes #730 

**Chromatic Storybook links:**
[CheckboxButtonGroup - Bordered Column Full Width](https://62d040e741710e4f085e0647-voixuxvztu.chromatic.com/?path=/story/components-form-elements-checkboxbuttongroup--bordered-column-full-width)

[RadioButtonGroup - Bordered Column Full Width](https://62d040e741710e4f085e0647-voixuxvztu.chromatic.com/?path=/story/components-form-elements-radiobuttongroup--bordered-column-full-width)

We're making some updates for a better form experience for P's when taking Surveys, especially on mobile (for better touch targets)

- Updates the hover and active state of `FormControlLabel`
- Supports fullWidth for column orientations of `CheckboxButtonGroup` and `RadioButtonGroup`
- Updates stories and docs

Should eventually look something like this (new hover / active states not shown yet, but will be):



https://user-images.githubusercontent.com/37383785/187993668-299a00fe-d743-49e3-a13b-6c4baca35f06.mov


