### PR TITLE
Add aria-label for trailingIconOnClickSubmit Input

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -6611,6 +6611,7 @@ exports[`Storyshots Components/Form Elements/Form Group With Trailing Icon And B
         value=""
       />
       <button
+        aria-label=""
         className="trailing-icon-button"
         onClick={[Function]}
         type="button"
@@ -6679,6 +6680,7 @@ exports[`Storyshots Components/Form Elements/Form Group With Trailing Icon And B
         value=""
       />
       <button
+        aria-label=""
         className="trailing-icon-button"
         onClick={[Function]}
         type="submit"
@@ -6710,6 +6712,75 @@ exports[`Storyshots Components/Form Elements/Form Group With Trailing Icon And B
       className="FormGroup__helper-text"
     >
       with trailing icon and button with submit
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Components/Form Elements/Form Group With Trailing Icon And Button With Submit And Label 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="FormGroup"
+    id="with-trailing-icon-and-button-with-submit-and-label"
+  >
+    <label
+      className="InputLabel"
+      htmlFor="input"
+    >
+      Form Group with input trailing icon and button with submit and label
+    </label>
+    <div
+      className="Input input-group"
+    >
+      <input
+        className="Input form-control Input--with-trailing-icon"
+        disabled={false}
+        id="input"
+        name="with-leading-icon-and-button"
+        onChange={[Function]}
+        placeholder="Placeholder text"
+        type="text"
+        value=""
+      />
+      <button
+        aria-label="label"
+        className="trailing-icon-button"
+        onClick={[Function]}
+        type="submit"
+      >
+        <div
+          className="input-group-text"
+        >
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-search fa-w-16 "
+            data-icon="search"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={Object {}}
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
+    <div
+      className="FormGroup__helper-text"
+    >
+      with trailing icon and button with submit and label
     </div>
   </div>
 </div>

--- a/src/FormGroup/FormGroup.stories.jsx
+++ b/src/FormGroup/FormGroup.stories.jsx
@@ -141,6 +141,25 @@ export const WithTrailingIconAndButtonWithSubmit = () => (
   </FormGroup>
 );
 
+export const WithTrailingIconAndButtonWithSubmitAndLabel = () => (
+  <FormGroup
+    helperText="with trailing icon and button with submit and label"
+    id="with-trailing-icon-and-button-with-submit-and-label"
+    label="Form Group with input trailing icon and button with submit and label"
+    labelHtmlFor="input"
+  >
+    <InputComponent
+      id="input"
+      name="with-leading-icon-and-button"
+      placeholder="Placeholder text"
+      trailingIcon={faSearch}
+      trailingIconLabel="label"
+      trailingIconOnClick={() => alert('Great job!')}
+      trailingIconOnClickSubmit
+    />
+  </FormGroup>
+);
+
 export const WithLeadingAndTrailingIcons = () => (
   <FormGroup
     helperText="with leading and trailing icons"

--- a/src/Input/Input.jsx
+++ b/src/Input/Input.jsx
@@ -13,6 +13,7 @@ const Input = React.forwardRef((props, ref) => {
     name,
     placeholder,
     trailingIcon,
+    trailingIconLabel,
     trailingIconOnClick,
     trailingIconOnClickSubmit,
     type,
@@ -48,6 +49,7 @@ const Input = React.forwardRef((props, ref) => {
       />
       {(trailingIcon && trailingIconOnClick) && (
         <button
+          aria-label={trailingIconLabel}
           className="trailing-icon-button"
           type={trailingIconOnClickSubmit ? 'submit' : 'button'}
           onClick={trailingIconOnClick}
@@ -73,6 +75,7 @@ Input.propTypes = {
   name: PropTypes.string.isRequired,
   placeholder: PropTypes.string,
   trailingIcon: PropTypes.object,
+  trailingIconLabel: PropTypes.string,
   trailingIconOnClick: PropTypes.func,
   trailingIconOnClickSubmit: PropTypes.bool,
   type: PropTypes.string,
@@ -85,6 +88,7 @@ Input.defaultProps = {
   leadingIcon: undefined,
   placeholder: '',
   trailingIcon: undefined,
+  trailingIconLabel: '',
   trailingIconOnClick: undefined,
   trailingIconOnClickSubmit: false,
   type: 'text',


### PR DESCRIPTION
Adds an `aria-label` to this button:
![Screen Shot 2022-09-30 at 6 48 59 AM](https://user-images.githubusercontent.com/84730553/193296909-72f94911-7e67-4a6a-a077-0d0a9cf75283.png)
