### PR TITLE
add Grid components (Container, Row, Col)

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -25688,12 +25688,11 @@ exports[`Storyshots Layouts/Container Setting One Column Width 1`] = `
             <h2
               className="Card__title"
             >
-              2 of 3
+              2 of 3 (adjust me!)
             </h2>
           </div>
           <code>
-            xs=
-            8
+            xs={8}
           </code>
         </section>
       </div>

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -24943,16 +24943,16 @@ exports[`Storyshots Layouts/Container Auto Layout Columns 1`] = `
     }
   }
 >
-  <p>
-    When no column widths are specified the 
-    <code>
-      &lt;Col&gt; 
-    </code>
-    component will render equal width columns.
-  </p>
   <div
     className="container"
   >
+    <p>
+      When no column widths are specified the 
+      <code>
+        &lt;Col&gt; 
+      </code>
+      component will render equal width columns.
+    </p>
     <div
       className="row"
     >
@@ -25554,35 +25554,35 @@ exports[`Storyshots Layouts/Container Setting Column Widths In Row 1`] = `
     }
   }
 >
-  <p>
-    The 
-    <code>
-      Row
-    </code>
-     lets you specify column widths across 5 breakpoint sizes (xs, sm, md, lg, xl and xxl). For every breakpoint, you can specify the amount of columns that will fit next to each other. You can also specify auto to set the columns to their natural widths.
-  </p>
-  <p>
-    Note that 
-    <code>
-      Row
-    </code>
-     column widths will override 
-    <code>
-      Col
-    </code>
-    widths set on lower breakpoints when viewed on larger screens. The 
-    <code>
-      &lt;Col xs={6} /&gt;
-    </code>
-     size will be overriden by
-    <code>
-      &lt;Row md={4} /&gt;
-    </code>
-     on medium and larger screens.
-  </p>
   <div
     className="container"
   >
+    <p>
+      The 
+      <code>
+        Row
+      </code>
+       lets you specify column widths across 5 breakpoint sizes (xs, sm, md, lg, xl and xxl). For every breakpoint, you can specify the amount of columns that will fit next to each other. You can also specify auto to set the columns to their natural widths.
+    </p>
+    <p>
+      Note that 
+      <code>
+        Row
+      </code>
+       column widths will override 
+      <code>
+        Col
+      </code>
+      widths set on lower breakpoints when viewed on larger screens. The 
+      <code>
+        &lt;Col xs={6} /&gt;
+      </code>
+       size will be overriden by
+      <code>
+        &lt;Row md={4} /&gt;
+      </code>
+       on medium and larger screens.
+    </p>
     <div
       className="row row-cols-lg-3 row-cols-md-2 row-cols-sm-1 row-cols-1"
     >
@@ -25650,12 +25650,12 @@ exports[`Storyshots Layouts/Container Setting One Column Width 1`] = `
     }
   }
 >
-  <p>
-    Auto-layout for flexbox grid columns also means you can set the width of one column and have the sibling columns automatically resize around it. You may use predefined grid classes (as shown below), grid mixins, or inline widths. Note that the other columns will resize no matter the width of the center column.
-  </p>
   <div
     className="container"
   >
+    <p>
+      Auto-layout for flexbox grid columns also means you can set the width of one column and have the sibling columns automatically resize around it. You may use predefined grid classes (as shown below), grid mixins, or inline widths. Note that the other columns will resize no matter the width of the center column.
+    </p>
     <div
       className="row"
     >

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -880,7 +880,7 @@ exports[`Storyshots Components/Accordion In Card 1`] = `
   }
 >
   <section
-    className="Card Card--lg Card--no-padding"
+    className="Card Card--no-padding"
   >
     <div
       className="Accordion accordion accordion-flush"
@@ -968,7 +968,7 @@ exports[`Storyshots Components/Accordion In Card 1`] = `
   </section>
   <br />
   <section
-    className="Card Card--lg"
+    className="Card"
   >
     <div
       className="Card__header"
@@ -11629,7 +11629,7 @@ exports[`Storyshots Components/Table Table On Card 1`] = `
   }
 >
   <section
-    className="Card Card--lg Card--divided"
+    className="Card Card--divided"
   >
     <div
       className="Card__header"
@@ -12192,7 +12192,7 @@ exports[`Storyshots Components/Table Table On Card No Padding 1`] = `
   }
 >
   <section
-    className="Card Card--lg Card--no-padding"
+    className="Card Card--no-padding"
   >
     <div
       id="Some table container"
@@ -24930,6 +24930,850 @@ exports[`Storyshots Foundations/Typography Typography 1`] = `
           </span>
         </li>
       </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Layouts/Container Auto Layout Columns 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <p>
+    When no column widths are specified the 
+    <code>
+      &lt;Col&gt; 
+    </code>
+    component will render equal width columns.
+  </p>
+  <div
+    className="container"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              1 of 2
+            </h2>
+          </div>
+        </section>
+      </div>
+      <div
+        className="col"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              2 of 2
+            </h2>
+          </div>
+        </section>
+      </div>
+    </div>
+    <br />
+    <div
+      className="row"
+    >
+      <div
+        className="col"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              1 of 3
+            </h2>
+          </div>
+        </section>
+      </div>
+      <div
+        className="col"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              2 of 3
+            </h2>
+          </div>
+        </section>
+      </div>
+      <div
+        className="col"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              3 of 3
+            </h2>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Layouts/Container Default 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="container"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              Default container
+            </h2>
+          </div>
+          <code>
+            &lt;Container&gt;
+          </code>
+           provides a means to center and horizontally pad your site's contents. Use Container for a responsive pixel width.
+        </section>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Layouts/Container Fluid Container 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="container-fluid"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              Fluid container
+            </h2>
+          </div>
+          You can use 
+          <code>
+            &lt;Container fluid /&gt;
+          </code>
+           for width: 100% across all viewport and device sizes.
+        </section>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Layouts/Container Fluid Container With Breakpoints 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="container-md"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              Fluid container with breakpoints
+            </h2>
+          </div>
+          You can set breakpoints for the 
+          <code>
+            fluid
+          </code>
+           prop. Setting it to a breakpoint 
+          <code>
+            ['sm', 'md', 'lg', 'xl', 'xxl']
+          </code>
+           will set the Container as fluid until the specified breakpoint.
+        </section>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Layouts/Container Mixing Breakpoints 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="container"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col-md-8 col-12"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              1 of 2
+            </h2>
+          </div>
+          <p>
+            <code>
+              md={8} xs={12}
+            </code>
+          </p>
+          <p>
+            You can also mix and match breakpoints to create different grids depending on the screen size.
+          </p>
+        </section>
+      </div>
+      <div
+        className="col-md-4 col-6"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              2 of 2
+            </h2>
+          </div>
+          <p>
+            <code>
+              md={4} xs={6}
+            </code>
+          </p>
+        </section>
+      </div>
+    </div>
+  </div>
+  <br />
+  <div
+    className="container"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col-md-4 col-3"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              1 of 3
+            </h2>
+          </div>
+          <p>
+            <code>
+              md={4} xs={3}
+            </code>
+          </p>
+        </section>
+      </div>
+      <div
+        className="col-md-4 col-3"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              2 of 3
+            </h2>
+          </div>
+          <p>
+            <code>
+              md={4} xs={3}
+            </code>
+          </p>
+        </section>
+      </div>
+      <div
+        className="col-md-4 col-3"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              3 of 3
+            </h2>
+          </div>
+          <p>
+            <code>
+              md={4} xs={3}
+            </code>
+          </p>
+        </section>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Layouts/Container Offsetting Columns 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="container"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col-md-4"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              1 of 2
+            </h2>
+          </div>
+          <p>
+            <code>
+              md={4}
+            </code>
+          </p>
+        </section>
+      </div>
+      <div
+        className="col-md-6 offset-md-2"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              2 of 2
+            </h2>
+          </div>
+          <p>
+            <code>
+              md={{ span: 6, offset: 2 }}
+            </code>
+          </p>
+          <p>
+            For offsetting grid columns you can set an 
+            <code>
+              offset
+            </code>
+             value.
+          </p>
+        </section>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Layouts/Container Responsive Grids 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="container"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col-sm-8"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              1 of 2
+            </h2>
+          </div>
+          <p>
+            <code>
+              sm=
+              8
+            </code>
+          </p>
+          <p>
+            The 
+            <code>
+              Col
+            </code>
+             lets you specify column widths across 6 breakpoint sizes (xs, sm, md, lg, xl and xxl). For every breakpoint, you can specify the amount of columns to span, or set the prop to 
+            <code>
+              &lt;Col lg={true} /&gt;
+            </code>
+             for auto layout widths.
+          </p>
+        </section>
+      </div>
+      <div
+        className="col-sm-4"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              2 of 2
+            </h2>
+          </div>
+          <p>
+            <code>
+              sm=
+              4
+            </code>
+          </p>
+        </section>
+      </div>
+    </div>
+  </div>
+  <br />
+  <div
+    className="container"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col-sm"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              1 of 3
+            </h2>
+          </div>
+          <p>
+            <code>
+              sm={true}
+            </code>
+          </p>
+          <p>
+            Or set the prop to 
+            <code>
+              &lt;Col lg={true}/&gt;
+            </code>
+             for auto layout widths.
+          </p>
+        </section>
+      </div>
+      <div
+        className="col-sm"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              2 of 3
+            </h2>
+          </div>
+          <p>
+            <code>
+              sm={true}
+            </code>
+          </p>
+        </section>
+      </div>
+      <div
+        className="col-sm"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              3 of 3
+            </h2>
+          </div>
+          <p>
+            <code>
+              sm={true}
+            </code>
+          </p>
+        </section>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Layouts/Container Setting Column Widths In Row 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <p>
+    The 
+    <code>
+      Row
+    </code>
+     lets you specify column widths across 5 breakpoint sizes (xs, sm, md, lg, xl and xxl). For every breakpoint, you can specify the amount of columns that will fit next to each other. You can also specify auto to set the columns to their natural widths.
+  </p>
+  <p>
+    Note that 
+    <code>
+      Row
+    </code>
+     column widths will override 
+    <code>
+      Col
+    </code>
+    widths set on lower breakpoints when viewed on larger screens. The 
+    <code>
+      &lt;Col xs={6} /&gt;
+    </code>
+     size will be overriden by
+    <code>
+      &lt;Row md={4} /&gt;
+    </code>
+     on medium and larger screens.
+  </p>
+  <div
+    className="container"
+  >
+    <div
+      className="row row-cols-lg-3 row-cols-md-2 row-cols-sm-1 row-cols-1"
+    >
+      <div
+        className="col"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              1 of 3
+            </h2>
+          </div>
+        </section>
+      </div>
+      <div
+        className="col"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              2 of 3
+            </h2>
+          </div>
+        </section>
+      </div>
+      <div
+        className="col"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              3 of 3
+            </h2>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Layouts/Container Setting One Column Width 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <p>
+    Auto-layout for flexbox grid columns also means you can set the width of one column and have the sibling columns automatically resize around it. You may use predefined grid classes (as shown below), grid mixins, or inline widths. Note that the other columns will resize no matter the width of the center column.
+  </p>
+  <div
+    className="container"
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              1 of 3
+            </h2>
+          </div>
+        </section>
+      </div>
+      <div
+        className="col-8"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              2 of 3
+            </h2>
+          </div>
+          <code>
+            xs=
+            8
+          </code>
+        </section>
+      </div>
+      <div
+        className="col"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              3 of 3
+            </h2>
+          </div>
+        </section>
+      </div>
+    </div>
+    <br />
+    <div
+      className="row"
+    >
+      <div
+        className="col"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              1 of 3
+            </h2>
+          </div>
+        </section>
+      </div>
+      <div
+        className="col-4"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              2 of 3
+            </h2>
+          </div>
+          <code>
+            xs=
+            4
+          </code>
+        </section>
+      </div>
+      <div
+        className="col"
+      >
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              3 of 3
+            </h2>
+          </div>
+        </section>
+      </div>
     </div>
   </div>
 </div>

--- a/src/Card/Card.jsx
+++ b/src/Card/Card.jsx
@@ -44,7 +44,7 @@ const Card = ({
       ...props,
       className: classNames(
         'Card',
-        `Card--${size}`,
+        { [`Card--${size}`]: size },
         className,
         {
           'Card--divided': divided,
@@ -73,7 +73,7 @@ Card.defaultProps = {
   elementType: 'section',
   helperText: undefined,
   noPadding: false,
-  size: CardSizes.LARGE,
+  size: undefined,
   subTitle: undefined,
   title: undefined,
 };

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -16,11 +16,7 @@ $card-width-xs: 15rem;
   outline-color: $ux-green-500;
   padding: $card-spacing;
 
-  width: calc(100% - #{$card-xs-spacing});
-
-  @include media-breakpoint-up(sm) {
-    width: calc(100% - 2rem);
-  }
+  width: 100%;
 
   &__divider {
     border-top: 1px solid rgba(0,0,0,.1);

--- a/src/Container/Col.jsx
+++ b/src/Container/Col.jsx
@@ -5,6 +5,7 @@ import { Col as ReactBootstrapCol } from 'react-bootstrap';
 const Col = ({
   as,
   children,
+  className,
   lg,
   md,
   sm,
@@ -17,6 +18,7 @@ const Col = ({
   <ReactBootstrapCol
     as={as}
     bsPrefix={bsPrefix}
+    className={className}
     lg={lg}
     md={md}
     sm={sm}
@@ -60,6 +62,7 @@ Col.propTypes = {
    This is an escape hatch for working with heavily customized bootstrap css.
   */
   bsPrefix: PropTypes.string,
+  className: PropTypes.string,
   /**
    The number of columns to span on large devices (≥992px)
    `boolean | "auto" | number | { span: boolean | "auto" | number,
@@ -101,6 +104,7 @@ Col.propTypes = {
 Col.defaultProps = {
   as: undefined,
   bsPrefix: 'col',
+  className: undefined,
   lg: undefined,
   md: undefined,
   sm: undefined,

--- a/src/Container/Col.jsx
+++ b/src/Container/Col.jsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Col as ReactBootstrapCol } from 'react-bootstrap';
+
+const Col = ({
+  as,
+  children,
+  lg,
+  md,
+  sm,
+  xl,
+  xs,
+  xxl,
+  bsPrefix,
+  ...props
+}) => (
+  <ReactBootstrapCol
+    as={as}
+    bsPrefix={bsPrefix}
+    lg={lg}
+    md={md}
+    sm={sm}
+    xl={xl}
+    xs={xs}
+    xxl={xxl}
+    {...props}
+  >
+    { children }
+  </ReactBootstrapCol>
+  );
+
+const colSize = PropTypes.oneOfType([
+  PropTypes.bool,
+  PropTypes.number,
+  PropTypes.string,
+  PropTypes.oneOf(['auto']),
+]);
+
+const stringOrNumber = PropTypes.oneOfType([
+  PropTypes.number,
+  PropTypes.string,
+]);
+
+const column = PropTypes.oneOfType([
+  colSize,
+  PropTypes.shape({
+    offset: stringOrNumber,
+    order: stringOrNumber,
+    size: colSize,
+  }),
+]);
+
+Col.propTypes = {
+  /**
+   You can use a custom element for this component
+  */
+  as: PropTypes.elementType,
+  /**
+   Change the underlying component CSS base class name and modifier class names prefix.
+   This is an escape hatch for working with heavily customized bootstrap css.
+  */
+  bsPrefix: PropTypes.string,
+  /**
+   The number of columns to span on large devices (≥992px)
+   `boolean | "auto" | number | { span: boolean | "auto" | number,
+   offset: number, order: "first" | "last" | number }`
+  */
+  lg: column,
+  /**
+   The number of columns to span on medium devices (≥768px)
+   `boolean | "auto" | number | { span: boolean | "auto" | number,
+   offset: number, order: "first" | "last" | number }`
+  */
+  md: column,
+  /**
+   The number of columns to span on small devices (≥576px)
+   `boolean | "auto" | number | { span: boolean | "auto" | number,
+   offset: number, order: "first" | "last" | number }`
+  */
+  sm: column,
+  /**
+   The number of columns to span on extra large devices (≥1200px)
+   `boolean | "auto" | number | { span: boolean | "auto" | number,
+   offset: number, order: "first" | "last" | number }`
+  */
+  xl: column,
+  /**
+   The number of columns to span on extra small devices (<576px)
+   `boolean | "auto" | number | { span: boolean | "auto" | number,
+   offset: number, order: "first" | "last" | number }`
+  */
+  xs: column,
+  /**
+   The number of columns to span on extra extra large devices (≥1400px)
+   `boolean | "auto" | number | { span: boolean | "auto" | number,
+   offset: number, order: "first" | "last" | number }`
+  */
+  xxl: column,
+};
+
+Col.defaultProps = {
+  as: undefined,
+  bsPrefix: 'col',
+  lg: undefined,
+  md: undefined,
+  sm: undefined,
+  xl: undefined,
+  xs: undefined,
+  xxl: undefined,
+};
+
+export default Col;

--- a/src/Container/Container.jsx
+++ b/src/Container/Container.jsx
@@ -5,6 +5,7 @@ import { Container as ReactBootstrapContainer } from 'react-bootstrap';
 const Container = ({
   as,
   children,
+  className,
   fluid,
   bsPrefix,
   ...props
@@ -12,6 +13,7 @@ const Container = ({
   <ReactBootstrapContainer
     as={as}
     bsPrefix={bsPrefix}
+    className={className}
     fluid={fluid}
     {...props}
   >
@@ -34,6 +36,7 @@ Container.propTypes = {
    This is an escape hatch for working with heavily customized bootstrap css.
   */
   bsPrefix: PropTypes.string,
+  className: PropTypes.string,
   /**
    Allow the Container to fill all of its available horizontal space.
    `bool | 'sm' | 'md' | 'lg' | 'xl' | 'xxl'`
@@ -44,6 +47,7 @@ Container.propTypes = {
 Container.defaultProps = {
   as: undefined,
   bsPrefix: 'container',
+  className: undefined,
   fluid: false,
 };
 

--- a/src/Container/Container.jsx
+++ b/src/Container/Container.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Container as ReactBootstrapContainer } from 'react-bootstrap';
+
+const Container = ({
+  as,
+  children,
+  fluid,
+  bsPrefix,
+  ...props
+}) => (
+  <ReactBootstrapContainer
+    as={as}
+    bsPrefix={bsPrefix}
+    fluid={fluid}
+    {...props}
+  >
+    { children }
+  </ReactBootstrapContainer>
+  );
+
+const containerSizes = PropTypes.oneOfType([
+  PropTypes.bool,
+  PropTypes.oneOf(['sm', 'md', 'lg', 'xl', 'xxl']),
+]);
+
+Container.propTypes = {
+  /**
+   You can use a custom element for this component
+  */
+  as: PropTypes.elementType,
+  /**
+   Change the underlying component CSS base class name and modifier class names prefix.
+   This is an escape hatch for working with heavily customized bootstrap css.
+  */
+  bsPrefix: PropTypes.string,
+  /**
+   Allow the Container to fill all of its available horizontal space.
+   `bool | 'sm' | 'md' | 'lg' | 'xl' | 'xxl'`
+  */
+  fluid: containerSizes,
+};
+
+Container.defaultProps = {
+  as: undefined,
+  bsPrefix: 'container',
+  fluid: false,
+};
+
+export default Container;

--- a/src/Container/Container.mdx
+++ b/src/Container/Container.mdx
@@ -1,0 +1,82 @@
+import { ArgsTable, Story, Canvas } from '@storybook/addon-docs/blocks';
+import Container from './Container'
+
+# Container
+
+Utilizing Bootstrap's grid system makes use of a series of containers, rows, and columns to layout and align content. 
+It's built with flexbox and is fully responsive.
+
+For official documentation, visit [React Bootstrap Grid system](https://react-bootstrap.github.io/layout/grid/)
+
+There are six default breakpoints, sometimes referred to as grid tiers, for building responsively.
+
+| Breakpoint        | Class infix | Dimensions |
+|-------------------|-------------|------------|
+| x-small           | none        | <576px     |
+| small             | sm          | ≥576px     |
+| medium            | md          | ≥768px     |
+| large             | lg          | ≥992px     |
+| extra large       | xl          | ≥1200px    |
+| extra extra large | xxl         | ≥1400px    |
+
+<Canvas>
+  <Story id="layouts-container--default"/>
+</Canvas>
+
+<ArgsTable of={Container} />
+
+## Stories
+
+### Default
+
+<Canvas>
+  <Story id="layouts-container--default" />
+</Canvas>
+
+### Fluid Container
+
+<Canvas>
+  <Story id="layouts-container--fluid-container" />
+</Canvas>
+
+### Fluid Container With Breakpoints
+
+<Canvas>
+  <Story id="layouts-container--fluid-container-with-breakpoints" />
+</Canvas>
+
+### Auto Layout Columns
+
+<Canvas>
+  <Story id="layouts-container--auto-layout-columns" />
+</Canvas>
+
+### Setting One Column Width
+
+<Canvas>
+  <Story id="layouts-container--setting-one-column-width" />
+</Canvas>
+
+### Responsive Grids
+
+<Canvas>
+  <Story id="layouts-container--responsive-grids" />
+</Canvas>
+
+### Mixing Breakpoints
+
+<Canvas>
+  <Story id="layouts-container--mixing-breakpoints" />
+</Canvas>
+
+### Offsetting Columns
+
+<Canvas>
+  <Story id="layouts-container--offsetting-columns" />
+</Canvas>
+
+### Setting Column Widths In Row
+
+<Canvas>
+  <Story id="layouts-container--setting-column-widths-in-row" />
+</Canvas>

--- a/src/Container/Container.stories.jsx
+++ b/src/Container/Container.stories.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {
+  boolean,
   select,
   withKnobs,
 } from '@storybook/addon-knobs';
@@ -37,7 +38,7 @@ export const Default = () => (
 );
 
 export const FluidContainer = () => (
-  <Container fluid>
+  <Container fluid={boolean('fluid', true)}>
     <Row>
       <Col>
         <Card title="Fluid container">
@@ -93,46 +94,49 @@ export const AutoLayoutColumns = () => (
   </>
 );
 
-export const SettingOneColumnWidth = () => (
-  <>
-    <p>
-      Auto-layout for flexbox grid columns also means you can set the width of one column and
-      have the sibling columns automatically resize around it.
-      You may use predefined grid classes (as shown below), grid mixins, or inline widths.
-      Note that the other columns will resize no matter the width of the center column.
-    </p>
-    <Container>
-      <Row>
-        <Col>
-          <Card title="1 of 3" />
-        </Col>
-        <Col xs={8}>
-          <Card title="2 of 3">
-            <code>xs={8}</code>
+export const SettingOneColumnWidth = () => {
+  const xs = select('column width', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], 8);
 
-          </Card>
-        </Col>
-        <Col>
-          <Card title="3 of 3" />
-        </Col>
-      </Row>
-      <br />
-      <Row>
-        <Col>
-          <Card title="1 of 3" />
-        </Col>
-        <Col xs={4}>
-          <Card title="2 of 3">
-            <code>xs={4}</code>
-          </Card>
-        </Col>
-        <Col>
-          <Card title="3 of 3" />
-        </Col>
-      </Row>
-    </Container>
-  </>
+  return (
+    <>
+      <p>
+        Auto-layout for flexbox grid columns also means you can set the width of one column and
+        have the sibling columns automatically resize around it.
+        You may use predefined grid classes (as shown below), grid mixins, or inline widths.
+        Note that the other columns will resize no matter the width of the center column.
+      </p>
+      <Container>
+        <Row>
+          <Col>
+            <Card title="1 of 3" />
+          </Col>
+          <Col xs={xs}>
+            <Card title="2 of 3 (adjust me!)">
+              <code>{`xs={${xs}}`}</code>
+            </Card>
+          </Col>
+          <Col>
+            <Card title="3 of 3" />
+          </Col>
+        </Row>
+        <br />
+        <Row>
+          <Col>
+            <Card title="1 of 3" />
+          </Col>
+          <Col xs={4}>
+            <Card title="2 of 3">
+              <code>xs={4}</code>
+            </Card>
+          </Col>
+          <Col>
+            <Card title="3 of 3" />
+          </Col>
+        </Row>
+      </Container>
+    </>
 );
+};
 
 export const ResponsiveGrids = () => (
   <>

--- a/src/Container/Container.stories.jsx
+++ b/src/Container/Container.stories.jsx
@@ -1,0 +1,300 @@
+import React from 'react';
+
+import {
+  select,
+  withKnobs,
+} from '@storybook/addon-knobs';
+
+import Card from 'src/Card';
+import { Col, Container, Row } from 'src/Container';
+import mdx from './Container.mdx';
+
+export default {
+  title: 'Layouts/Container',
+  component: Container,
+  subcomponents: {
+    Col, Row,
+  },
+  decorators: [withKnobs],
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+};
+
+export const Default = () => (
+  <Container>
+    <Row>
+      <Col>
+        <Card title="Default container">
+          <code>{`<Container>`}</code> provides a means to center and horizontally pad your site's contents.
+          Use Container for a responsive pixel width.
+        </Card>
+      </Col>
+    </Row>
+  </Container>
+);
+
+export const FluidContainer = () => (
+  <Container fluid>
+    <Row>
+      <Col>
+        <Card title="Fluid container">
+          You can use <code>{`<Container fluid />`}</code> for width: 100% across all viewport and device sizes.
+        </Card>
+      </Col>
+    </Row>
+  </Container>
+);
+
+export const FluidContainerWithBreakpoints = () => (
+  <Container fluid={select('breakpoint', ['sm', 'md', 'lg', 'xl', 'xxl'], 'md')}>
+    <Row>
+      <Col>
+        <Card title="Fluid container with breakpoints">
+          You can set breakpoints for the <code>fluid</code> prop.
+          Setting it to a breakpoint <code>['sm', 'md', 'lg', 'xl', 'xxl']</code> will set the
+          Container as fluid until the specified breakpoint.
+        </Card>
+      </Col>
+    </Row>
+  </Container>
+);
+
+export const AutoLayoutColumns = () => (
+  <>
+    <p>
+      When no column widths are specified the <code>{`<Col> `}</code>
+      component will render equal width columns.
+    </p>
+    <Container>
+      <Row>
+        <Col>
+          <Card title="1 of 2" />
+        </Col>
+        <Col>
+          <Card title="2 of 2" />
+        </Col>
+      </Row>
+      <br />
+      <Row>
+        <Col>
+          <Card title="1 of 3" />
+        </Col>
+        <Col>
+          <Card title="2 of 3" />
+        </Col>
+        <Col>
+          <Card title="3 of 3" />
+        </Col>
+      </Row>
+    </Container>
+  </>
+);
+
+export const SettingOneColumnWidth = () => (
+  <>
+    <p>
+      Auto-layout for flexbox grid columns also means you can set the width of one column and
+      have the sibling columns automatically resize around it.
+      You may use predefined grid classes (as shown below), grid mixins, or inline widths.
+      Note that the other columns will resize no matter the width of the center column.
+    </p>
+    <Container>
+      <Row>
+        <Col>
+          <Card title="1 of 3" />
+        </Col>
+        <Col xs={8}>
+          <Card title="2 of 3">
+            <code>xs={8}</code>
+
+          </Card>
+        </Col>
+        <Col>
+          <Card title="3 of 3" />
+        </Col>
+      </Row>
+      <br />
+      <Row>
+        <Col>
+          <Card title="1 of 3" />
+        </Col>
+        <Col xs={4}>
+          <Card title="2 of 3">
+            <code>xs={4}</code>
+          </Card>
+        </Col>
+        <Col>
+          <Card title="3 of 3" />
+        </Col>
+      </Row>
+    </Container>
+  </>
+);
+
+export const ResponsiveGrids = () => (
+  <>
+    <Container>
+      <Row>
+        <Col sm={8}>
+          <Card title="1 of 2">
+            <p>
+              <code>sm={8}</code>
+            </p>
+            <p>
+              The <code>Col</code> lets you specify column widths across
+              6 breakpoint sizes (xs, sm, md, lg, xl and xxl).
+              For every breakpoint, you can specify the amount of columns to span,
+              or set the prop to <code>{`<Col lg={true} />`}</code> for auto layout widths.
+            </p>
+          </Card>
+        </Col>
+        <Col sm={4}>
+          <Card title="2 of 2">
+            <p>
+              <code>sm={4}</code>
+            </p>
+          </Card>
+        </Col>
+      </Row>
+    </Container>
+    <br />
+    <Container>
+      <Row>
+        <Col sm>
+          <Card title="1 of 3">
+            <p>
+              <code>{`sm={true}`}</code>
+            </p>
+            <p>
+              Or set the prop to <code>{`<Col lg={true}/>`}</code> for auto layout widths.
+            </p>
+          </Card>
+        </Col>
+        <Col sm>
+          <Card title="2 of 3">
+            <p>
+              <code>{`sm={true}`}</code>
+            </p>
+          </Card>
+        </Col>
+        <Col sm>
+          <Card title="3 of 3">
+            <p>
+              <code>{`sm={true}`}</code>
+            </p>
+          </Card>
+        </Col>
+      </Row>
+    </Container>
+  </>
+);
+
+export const MixingBreakpoints = () => (
+  <>
+    <Container>
+      <Row>
+        <Col md={8} xs={12}>
+          <Card title="1 of 2">
+            <p>
+              <code>{`md={8} xs={12}`}</code>
+            </p>
+            <p>
+              You can also mix and match breakpoints to create different grids
+              depending on the screen size.
+            </p>
+          </Card>
+        </Col>
+        <Col md={4} xs={6}>
+          <Card title="2 of 2">
+            <p>
+              <code>{`md={4} xs={6}`}</code>
+            </p>
+          </Card>
+        </Col>
+      </Row>
+    </Container>
+    <br />
+    <Container>
+      <Row>
+        <Col md={4} xs={3}>
+          <Card title="1 of 3">
+            <p>
+              <code>{`md={4} xs={3}`}</code>
+            </p>
+          </Card>
+        </Col>
+        <Col md={4} xs={3}>
+          <Card title="2 of 3">
+            <p>
+              <code>{`md={4} xs={3}`}</code>
+            </p>
+          </Card>
+        </Col>
+        <Col md={4} xs={3}>
+          <Card title="3 of 3">
+            <p>
+              <code>{`md={4} xs={3}`}</code>
+            </p>
+          </Card>
+        </Col>
+      </Row>
+    </Container>
+  </>
+);
+
+export const OffsettingColumns = () => (
+  <Container>
+    <Row>
+      <Col md={4}>
+        <Card title="1 of 2">
+          <p>
+            <code>{`md={4}`}</code>
+          </p>
+        </Card>
+      </Col>
+      <Col md={{ span: 6, offset: 2 }}>
+        <Card title="2 of 2">
+          <p>
+            <code>{`md={{ span: 6, offset: 2 }}`}</code>
+          </p>
+          <p>
+            For offsetting grid columns you can set an <code>offset</code> value.
+          </p>
+        </Card>
+      </Col>
+    </Row>
+  </Container>
+);
+
+export const SettingColumnWidthsInRow = () => (
+  <>
+    <p>
+      The <code>Row</code> lets you specify column widths across
+      5 breakpoint sizes (xs, sm, md, lg, xl and xxl).
+      For every breakpoint, you can specify the amount of columns that will fit next to each other.
+      You can also specify auto to set the columns to their natural widths.
+    </p>
+    <p>
+      Note that <code>Row</code> column widths will override <code>Col</code>
+      widths set on lower breakpoints when viewed on larger screens.
+      The <code>{`<Col xs={6} />`}</code> size will be overriden by
+      <code>{`<Row md={4} />`}</code> on medium and larger screens.
+    </p>
+    <Container>
+      <Row lg={3} md={2} sm={1} xs={1}>
+        <Col>
+          <Card title="1 of 3" />
+        </Col>
+        <Col>
+          <Card title="2 of 3" />
+        </Col>
+        <Col>
+          <Card title="3 of 3" />
+        </Col>
+      </Row>
+    </Container>
+  </>
+);

--- a/src/Container/Container.stories.jsx
+++ b/src/Container/Container.stories.jsx
@@ -64,18 +64,56 @@ export const FluidContainerWithBreakpoints = () => (
 );
 
 export const AutoLayoutColumns = () => (
-  <>
+  <Container>
     <p>
       When no column widths are specified the <code>{`<Col> `}</code>
       component will render equal width columns.
     </p>
+    <Row>
+      <Col>
+        <Card title="1 of 2" />
+      </Col>
+      <Col>
+        <Card title="2 of 2" />
+      </Col>
+    </Row>
+    <br />
+    <Row>
+      <Col>
+        <Card title="1 of 3" />
+      </Col>
+      <Col>
+        <Card title="2 of 3" />
+      </Col>
+      <Col>
+        <Card title="3 of 3" />
+      </Col>
+    </Row>
+  </Container>
+);
+
+export const SettingOneColumnWidth = () => {
+  const xs = select('column width', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], 8);
+
+  return (
     <Container>
+      <p>
+        Auto-layout for flexbox grid columns also means you can set the width of one column and
+        have the sibling columns automatically resize around it.
+        You may use predefined grid classes (as shown below), grid mixins, or inline widths.
+        Note that the other columns will resize no matter the width of the center column.
+      </p>
       <Row>
         <Col>
-          <Card title="1 of 2" />
+          <Card title="1 of 3" />
+        </Col>
+        <Col xs={xs}>
+          <Card title="2 of 3 (adjust me!)">
+            <code>{`xs={${xs}}`}</code>
+          </Card>
         </Col>
         <Col>
-          <Card title="2 of 2" />
+          <Card title="3 of 3" />
         </Col>
       </Row>
       <br />
@@ -83,59 +121,17 @@ export const AutoLayoutColumns = () => (
         <Col>
           <Card title="1 of 3" />
         </Col>
-        <Col>
-          <Card title="2 of 3" />
+        <Col xs={4}>
+          <Card title="2 of 3">
+            <code>xs={4}</code>
+          </Card>
         </Col>
         <Col>
           <Card title="3 of 3" />
         </Col>
       </Row>
     </Container>
-  </>
-);
-
-export const SettingOneColumnWidth = () => {
-  const xs = select('column width', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], 8);
-
-  return (
-    <>
-      <p>
-        Auto-layout for flexbox grid columns also means you can set the width of one column and
-        have the sibling columns automatically resize around it.
-        You may use predefined grid classes (as shown below), grid mixins, or inline widths.
-        Note that the other columns will resize no matter the width of the center column.
-      </p>
-      <Container>
-        <Row>
-          <Col>
-            <Card title="1 of 3" />
-          </Col>
-          <Col xs={xs}>
-            <Card title="2 of 3 (adjust me!)">
-              <code>{`xs={${xs}}`}</code>
-            </Card>
-          </Col>
-          <Col>
-            <Card title="3 of 3" />
-          </Col>
-        </Row>
-        <br />
-        <Row>
-          <Col>
-            <Card title="1 of 3" />
-          </Col>
-          <Col xs={4}>
-            <Card title="2 of 3">
-              <code>xs={4}</code>
-            </Card>
-          </Col>
-          <Col>
-            <Card title="3 of 3" />
-          </Col>
-        </Row>
-      </Container>
-    </>
-);
+  );
 };
 
 export const ResponsiveGrids = () => (
@@ -274,7 +270,7 @@ export const OffsettingColumns = () => (
 );
 
 export const SettingColumnWidthsInRow = () => (
-  <>
+  <Container>
     <p>
       The <code>Row</code> lets you specify column widths across
       5 breakpoint sizes (xs, sm, md, lg, xl and xxl).
@@ -287,18 +283,16 @@ export const SettingColumnWidthsInRow = () => (
       The <code>{`<Col xs={6} />`}</code> size will be overriden by
       <code>{`<Row md={4} />`}</code> on medium and larger screens.
     </p>
-    <Container>
-      <Row lg={3} md={2} sm={1} xs={1}>
-        <Col>
-          <Card title="1 of 3" />
-        </Col>
-        <Col>
-          <Card title="2 of 3" />
-        </Col>
-        <Col>
-          <Card title="3 of 3" />
-        </Col>
-      </Row>
-    </Container>
-  </>
+    <Row lg={3} md={2} sm={1} xs={1}>
+      <Col>
+        <Card title="1 of 3" />
+      </Col>
+      <Col>
+        <Card title="2 of 3" />
+      </Col>
+      <Col>
+        <Card title="3 of 3" />
+      </Col>
+    </Row>
+  </Container>
 );

--- a/src/Container/Row.jsx
+++ b/src/Container/Row.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Row as ReactBootstrapRow } from 'react-bootstrap';
+
+const Row = ({
+  as,
+  children,
+  lg,
+  md,
+  sm,
+  xl,
+  xs,
+  xxl,
+  bsPrefix,
+  ...props
+}) => (
+  <ReactBootstrapRow
+    as={as}
+    bsPrefix={bsPrefix}
+    lg={lg}
+    md={md}
+    sm={sm}
+    xl={xl}
+    xs={xs}
+    xxl={xxl}
+    {...props}
+  >
+    { children }
+  </ReactBootstrapRow>
+  );
+
+const rowColWidth = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
+
+const rowColumns = PropTypes.oneOfType([
+  rowColWidth,
+  PropTypes.shape({
+    cols: rowColWidth,
+  }),
+]);
+
+Row.propTypes = {
+  /**
+   You can use a custom element for this component
+  */
+  as: PropTypes.elementType,
+  /**
+   Change the underlying component CSS base class name and modifier class names prefix.
+   This is an escape hatch for working with heavily customized bootstrap css.
+  */
+  bsPrefix: PropTypes.string,
+  /**
+   The number of columns that will fit next to each other on large devices (≥992px).
+   Use auto to give columns their natural widths.
+   `number | 'auto' | { cols: number | 'auto' }`
+  */
+  lg: rowColumns,
+  /**
+   The number of columns that will fit next to each other on medium devices (≥768px).
+   Use auto to give columns their natural widths.
+   `number | 'auto' | { cols: number | 'auto' }`
+  */
+  md: rowColumns,
+  /**
+   The number of columns that will fit next to each other on small devices (≥576px).
+   Use auto to give columns their natural widths.
+   `number | 'auto' | { cols: number | 'auto' }`
+  */
+  sm: rowColumns,
+  /**
+    The number of columns that will fit next to each other on extra large devices (≥1200px).
+    Use auto to give columns their natural widths.
+    `number | 'auto' | { cols: number | 'auto' }`
+  */
+  xl: rowColumns,
+  /**
+    The number of columns that will fit next to each other on extra small devices (<576px).
+    Use auto to give columns their natural widths.
+    `number | 'auto' | { cols: number | 'auto' }`
+  */
+  xs: rowColumns,
+  /**
+    The number of columns that will fit next to each other on extra extra large devices (≥1400px).
+    Use auto to give columns their natural widths.
+    `number | 'auto' | { cols: number | 'auto' }`
+  */
+  xxl: rowColumns,
+};
+
+Row.defaultProps = {
+  as: undefined,
+  bsPrefix: 'row',
+  lg: undefined,
+  md: undefined,
+  sm: undefined,
+  xl: undefined,
+  xs: undefined,
+  xxl: undefined,
+};
+
+export default Row;

--- a/src/Container/Row.jsx
+++ b/src/Container/Row.jsx
@@ -5,6 +5,7 @@ import { Row as ReactBootstrapRow } from 'react-bootstrap';
 const Row = ({
   as,
   children,
+  className,
   lg,
   md,
   sm,
@@ -17,6 +18,7 @@ const Row = ({
   <ReactBootstrapRow
     as={as}
     bsPrefix={bsPrefix}
+    className={className}
     lg={lg}
     md={md}
     sm={sm}
@@ -48,6 +50,7 @@ Row.propTypes = {
    This is an escape hatch for working with heavily customized bootstrap css.
   */
   bsPrefix: PropTypes.string,
+  className: PropTypes.string,
   /**
    The number of columns that will fit next to each other on large devices (≥992px).
    Use auto to give columns their natural widths.
@@ -89,6 +92,7 @@ Row.propTypes = {
 Row.defaultProps = {
   as: undefined,
   bsPrefix: 'row',
+  className: undefined,
   lg: undefined,
   md: undefined,
   sm: undefined,

--- a/src/Container/index.js
+++ b/src/Container/index.js
@@ -1,0 +1,9 @@
+import Col from './Col';
+import Container from './Container';
+import Row from './Row';
+
+export {
+  Col,
+  Container,
+  Row,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import Card, { CardSizes } from 'src/Card';
 import CardContainer from 'src/CardContainer';
 import CheckboxButton, { CHECKED_STATES } from 'src/CheckboxButton';
 import CheckboxButtonGroup from 'src/CheckboxButtonGroup';
+import { Col, Container, Row } from 'src/Container';
 import { ORIENTATIONS as BUTTON_GROUP_ORIENTATIONS } from 'src/ControlButtonGroup';
 import CopyToClipboard from 'src/CopyToClipboard';
 import CopyToClipboardButton from 'src/CopyToClipboardButton';
@@ -91,7 +92,9 @@ export {
   CheckboxButton,
   CheckboxButtonGroup,
   CHECKED_STATES,
+  Col,
   COLORS,
+  Container,
   CopyToClipboard,
   CopyToClipboardButton,
   CreatableSelect,
@@ -122,6 +125,7 @@ export {
   ProfileCell,
   RadioButton,
   RadioButtonGroup,
+  Row,
   SELECT_SIZES,
   SelectComponents,
   SingleSelect,


### PR DESCRIPTION
closes #749 

This PR brings in the Grid layout components from React Bootstrap. A few devs have asked for some basic layout components and thought it would be valuable to have. Hopefully it should be intuitive enough to align and manage basic content across all breakpoints, especially as we try to create better experiences on mobile screens.

Chromatic build: https://62d040e741710e4f085e0647-bcwpacclug.chromatic.com/?path=/story/layouts-container--default
(ask me for the join link if you don't already have access to Chromatic)