### PR TITLE
make modal prop work with all Selects

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -8845,7 +8845,7 @@ exports[`Storyshots Components/Selects/Async Default 1`] = `
   >
     <span
       className="css-1f43avz-a11yText-A11yText"
-      id="react-select-3-live-region"
+      id="react-select-4-live-region"
     />
     <span
       aria-atomic="false"
@@ -8863,7 +8863,7 @@ exports[`Storyshots Components/Selects/Async Default 1`] = `
       >
         <div
           className=" css-858797-placeholder"
-          id="react-select-3-placeholder"
+          id="react-select-4-placeholder"
         >
           Select...
         </div>
@@ -8873,7 +8873,7 @@ exports[`Storyshots Components/Selects/Async Default 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-3-placeholder"
+            aria-describedby="react-select-4-placeholder"
             aria-expanded={false}
             aria-haspopup={true}
             aria-label="Async select"
@@ -8882,7 +8882,7 @@ exports[`Storyshots Components/Selects/Async Default 1`] = `
             autoCorrect="off"
             className=""
             disabled={false}
-            id="react-select-3-input"
+            id="react-select-4-input"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -8941,6 +8941,190 @@ exports[`Storyshots Components/Selects/Async Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Selects/Async In Modal 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="ReactModal__Overlay ReactModal__Overlay--after-open"
+    onClick={[Function]}
+    onMouseDown={[Function]}
+    style={
+      Object {
+        "backgroundColor": "rgba(255, 255, 255, 0.75)",
+        "bottom": 0,
+        "left": 0,
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <div
+      aria-label="AsyncSelect in Modal"
+      aria-modal={true}
+      className="ReactModal__Content ReactModal__Content--after-open AsyncSelectInModal"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="dialog"
+      style={Object {}}
+      tabIndex="-1"
+    >
+      <header
+        className="ModalHeader"
+      >
+        <div
+          className="ModalHeader__heading"
+        >
+          <h1
+            className="ModalHeader__title"
+            id="async-select-in-modal"
+          >
+            AsyncSelect in modal
+          </h1>
+        </div>
+        <button
+          aria-label="Close"
+          className="btn btn-sm btn-close"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        />
+      </header>
+      <div
+        className="ModalBody"
+      >
+        <div
+          className="AsyncSelect css-b62m3t-container"
+          id="async-select"
+          onKeyDown={[Function]}
+        >
+          <span
+            className="css-1f43avz-a11yText-A11yText"
+            id="react-select-6-live-region"
+          />
+          <span
+            aria-atomic="false"
+            aria-live="polite"
+            aria-relevant="additions text"
+            className="css-1f43avz-a11yText-A11yText"
+          />
+          <div
+            className=" css-15ub2n0-control"
+            onMouseDown={[Function]}
+            onTouchEnd={[Function]}
+          >
+            <div
+              className=" css-319lph-ValueContainer"
+            >
+              <div
+                className=" css-858797-placeholder"
+                id="react-select-6-placeholder"
+              >
+                Select...
+              </div>
+              <div
+                className=" css-6j8wv5-Input"
+                data-value=""
+              >
+                <input
+                  aria-autocomplete="list"
+                  aria-describedby="react-select-6-placeholder"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  aria-labelledby="async-label"
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  className=""
+                  disabled={false}
+                  id="react-select-6-input"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="combobox"
+                  spellCheck="false"
+                  style={
+                    Object {
+                      "background": 0,
+                      "border": 0,
+                      "color": "inherit",
+                      "font": "inherit",
+                      "gridArea": "1 / 2",
+                      "label": "input",
+                      "margin": 0,
+                      "minWidth": "2px",
+                      "opacity": 1,
+                      "outline": 0,
+                      "padding": 0,
+                      "width": "100%",
+                    }
+                  }
+                  tabIndex={0}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              className=" css-1hb7zxy-IndicatorsContainer"
+            >
+              <span
+                className=" css-43ykx9-indicatorSeparator"
+              />
+              <div
+                aria-hidden="true"
+                className=" css-7sl878-indicatorContainer"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
+              >
+                <svg
+                  aria-hidden="true"
+                  className="css-tj5bde-Svg"
+                  focusable="false"
+                  height={20}
+                  viewBox="0 0 20 20"
+                  width={20}
+                >
+                  <path
+                    d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ModalFooter"
+      >
+        <button
+          className="Button btn btn-transparent"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          Cancel
+        </button>
+        <button
+          className="Button btn btn-primary"
+          disabled={false}
+          type="submit"
+        >
+          Confirm
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Components/Selects/Async Labeled 1`] = `
 <div
   style={
@@ -8962,7 +9146,7 @@ exports[`Storyshots Components/Selects/Async Labeled 1`] = `
   >
     <span
       className="css-1f43avz-a11yText-A11yText"
-      id="react-select-4-live-region"
+      id="react-select-5-live-region"
     />
     <span
       aria-atomic="false"
@@ -8980,7 +9164,7 @@ exports[`Storyshots Components/Selects/Async Labeled 1`] = `
       >
         <div
           className=" css-858797-placeholder"
-          id="react-select-4-placeholder"
+          id="react-select-5-placeholder"
         >
           Select...
         </div>
@@ -8990,7 +9174,7 @@ exports[`Storyshots Components/Selects/Async Labeled 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-4-placeholder"
+            aria-describedby="react-select-5-placeholder"
             aria-expanded={false}
             aria-haspopup={true}
             aria-labelledby="async-label"
@@ -8999,7 +9183,7 @@ exports[`Storyshots Components/Selects/Async Labeled 1`] = `
             autoCorrect="off"
             className=""
             disabled={false}
-            id="react-select-4-input"
+            id="react-select-5-input"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -9168,6 +9352,190 @@ exports[`Storyshots Components/Selects/AsyncCreatable Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Selects/AsyncCreatable In Modal 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="ReactModal__Overlay ReactModal__Overlay--after-open"
+    onClick={[Function]}
+    onMouseDown={[Function]}
+    style={
+      Object {
+        "backgroundColor": "rgba(255, 255, 255, 0.75)",
+        "bottom": 0,
+        "left": 0,
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <div
+      aria-label="AsyncCreatableSelect in Modal"
+      aria-modal={true}
+      className="ReactModal__Content ReactModal__Content--after-open AsyncCreatableSelectInModal"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="dialog"
+      style={Object {}}
+      tabIndex="-1"
+    >
+      <header
+        className="ModalHeader"
+      >
+        <div
+          className="ModalHeader__heading"
+        >
+          <h1
+            className="ModalHeader__title"
+            id="async-creatable-select-in-modal"
+          >
+            AsyncCreatableSelect in modal
+          </h1>
+        </div>
+        <button
+          aria-label="Close"
+          className="btn btn-sm btn-close"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        />
+      </header>
+      <div
+        className="ModalBody"
+      >
+        <div
+          className="AsyncSelect css-b62m3t-container"
+          id="async-creatable-select"
+          onKeyDown={[Function]}
+        >
+          <span
+            className="css-1f43avz-a11yText-A11yText"
+            id="react-select-3-live-region"
+          />
+          <span
+            aria-atomic="false"
+            aria-live="polite"
+            aria-relevant="additions text"
+            className="css-1f43avz-a11yText-A11yText"
+          />
+          <div
+            className=" css-15ub2n0-control"
+            onMouseDown={[Function]}
+            onTouchEnd={[Function]}
+          >
+            <div
+              className=" css-319lph-ValueContainer"
+            >
+              <div
+                className=" css-858797-placeholder"
+                id="react-select-3-placeholder"
+              >
+                Select...
+              </div>
+              <div
+                className=" css-6j8wv5-Input"
+                data-value=""
+              >
+                <input
+                  aria-autocomplete="list"
+                  aria-describedby="react-select-3-placeholder"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  aria-labelledby="async-label"
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  className=""
+                  disabled={false}
+                  id="react-select-3-input"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="combobox"
+                  spellCheck="false"
+                  style={
+                    Object {
+                      "background": 0,
+                      "border": 0,
+                      "color": "inherit",
+                      "font": "inherit",
+                      "gridArea": "1 / 2",
+                      "label": "input",
+                      "margin": 0,
+                      "minWidth": "2px",
+                      "opacity": 1,
+                      "outline": 0,
+                      "padding": 0,
+                      "width": "100%",
+                    }
+                  }
+                  tabIndex={0}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              className=" css-1hb7zxy-IndicatorsContainer"
+            >
+              <span
+                className=" css-43ykx9-indicatorSeparator"
+              />
+              <div
+                aria-hidden="true"
+                className=" css-7sl878-indicatorContainer"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
+              >
+                <svg
+                  aria-hidden="true"
+                  className="css-tj5bde-Svg"
+                  focusable="false"
+                  height={20}
+                  viewBox="0 0 20 20"
+                  width={20}
+                >
+                  <path
+                    d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ModalFooter"
+      >
+        <button
+          className="Button btn btn-transparent"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          Cancel
+        </button>
+        <button
+          className="Button btn btn-primary"
+          disabled={false}
+          type="submit"
+        >
+          Confirm
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Components/Selects/Creatable Default 1`] = `
 <div
   style={
@@ -9182,7 +9550,7 @@ exports[`Storyshots Components/Selects/Creatable Default 1`] = `
   >
     <span
       className="css-1f43avz-a11yText-A11yText"
-      id="react-select-5-live-region"
+      id="react-select-7-live-region"
     />
     <span
       aria-atomic="false"
@@ -9200,7 +9568,7 @@ exports[`Storyshots Components/Selects/Creatable Default 1`] = `
       >
         <div
           className=" css-858797-placeholder"
-          id="react-select-5-placeholder"
+          id="react-select-7-placeholder"
         >
           Select...
         </div>
@@ -9210,7 +9578,7 @@ exports[`Storyshots Components/Selects/Creatable Default 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-5-placeholder"
+            aria-describedby="react-select-7-placeholder"
             aria-expanded={false}
             aria-haspopup={true}
             autoCapitalize="none"
@@ -9218,7 +9586,7 @@ exports[`Storyshots Components/Selects/Creatable Default 1`] = `
             autoCorrect="off"
             className=""
             disabled={false}
-            id="react-select-5-input"
+            id="react-select-7-input"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -9277,6 +9645,188 @@ exports[`Storyshots Components/Selects/Creatable Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Selects/Creatable In Modal 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="ReactModal__Overlay ReactModal__Overlay--after-open"
+    onClick={[Function]}
+    onMouseDown={[Function]}
+    style={
+      Object {
+        "backgroundColor": "rgba(255, 255, 255, 0.75)",
+        "bottom": 0,
+        "left": 0,
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <div
+      aria-label="CreatableSelect in Modal"
+      aria-modal={true}
+      className="ReactModal__Content ReactModal__Content--after-open CreatableSelectInModal"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="dialog"
+      style={Object {}}
+      tabIndex="-1"
+    >
+      <header
+        className="ModalHeader"
+      >
+        <div
+          className="ModalHeader__heading"
+        >
+          <h1
+            className="ModalHeader__title"
+            id="creatable-select-in-modal"
+          >
+            CreatableSelect in modal
+          </h1>
+        </div>
+        <button
+          aria-label="Close"
+          className="btn btn-sm btn-close"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        />
+      </header>
+      <div
+        className="ModalBody"
+      >
+        <div
+          className="CreatableSelect css-b62m3t-container"
+          onKeyDown={[Function]}
+        >
+          <span
+            className="css-1f43avz-a11yText-A11yText"
+            id="react-select-8-live-region"
+          />
+          <span
+            aria-atomic="false"
+            aria-live="polite"
+            aria-relevant="additions text"
+            className="css-1f43avz-a11yText-A11yText"
+          />
+          <div
+            className=" css-15ub2n0-control"
+            onMouseDown={[Function]}
+            onTouchEnd={[Function]}
+          >
+            <div
+              className=" css-319lph-ValueContainer"
+            >
+              <div
+                className=" css-858797-placeholder"
+                id="react-select-8-placeholder"
+              >
+                Select...
+              </div>
+              <div
+                className=" css-6j8wv5-Input"
+                data-value=""
+              >
+                <input
+                  aria-autocomplete="list"
+                  aria-describedby="react-select-8-placeholder"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  className=""
+                  disabled={false}
+                  id="react-select-8-input"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="combobox"
+                  spellCheck="false"
+                  style={
+                    Object {
+                      "background": 0,
+                      "border": 0,
+                      "color": "inherit",
+                      "font": "inherit",
+                      "gridArea": "1 / 2",
+                      "label": "input",
+                      "margin": 0,
+                      "minWidth": "2px",
+                      "opacity": 1,
+                      "outline": 0,
+                      "padding": 0,
+                      "width": "100%",
+                    }
+                  }
+                  tabIndex={0}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              className=" css-1hb7zxy-IndicatorsContainer"
+            >
+              <span
+                className=" css-43ykx9-indicatorSeparator"
+              />
+              <div
+                aria-hidden="true"
+                className=" css-7sl878-indicatorContainer"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
+              >
+                <svg
+                  aria-hidden="true"
+                  className="css-tj5bde-Svg"
+                  focusable="false"
+                  height={20}
+                  viewBox="0 0 20 20"
+                  width={20}
+                >
+                  <path
+                    d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ModalFooter"
+      >
+        <button
+          className="Button btn btn-transparent"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          Cancel
+        </button>
+        <button
+          className="Button btn btn-primary"
+          disabled={false}
+          type="submit"
+        >
+          Confirm
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Components/Selects/Single Custom Option With Checkbox 1`] = `
 <div
   style={
@@ -9298,7 +9848,7 @@ exports[`Storyshots Components/Selects/Single Custom Option With Checkbox 1`] = 
   >
     <span
       className="css-1f43avz-a11yText-A11yText"
-      id="react-select-12-live-region"
+      id="react-select-15-live-region"
     />
     <span
       aria-atomic="false"
@@ -9316,20 +9866,20 @@ exports[`Storyshots Components/Selects/Single Custom Option With Checkbox 1`] = 
       >
         <div
           className=" css-858797-placeholder"
-          id="react-select-12-placeholder"
+          id="react-select-15-placeholder"
         >
           Select...
         </div>
         <input
           aria-autocomplete="list"
-          aria-describedby="react-select-12-placeholder"
+          aria-describedby="react-select-15-placeholder"
           aria-expanded={false}
           aria-haspopup={true}
           aria-labelledby="select-label"
           aria-readonly={true}
           className="css-mohuvp-dummyInput-DummyInput"
           disabled={false}
-          id="react-select-12-input"
+          id="react-select-15-input"
           inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}
@@ -9391,7 +9941,7 @@ exports[`Storyshots Components/Selects/Single Custom Option With Indeterminate C
   >
     <span
       className="css-1f43avz-a11yText-A11yText"
-      id="react-select-13-live-region"
+      id="react-select-16-live-region"
     />
     <span
       aria-atomic="false"
@@ -9409,20 +9959,20 @@ exports[`Storyshots Components/Selects/Single Custom Option With Indeterminate C
       >
         <div
           className=" css-858797-placeholder"
-          id="react-select-13-placeholder"
+          id="react-select-16-placeholder"
         >
           Select...
         </div>
         <input
           aria-autocomplete="list"
-          aria-describedby="react-select-13-placeholder"
+          aria-describedby="react-select-16-placeholder"
           aria-expanded={false}
           aria-haspopup={true}
           aria-labelledby="select-label"
           aria-readonly={true}
           className="css-mohuvp-dummyInput-DummyInput"
           disabled={false}
-          id="react-select-13-input"
+          id="react-select-16-input"
           inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}
@@ -9484,7 +10034,7 @@ exports[`Storyshots Components/Selects/Single Custom Value Container 1`] = `
   >
     <span
       className="css-1f43avz-a11yText-A11yText"
-      id="react-select-14-live-region"
+      id="react-select-17-live-region"
     />
     <span
       aria-atomic="false"
@@ -9502,20 +10052,20 @@ exports[`Storyshots Components/Selects/Single Custom Value Container 1`] = `
       >
         <div
           className=" css-858797-placeholder"
-          id="react-select-14-placeholder"
+          id="react-select-17-placeholder"
         >
           Select...
         </div>
         <input
           aria-autocomplete="list"
-          aria-describedby="react-select-14-placeholder"
+          aria-describedby="react-select-17-placeholder"
           aria-expanded={false}
           aria-haspopup={true}
           aria-labelledby="select-label"
           aria-readonly={true}
           className="css-mohuvp-dummyInput-DummyInput"
           disabled={false}
-          id="react-select-14-input"
+          id="react-select-17-input"
           inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}
@@ -9570,7 +10120,7 @@ exports[`Storyshots Components/Selects/Single Default 1`] = `
   >
     <span
       className="css-1f43avz-a11yText-A11yText"
-      id="react-select-6-live-region"
+      id="react-select-9-live-region"
     />
     <span
       aria-atomic="false"
@@ -9588,20 +10138,20 @@ exports[`Storyshots Components/Selects/Single Default 1`] = `
       >
         <div
           className=" css-858797-placeholder"
-          id="react-select-6-placeholder"
+          id="react-select-9-placeholder"
         >
           Select...
         </div>
         <input
           aria-autocomplete="list"
-          aria-describedby="react-select-6-placeholder"
+          aria-describedby="react-select-9-placeholder"
           aria-expanded={false}
           aria-haspopup={true}
           aria-label="Default select"
           aria-readonly={true}
           className="css-mohuvp-dummyInput-DummyInput"
           disabled={false}
-          id="react-select-6-input"
+          id="react-select-9-input"
           inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}
@@ -9701,9 +10251,6 @@ exports[`Storyshots Components/Selects/Single In Modal 1`] = `
       <div
         className="ModalBody"
       >
-        <span>
-          A select inside a modal
-        </span>
         <div
           className="SingleSelect css-b62m3t-container"
           id="select-in-modal"
@@ -9711,7 +10258,7 @@ exports[`Storyshots Components/Selects/Single In Modal 1`] = `
         >
           <span
             className="css-1f43avz-a11yText-A11yText"
-            id="react-select-11-live-region"
+            id="react-select-14-live-region"
           />
           <span
             aria-atomic="false"
@@ -9729,20 +10276,20 @@ exports[`Storyshots Components/Selects/Single In Modal 1`] = `
             >
               <div
                 className=" css-858797-placeholder"
-                id="react-select-11-placeholder"
+                id="react-select-14-placeholder"
               >
                 Select...
               </div>
               <input
                 aria-autocomplete="list"
-                aria-describedby="react-select-11-placeholder"
+                aria-describedby="react-select-14-placeholder"
                 aria-expanded={false}
                 aria-haspopup={true}
                 aria-labelledby="select-label"
                 aria-readonly={true}
                 className="css-mohuvp-dummyInput-DummyInput"
                 disabled={false}
-                id="react-select-11-input"
+                id="react-select-14-input"
                 inputMode="none"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -9785,16 +10332,19 @@ exports[`Storyshots Components/Selects/Single In Modal 1`] = `
         className="ModalFooter"
       >
         <button
-          className="btn btn-transparent"
+          className="Button btn btn-transparent"
+          disabled={false}
+          onClick={[Function]}
           type="button"
         >
           Cancel
         </button>
         <button
-          className="btn btn-success"
+          className="Button btn btn-primary"
+          disabled={false}
           type="submit"
         >
-          Save
+          Confirm
         </button>
       </div>
     </div>
@@ -9823,7 +10373,7 @@ exports[`Storyshots Components/Selects/Single Labeled 1`] = `
   >
     <span
       className="css-1f43avz-a11yText-A11yText"
-      id="react-select-9-live-region"
+      id="react-select-12-live-region"
     />
     <span
       aria-atomic="false"
@@ -9841,20 +10391,20 @@ exports[`Storyshots Components/Selects/Single Labeled 1`] = `
       >
         <div
           className=" css-858797-placeholder"
-          id="react-select-9-placeholder"
+          id="react-select-12-placeholder"
         >
           Select...
         </div>
         <input
           aria-autocomplete="list"
-          aria-describedby="react-select-9-placeholder"
+          aria-describedby="react-select-12-placeholder"
           aria-expanded={false}
           aria-haspopup={true}
           aria-labelledby="select-label"
           aria-readonly={true}
           className="css-mohuvp-dummyInput-DummyInput"
           disabled={false}
-          id="react-select-9-input"
+          id="react-select-12-input"
           inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}
@@ -9909,7 +10459,7 @@ exports[`Storyshots Components/Selects/Single Loading 1`] = `
   >
     <span
       className="css-1f43avz-a11yText-A11yText"
-      id="react-select-8-live-region"
+      id="react-select-11-live-region"
     />
     <span
       aria-atomic="false"
@@ -9927,20 +10477,20 @@ exports[`Storyshots Components/Selects/Single Loading 1`] = `
       >
         <div
           className=" css-858797-placeholder"
-          id="react-select-8-placeholder"
+          id="react-select-11-placeholder"
         >
           Select...
         </div>
         <input
           aria-autocomplete="list"
-          aria-describedby="react-select-8-placeholder"
+          aria-describedby="react-select-11-placeholder"
           aria-expanded={false}
           aria-haspopup={true}
           aria-label="Loading select"
           aria-readonly={true}
           className="css-mohuvp-dummyInput-DummyInput"
           disabled={true}
-          id="react-select-8-input"
+          id="react-select-11-input"
           inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}
@@ -10002,7 +10552,7 @@ exports[`Storyshots Components/Selects/Single Multi Select 1`] = `
   >
     <span
       className="css-1f43avz-a11yText-A11yText"
-      id="react-select-10-live-region"
+      id="react-select-13-live-region"
     />
     <span
       aria-atomic="false"
@@ -10020,20 +10570,20 @@ exports[`Storyshots Components/Selects/Single Multi Select 1`] = `
       >
         <div
           className=" css-858797-placeholder"
-          id="react-select-10-placeholder"
+          id="react-select-13-placeholder"
         >
           Select...
         </div>
         <input
           aria-autocomplete="list"
-          aria-describedby="react-select-10-placeholder"
+          aria-describedby="react-select-13-placeholder"
           aria-expanded={false}
           aria-haspopup={true}
           aria-labelledby="select-label"
           aria-readonly={true}
           className="css-mohuvp-dummyInput-DummyInput"
           disabled={false}
-          id="react-select-10-input"
+          id="react-select-13-input"
           inputMode="none"
           onBlur={[Function]}
           onChange={[Function]}
@@ -10088,7 +10638,7 @@ exports[`Storyshots Components/Selects/Single Searchable 1`] = `
   >
     <span
       className="css-1f43avz-a11yText-A11yText"
-      id="react-select-7-live-region"
+      id="react-select-10-live-region"
     />
     <span
       aria-atomic="false"
@@ -10106,7 +10656,7 @@ exports[`Storyshots Components/Selects/Single Searchable 1`] = `
       >
         <div
           className=" css-858797-placeholder"
-          id="react-select-7-placeholder"
+          id="react-select-10-placeholder"
         >
           Select...
         </div>
@@ -10116,7 +10666,7 @@ exports[`Storyshots Components/Selects/Single Searchable 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-7-placeholder"
+            aria-describedby="react-select-10-placeholder"
             aria-expanded={false}
             aria-haspopup={true}
             aria-label="Searchable select"
@@ -10125,7 +10675,7 @@ exports[`Storyshots Components/Selects/Single Searchable 1`] = `
             autoCorrect="off"
             className=""
             disabled={false}
-            id="react-select-7-input"
+            id="react-select-10-input"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -19591,6 +20141,7 @@ exports[`Storyshots Components/Tabs Controlled 1`] = `
         >
           <button
             aria-controls="controlled-tabpane-two"
+            aria-selected={false}
             className="nav-link"
             data-rr-ui-event-key="two"
             disabled={false}
@@ -19609,6 +20160,7 @@ exports[`Storyshots Components/Tabs Controlled 1`] = `
         >
           <button
             aria-controls="controlled-tabpane-three"
+            aria-selected={false}
             className="nav-link"
             data-rr-ui-event-key="three"
             disabled={false}
@@ -19628,6 +20180,7 @@ exports[`Storyshots Components/Tabs Controlled 1`] = `
           <button
             aria-controls="controlled-tabpane-four"
             aria-disabled={true}
+            aria-selected={false}
             className="nav-link disabled"
             data-rr-ui-event-key="four"
             disabled={true}
@@ -19646,8 +20199,9 @@ exports[`Storyshots Components/Tabs Controlled 1`] = `
       >
         <div
           aria-labelledby="controlled-tab-one"
-          className="tab-pane active"
+          className="fade tab-pane active show"
           id="controlled-tabpane-one"
+          role="tabpanel"
         >
           <div
             style={
@@ -19661,8 +20215,9 @@ exports[`Storyshots Components/Tabs Controlled 1`] = `
         </div>
         <div
           aria-labelledby="controlled-tab-two"
-          className="tab-pane"
+          className="fade tab-pane"
           id="controlled-tabpane-two"
+          role="tabpanel"
         >
           <div
             style={
@@ -19676,8 +20231,9 @@ exports[`Storyshots Components/Tabs Controlled 1`] = `
         </div>
         <div
           aria-labelledby="controlled-tab-three"
-          className="tab-pane"
+          className="fade tab-pane"
           id="controlled-tabpane-three"
+          role="tabpanel"
         >
           <div
             style={
@@ -19691,8 +20247,9 @@ exports[`Storyshots Components/Tabs Controlled 1`] = `
         </div>
         <div
           aria-labelledby="controlled-tab-four"
-          className="tab-pane"
+          className="fade tab-pane"
           id="controlled-tabpane-four"
+          role="tabpanel"
         >
           <div
             style={
@@ -19751,6 +20308,7 @@ exports[`Storyshots Components/Tabs Uncontrolled 1`] = `
         >
           <button
             aria-controls="uncontrolled-tabpane-two"
+            aria-selected={false}
             className="nav-link"
             data-rr-ui-event-key="two"
             disabled={false}
@@ -19769,6 +20327,7 @@ exports[`Storyshots Components/Tabs Uncontrolled 1`] = `
         >
           <button
             aria-controls="uncontrolled-tabpane-three"
+            aria-selected={false}
             className="nav-link"
             data-rr-ui-event-key="three"
             disabled={false}
@@ -19788,6 +20347,7 @@ exports[`Storyshots Components/Tabs Uncontrolled 1`] = `
           <button
             aria-controls="uncontrolled-tabpane-four"
             aria-disabled={true}
+            aria-selected={false}
             className="nav-link disabled"
             data-rr-ui-event-key="four"
             disabled={true}
@@ -19806,8 +20366,9 @@ exports[`Storyshots Components/Tabs Uncontrolled 1`] = `
       >
         <div
           aria-labelledby="uncontrolled-tab-one"
-          className="tab-pane active"
+          className="fade tab-pane active show"
           id="uncontrolled-tabpane-one"
+          role="tabpanel"
         >
           <div
             style={
@@ -19821,8 +20382,9 @@ exports[`Storyshots Components/Tabs Uncontrolled 1`] = `
         </div>
         <div
           aria-labelledby="uncontrolled-tab-two"
-          className="tab-pane"
+          className="fade tab-pane"
           id="uncontrolled-tabpane-two"
+          role="tabpanel"
         >
           <div
             style={
@@ -19836,8 +20398,9 @@ exports[`Storyshots Components/Tabs Uncontrolled 1`] = `
         </div>
         <div
           aria-labelledby="uncontrolled-tab-three"
-          className="tab-pane"
+          className="fade tab-pane"
           id="uncontrolled-tabpane-three"
+          role="tabpanel"
         >
           <div
             style={
@@ -19851,8 +20414,9 @@ exports[`Storyshots Components/Tabs Uncontrolled 1`] = `
         </div>
         <div
           aria-labelledby="uncontrolled-tab-four"
-          className="tab-pane"
+          className="fade tab-pane"
           id="uncontrolled-tabpane-four"
+          role="tabpanel"
         >
           <div
             style={

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -20141,7 +20141,6 @@ exports[`Storyshots Components/Tabs Controlled 1`] = `
         >
           <button
             aria-controls="controlled-tabpane-two"
-            aria-selected={false}
             className="nav-link"
             data-rr-ui-event-key="two"
             disabled={false}
@@ -20160,7 +20159,6 @@ exports[`Storyshots Components/Tabs Controlled 1`] = `
         >
           <button
             aria-controls="controlled-tabpane-three"
-            aria-selected={false}
             className="nav-link"
             data-rr-ui-event-key="three"
             disabled={false}
@@ -20180,7 +20178,6 @@ exports[`Storyshots Components/Tabs Controlled 1`] = `
           <button
             aria-controls="controlled-tabpane-four"
             aria-disabled={true}
-            aria-selected={false}
             className="nav-link disabled"
             data-rr-ui-event-key="four"
             disabled={true}
@@ -20199,9 +20196,8 @@ exports[`Storyshots Components/Tabs Controlled 1`] = `
       >
         <div
           aria-labelledby="controlled-tab-one"
-          className="fade tab-pane active show"
+          className="tab-pane active"
           id="controlled-tabpane-one"
-          role="tabpanel"
         >
           <div
             style={
@@ -20215,9 +20211,8 @@ exports[`Storyshots Components/Tabs Controlled 1`] = `
         </div>
         <div
           aria-labelledby="controlled-tab-two"
-          className="fade tab-pane"
+          className="tab-pane"
           id="controlled-tabpane-two"
-          role="tabpanel"
         >
           <div
             style={
@@ -20231,9 +20226,8 @@ exports[`Storyshots Components/Tabs Controlled 1`] = `
         </div>
         <div
           aria-labelledby="controlled-tab-three"
-          className="fade tab-pane"
+          className="tab-pane"
           id="controlled-tabpane-three"
-          role="tabpanel"
         >
           <div
             style={
@@ -20247,9 +20241,8 @@ exports[`Storyshots Components/Tabs Controlled 1`] = `
         </div>
         <div
           aria-labelledby="controlled-tab-four"
-          className="fade tab-pane"
+          className="tab-pane"
           id="controlled-tabpane-four"
-          role="tabpanel"
         >
           <div
             style={
@@ -20308,7 +20301,6 @@ exports[`Storyshots Components/Tabs Uncontrolled 1`] = `
         >
           <button
             aria-controls="uncontrolled-tabpane-two"
-            aria-selected={false}
             className="nav-link"
             data-rr-ui-event-key="two"
             disabled={false}
@@ -20327,7 +20319,6 @@ exports[`Storyshots Components/Tabs Uncontrolled 1`] = `
         >
           <button
             aria-controls="uncontrolled-tabpane-three"
-            aria-selected={false}
             className="nav-link"
             data-rr-ui-event-key="three"
             disabled={false}
@@ -20347,7 +20338,6 @@ exports[`Storyshots Components/Tabs Uncontrolled 1`] = `
           <button
             aria-controls="uncontrolled-tabpane-four"
             aria-disabled={true}
-            aria-selected={false}
             className="nav-link disabled"
             data-rr-ui-event-key="four"
             disabled={true}
@@ -20366,9 +20356,8 @@ exports[`Storyshots Components/Tabs Uncontrolled 1`] = `
       >
         <div
           aria-labelledby="uncontrolled-tab-one"
-          className="fade tab-pane active show"
+          className="tab-pane active"
           id="uncontrolled-tabpane-one"
-          role="tabpanel"
         >
           <div
             style={
@@ -20382,9 +20371,8 @@ exports[`Storyshots Components/Tabs Uncontrolled 1`] = `
         </div>
         <div
           aria-labelledby="uncontrolled-tab-two"
-          className="fade tab-pane"
+          className="tab-pane"
           id="uncontrolled-tabpane-two"
-          role="tabpanel"
         >
           <div
             style={
@@ -20398,9 +20386,8 @@ exports[`Storyshots Components/Tabs Uncontrolled 1`] = `
         </div>
         <div
           aria-labelledby="uncontrolled-tab-three"
-          className="fade tab-pane"
+          className="tab-pane"
           id="uncontrolled-tabpane-three"
-          role="tabpanel"
         >
           <div
             style={
@@ -20414,9 +20401,8 @@ exports[`Storyshots Components/Tabs Uncontrolled 1`] = `
         </div>
         <div
           aria-labelledby="uncontrolled-tab-four"
-          className="fade tab-pane"
+          className="tab-pane"
           id="uncontrolled-tabpane-four"
-          role="tabpanel"
         >
           <div
             style={

--- a/src/Select/AsyncCreatableSelect.jsx
+++ b/src/Select/AsyncCreatableSelect.jsx
@@ -56,8 +56,8 @@ const AsyncCreatableSelect = ({
       ...defaultStyles({ size }),
       menuPortal: (base) => (
         modal ?
-          base :
-          { ...base, zIndex: zStack.zIndexModalBackdrop + 1 }
+        { ...base, zIndex: zStack.zIndexModalBackdrop + 1 } :
+          base
       ),
     }}
     theme={defaultTheme}

--- a/src/Select/AsyncCreatableSelect.stories.jsx
+++ b/src/Select/AsyncCreatableSelect.stories.jsx
@@ -1,6 +1,11 @@
 import React from 'react';
+import { action } from '@storybook/addon-actions';
 
 import AsyncCreatableSelect from 'src/Select/AsyncCreatableSelect';
+import Button from 'src/Button';
+import {
+  Modal, ModalHeader, ModalBody, ModalFooter,
+ } from 'src/Modal';
 
 export default {
   title: 'Components/Selects/AsyncCreatable',
@@ -12,6 +17,8 @@ const options = [
   { label: 'Green', value: 2 },
   { label: 'Blue', value: 3 },
 ];
+
+const handleRequestClose = () => action('Close');
 
 async function loadOptions(search) {
   await new Promise((resolve) => setTimeout(resolve, 2000));
@@ -37,3 +44,35 @@ export const Default = () => {
     />
   );
 };
+
+export const InModal = () => (
+  <Modal
+    ariaHideApp={false}
+    className="AsyncCreatableSelectInModal"
+    contentLabel="AsyncCreatableSelect in Modal"
+    isOpen
+  >
+    <ModalHeader
+      title="AsyncCreatableSelect in modal"
+      titleId="async-creatable-select-in-modal"
+      onRequestClose={handleRequestClose}
+    />
+    <ModalBody>
+      <AsyncCreatableSelect
+        aria-labelledby="async-label"
+        getOptionLabel={({ label }) => label}
+        getOptionValue={({ value }) => value}
+        id="async-creatable-select"
+        loadOptions={loadOptions}
+        modal
+        noOptionsMessage={({ inputValue }) => inputValue.length ? 'No results!' : 'Type to search...'}
+      />
+    </ModalBody>
+    <ModalFooter
+      dismissButtonText="Cancel"
+      onRequestClose={handleRequestClose}
+    >
+      <Button type="submit" variant="primary">Confirm</Button>
+    </ModalFooter>
+  </Modal>
+  );

--- a/src/Select/AsyncSelect.jsx
+++ b/src/Select/AsyncSelect.jsx
@@ -56,8 +56,8 @@ const AsyncSelect = ({
       ...defaultStyles({ size }),
       menuPortal: (base) => (
         modal ?
-          base :
-          { ...base, zIndex: zStack.zIndexModalBackdrop + 1 }
+        { ...base, zIndex: zStack.zIndexModalBackdrop + 1 } :
+          base
       ),
     }}
     theme={defaultTheme}

--- a/src/Select/AsyncSelect.stories.jsx
+++ b/src/Select/AsyncSelect.stories.jsx
@@ -1,6 +1,11 @@
 import React, { Fragment } from 'react';
+import { action } from '@storybook/addon-actions';
 
 import AsyncSelect from 'src/Select/AsyncSelect';
+import Button from 'src/Button';
+import {
+  Modal, ModalHeader, ModalBody, ModalFooter,
+ } from 'src/Modal';
 
 export default {
   title: 'Components/Selects/Async',
@@ -22,6 +27,8 @@ async function loadOptions(search) {
 
   return options.filter(({ label }) => label.toLowerCase().includes(search.toLowerCase()));
 }
+
+const handleRequestClose = () => action('Close');
 
 export const Default = () => (
   <AsyncSelect
@@ -46,3 +53,35 @@ export const Labeled = () => (
     />
   </Fragment>
 );
+
+export const InModal = () => (
+  <Modal
+    ariaHideApp={false}
+    className="AsyncSelectInModal"
+    contentLabel="AsyncSelect in Modal"
+    isOpen
+  >
+    <ModalHeader
+      title="AsyncSelect in modal"
+      titleId="async-select-in-modal"
+      onRequestClose={handleRequestClose}
+    />
+    <ModalBody>
+      <AsyncSelect
+        aria-labelledby="async-label"
+        getOptionLabel={({ label }) => label}
+        getOptionValue={({ value }) => value}
+        id="async-select"
+        loadOptions={loadOptions}
+        modal
+        noOptionsMessage={({ inputValue }) => inputValue.length ? 'No results!' : 'Type to search...'}
+      />
+    </ModalBody>
+    <ModalFooter
+      dismissButtonText="Cancel"
+      onRequestClose={handleRequestClose}
+    >
+      <Button type="submit" variant="primary">Confirm</Button>
+    </ModalFooter>
+  </Modal>
+  );

--- a/src/Select/CreatableSelect.jsx
+++ b/src/Select/CreatableSelect.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Creatable from 'react-select/creatable';
 import PropTypes from 'prop-types';
 
+import zStack from 'src/Styles/zStack';
+
 import { defaultTheme, defaultStyles, SELECT_SIZES } from './styles';
 
 const CreatableSelect = ({
@@ -43,13 +45,13 @@ const CreatableSelect = ({
     options={options}
     placeholder={placeholder}
     styles={{
-        ...defaultStyles({ size }),
-        menuPortal: (base) => (
-          modal ?
-            base :
-            { ...base, zIndex: zStack.zIndexModalBackdrop + 1 }
-        ),
-      }}
+      ...defaultStyles({ size }),
+      menuPortal: (base) => (
+        modal ?
+        { ...base, zIndex: zStack.zIndexModalBackdrop + 1 } :
+          base
+      ),
+    }}
     theme={defaultTheme}
     value={value}
     onChange={onChange}

--- a/src/Select/CreatableSelect.stories.jsx
+++ b/src/Select/CreatableSelect.stories.jsx
@@ -1,6 +1,11 @@
 import React from 'react';
+import { action } from '@storybook/addon-actions';
 
+import Button from 'src/Button';
 import CreatableSelect from 'src/Select/CreatableSelect';
+import {
+  Modal, ModalHeader, ModalBody, ModalFooter,
+ } from 'src/Modal';
 
 export default {
   title: 'Components/Selects/Creatable',
@@ -24,5 +29,41 @@ export const Default = () => {
       onChange={handleChange}
       onInputChange={handleInputChange}
     />
+  );
+};
+
+export const InModal = () => {
+  const handleChange = () => {};
+  const handleInputChange = () => {};
+  const handleRequestClose = () => action('Close');
+
+  return (
+    <Modal
+      ariaHideApp={false}
+      className="CreatableSelectInModal"
+      contentLabel="CreatableSelect in Modal"
+      isOpen
+    >
+      <ModalHeader
+        title="CreatableSelect in modal"
+        titleId="creatable-select-in-modal"
+        onRequestClose={handleRequestClose}
+      />
+      <ModalBody>
+        <CreatableSelect
+          isClearable
+          modal
+          options={options}
+          onChange={handleChange}
+          onInputChange={handleInputChange}
+        />
+      </ModalBody>
+      <ModalFooter
+        dismissButtonText="Cancel"
+        onRequestClose={handleRequestClose}
+      >
+        <Button type="submit" variant="primary">Confirm</Button>
+      </ModalFooter>
+    </Modal>
   );
 };

--- a/src/Select/SingleSelect.stories.jsx
+++ b/src/Select/SingleSelect.stories.jsx
@@ -1,6 +1,7 @@
 import React, { Fragment, useRef } from 'react';
 import { action } from '@storybook/addon-actions';
 
+import Button from 'src/Button';
 import {
  Modal, ModalHeader, ModalBody, ModalFooter,
 } from 'src/Modal';
@@ -83,7 +84,6 @@ export const InModal = () => (
       onRequestClose={handleRequestClose}
     />
     <ModalBody>
-      <span>A select inside a modal</span>
       <SingleSelect
         aria-labelledby="select-label"
         id="select-in-modal"
@@ -92,9 +92,11 @@ export const InModal = () => (
         onChange={onChange}
       />
     </ModalBody>
-    <ModalFooter>
-      <button className="btn btn-transparent" type="button">Cancel</button>
-      <button className="btn btn-success" type="submit">Save</button>
+    <ModalFooter
+      dismissButtonText="Cancel"
+      onRequestClose={handleRequestClose}
+    >
+      <Button type="submit" variant="primary">Confirm</Button>
     </ModalFooter>
   </Modal>
   );

--- a/src/Tabs/__snapshots__/Tabs.test.jsx.snap
+++ b/src/Tabs/__snapshots__/Tabs.test.jsx.snap
@@ -34,6 +34,7 @@ Object {
           >
             <button
               aria-controls="tabID-tabpane-two"
+              aria-selected="false"
               class="nav-link"
               data-rr-ui-event-key="two"
               id="tabID-tab-two"
@@ -51,6 +52,7 @@ Object {
             <button
               aria-controls="tabID-tabpane-three"
               aria-disabled="true"
+              aria-selected="false"
               class="nav-link disabled"
               data-rr-ui-event-key="three"
               disabled=""
@@ -70,6 +72,7 @@ Object {
             aria-labelledby="tabID-tab-one"
             class="tab-pane active"
             id="tabID-tabpane-one"
+            role="tabpanel"
           >
             Tab Content One
           </div>
@@ -77,6 +80,7 @@ Object {
             aria-labelledby="tabID-tab-two"
             class="tab-pane"
             id="tabID-tabpane-two"
+            role="tabpanel"
           >
             Tab Content Two
           </div>
@@ -84,6 +88,7 @@ Object {
             aria-labelledby="tabID-tab-three"
             class="tab-pane"
             id="tabID-tabpane-three"
+            role="tabpanel"
           >
             Tab Content Three
           </div>
@@ -121,6 +126,7 @@ Object {
         >
           <button
             aria-controls="tabID-tabpane-two"
+            aria-selected="false"
             class="nav-link"
             data-rr-ui-event-key="two"
             id="tabID-tab-two"
@@ -138,6 +144,7 @@ Object {
           <button
             aria-controls="tabID-tabpane-three"
             aria-disabled="true"
+            aria-selected="false"
             class="nav-link disabled"
             data-rr-ui-event-key="three"
             disabled=""
@@ -157,6 +164,7 @@ Object {
           aria-labelledby="tabID-tab-one"
           class="tab-pane active"
           id="tabID-tabpane-one"
+          role="tabpanel"
         >
           Tab Content One
         </div>
@@ -164,6 +172,7 @@ Object {
           aria-labelledby="tabID-tab-two"
           class="tab-pane"
           id="tabID-tabpane-two"
+          role="tabpanel"
         >
           Tab Content Two
         </div>
@@ -171,6 +180,7 @@ Object {
           aria-labelledby="tabID-tab-three"
           class="tab-pane"
           id="tabID-tabpane-three"
+          role="tabpanel"
         >
           Tab Content Three
         </div>
@@ -265,6 +275,7 @@ Object {
           >
             <button
               aria-controls="tabID-tabpane-two"
+              aria-selected="false"
               class="nav-link"
               data-rr-ui-event-key="two"
               id="tabID-tab-two"
@@ -282,6 +293,7 @@ Object {
             <button
               aria-controls="tabID-tabpane-three"
               aria-disabled="true"
+              aria-selected="false"
               class="nav-link disabled"
               data-rr-ui-event-key="three"
               disabled=""
@@ -301,6 +313,7 @@ Object {
             aria-labelledby="tabID-tab-one"
             class="tab-pane active"
             id="tabID-tabpane-one"
+            role="tabpanel"
           >
             Tab Content One
           </div>
@@ -308,6 +321,7 @@ Object {
             aria-labelledby="tabID-tab-two"
             class="tab-pane"
             id="tabID-tabpane-two"
+            role="tabpanel"
           >
             Tab Content Two
           </div>
@@ -315,6 +329,7 @@ Object {
             aria-labelledby="tabID-tab-three"
             class="tab-pane"
             id="tabID-tabpane-three"
+            role="tabpanel"
           >
             Tab Content Three
           </div>
@@ -352,6 +367,7 @@ Object {
         >
           <button
             aria-controls="tabID-tabpane-two"
+            aria-selected="false"
             class="nav-link"
             data-rr-ui-event-key="two"
             id="tabID-tab-two"
@@ -369,6 +385,7 @@ Object {
           <button
             aria-controls="tabID-tabpane-three"
             aria-disabled="true"
+            aria-selected="false"
             class="nav-link disabled"
             data-rr-ui-event-key="three"
             disabled=""
@@ -388,6 +405,7 @@ Object {
           aria-labelledby="tabID-tab-one"
           class="tab-pane active"
           id="tabID-tabpane-one"
+          role="tabpanel"
         >
           Tab Content One
         </div>
@@ -395,6 +413,7 @@ Object {
           aria-labelledby="tabID-tab-two"
           class="tab-pane"
           id="tabID-tabpane-two"
+          role="tabpanel"
         >
           Tab Content Two
         </div>
@@ -402,6 +421,7 @@ Object {
           aria-labelledby="tabID-tab-three"
           class="tab-pane"
           id="tabID-tabpane-three"
+          role="tabpanel"
         >
           Tab Content Three
         </div>

--- a/src/Tabs/__snapshots__/Tabs.test.jsx.snap
+++ b/src/Tabs/__snapshots__/Tabs.test.jsx.snap
@@ -34,7 +34,6 @@ Object {
           >
             <button
               aria-controls="tabID-tabpane-two"
-              aria-selected="false"
               class="nav-link"
               data-rr-ui-event-key="two"
               id="tabID-tab-two"
@@ -52,7 +51,6 @@ Object {
             <button
               aria-controls="tabID-tabpane-three"
               aria-disabled="true"
-              aria-selected="false"
               class="nav-link disabled"
               data-rr-ui-event-key="three"
               disabled=""
@@ -72,7 +70,6 @@ Object {
             aria-labelledby="tabID-tab-one"
             class="tab-pane active"
             id="tabID-tabpane-one"
-            role="tabpanel"
           >
             Tab Content One
           </div>
@@ -80,7 +77,6 @@ Object {
             aria-labelledby="tabID-tab-two"
             class="tab-pane"
             id="tabID-tabpane-two"
-            role="tabpanel"
           >
             Tab Content Two
           </div>
@@ -88,7 +84,6 @@ Object {
             aria-labelledby="tabID-tab-three"
             class="tab-pane"
             id="tabID-tabpane-three"
-            role="tabpanel"
           >
             Tab Content Three
           </div>
@@ -126,7 +121,6 @@ Object {
         >
           <button
             aria-controls="tabID-tabpane-two"
-            aria-selected="false"
             class="nav-link"
             data-rr-ui-event-key="two"
             id="tabID-tab-two"
@@ -144,7 +138,6 @@ Object {
           <button
             aria-controls="tabID-tabpane-three"
             aria-disabled="true"
-            aria-selected="false"
             class="nav-link disabled"
             data-rr-ui-event-key="three"
             disabled=""
@@ -164,7 +157,6 @@ Object {
           aria-labelledby="tabID-tab-one"
           class="tab-pane active"
           id="tabID-tabpane-one"
-          role="tabpanel"
         >
           Tab Content One
         </div>
@@ -172,7 +164,6 @@ Object {
           aria-labelledby="tabID-tab-two"
           class="tab-pane"
           id="tabID-tabpane-two"
-          role="tabpanel"
         >
           Tab Content Two
         </div>
@@ -180,7 +171,6 @@ Object {
           aria-labelledby="tabID-tab-three"
           class="tab-pane"
           id="tabID-tabpane-three"
-          role="tabpanel"
         >
           Tab Content Three
         </div>
@@ -275,7 +265,6 @@ Object {
           >
             <button
               aria-controls="tabID-tabpane-two"
-              aria-selected="false"
               class="nav-link"
               data-rr-ui-event-key="two"
               id="tabID-tab-two"
@@ -293,7 +282,6 @@ Object {
             <button
               aria-controls="tabID-tabpane-three"
               aria-disabled="true"
-              aria-selected="false"
               class="nav-link disabled"
               data-rr-ui-event-key="three"
               disabled=""
@@ -313,7 +301,6 @@ Object {
             aria-labelledby="tabID-tab-one"
             class="tab-pane active"
             id="tabID-tabpane-one"
-            role="tabpanel"
           >
             Tab Content One
           </div>
@@ -321,7 +308,6 @@ Object {
             aria-labelledby="tabID-tab-two"
             class="tab-pane"
             id="tabID-tabpane-two"
-            role="tabpanel"
           >
             Tab Content Two
           </div>
@@ -329,7 +315,6 @@ Object {
             aria-labelledby="tabID-tab-three"
             class="tab-pane"
             id="tabID-tabpane-three"
-            role="tabpanel"
           >
             Tab Content Three
           </div>
@@ -367,7 +352,6 @@ Object {
         >
           <button
             aria-controls="tabID-tabpane-two"
-            aria-selected="false"
             class="nav-link"
             data-rr-ui-event-key="two"
             id="tabID-tab-two"
@@ -385,7 +369,6 @@ Object {
           <button
             aria-controls="tabID-tabpane-three"
             aria-disabled="true"
-            aria-selected="false"
             class="nav-link disabled"
             data-rr-ui-event-key="three"
             disabled=""
@@ -405,7 +388,6 @@ Object {
           aria-labelledby="tabID-tab-one"
           class="tab-pane active"
           id="tabID-tabpane-one"
-          role="tabpanel"
         >
           Tab Content One
         </div>
@@ -413,7 +395,6 @@ Object {
           aria-labelledby="tabID-tab-two"
           class="tab-pane"
           id="tabID-tabpane-two"
-          role="tabpanel"
         >
           Tab Content Two
         </div>
@@ -421,7 +402,6 @@ Object {
           aria-labelledby="tabID-tab-three"
           class="tab-pane"
           id="tabID-tabpane-three"
-          role="tabpanel"
         >
           Tab Content Three
         </div>


### PR DESCRIPTION
closes #742 

Our `modal` prop wasn't working with all of our Selects. It works for our `SingleSelect` which we fixed a while ago when we noticed that the ternary order in the `styles` prop was backwards, so just fixing it with all the other selects we have. Should be like this: 

```
styles={{
  ...defaultStyles({ size }),
  menuPortal: (base) => (
    modal ?
    { ...base, zIndex: zStack.zIndexModalBackdrop + 1 } :
      base
  ),
}}
```

https://user-images.githubusercontent.com/37383785/190243609-69fe3eba-2d0e-49f2-9a23-f425767e69a2.mov

