### PR TITLE
change width to max-width on Card

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -4336,7 +4336,7 @@ exports[`Storyshots Components/Card Default 1`] = `
   }
 >
   <section
-    className="Card Card--lg"
+    className="Card"
   >
     <div
       className="Card__header"
@@ -4344,7 +4344,7 @@ exports[`Storyshots Components/Card Default 1`] = `
       <h2
         className="Card__title"
       >
-        Large card with title
+        Default card title
       </h2>
       <span
         className="Card__helper-text"
@@ -4355,11 +4355,100 @@ exports[`Storyshots Components/Card Default 1`] = `
     <h3
       className="Card__subtitle"
     >
-      And a subtitle
+      Subtitle
     </h3>
     <div>
       Use knobs to try out the different card sizes
     </div>
+  </section>
+</div>
+`;
+
+exports[`Storyshots Components/Card Sizes 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <section
+    className="Card Card--xs"
+  >
+    <div
+      className="Card__header"
+    >
+      <h2
+        className="Card__title"
+      >
+        xs
+      </h2>
+    </div>
+    <code>
+      CardSizes.EXTRA_SMALL
+    </code>
+  </section>
+  <section
+    className="Card Card--sm"
+  >
+    <div
+      className="Card__header"
+    >
+      <h2
+        className="Card__title"
+      >
+        sm
+      </h2>
+    </div>
+    <code>
+      CardSizes.SMALL
+    </code>
+  </section>
+  <section
+    className="Card Card--md"
+  >
+    <div
+      className="Card__header"
+    >
+      <h2
+        className="Card__title"
+      >
+        md
+      </h2>
+    </div>
+    <code>
+      CardSizes.MEDIUM
+    </code>
+  </section>
+  <section
+    className="Card Card--lg"
+  >
+    <div
+      className="Card__header"
+    >
+      <h2
+        className="Card__title"
+      >
+        lg
+      </h2>
+    </div>
+    <code>
+      CardSizes.LARGE
+    </code>
+  </section>
+  <section
+    className="Card"
+  >
+    <div
+      className="Card__header"
+    >
+      <h2
+        className="Card__title"
+      >
+        default
+      </h2>
+    </div>
+    When no size is given, the Card takes up the full width of its parent container.
   </section>
 </div>
 `;

--- a/src/Card/Card.mdx
+++ b/src/Card/Card.mdx
@@ -13,13 +13,6 @@ import Card from './Card';
   <Story id="components-card--default" />
 </Canvas>
 
-### When to use
-- Reason 1
-- Reason 2
-
-### When to not use
-- Reason 1
-- Reason 2
 
 ## Props
 
@@ -29,8 +22,16 @@ import Card from './Card';
 
 ### Default
 
+`Card` will take up the full width of its parent container by default.
+
 <Canvas>
   <Story id="components-card--default" />
+</Canvas>
+
+### Sizes
+
+<Canvas>
+  <Story id="components-card--sizes" />
 </Canvas>
 
 ## Formatting

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -8,7 +8,7 @@
   outline-color: $ux-green-500;
   padding: $card-spacing;
 
-  width: 100%;
+  max-width: 100%;
 
   &__divider {
     border-top: 1px solid rgba(0,0,0,.1);

--- a/src/Card/Card.stories.jsx
+++ b/src/Card/Card.stories.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  withKnobs, text, radios, boolean,
+  withKnobs, text, select, boolean,
 } from '@storybook/addon-knobs';
 
 import Card, { CardSizes } from 'src/Card';
@@ -19,15 +19,49 @@ export default {
 
 export const Default = () => (
   <Card
-    divided={boolean('With divider', false)}
-    helperText={text('Helper text', '(helper text)')}
-    noPadding={boolean('Without padding', false)}
-    size={radios('Message Type', CardSizes, CardSizes.LARGE)}
-    subTitle={text('Subtitle', 'And a subtitle')}
-    title={text('Title', 'Large card with title')}
+    divided={boolean('divided', false)}
+    helperText={text('helperText', '(helper text)')}
+    noPadding={boolean('noPadding', false)}
+    size={select('size', CardSizes, undefined)}
+    subTitle={text('subTitle', 'Subtitle')}
+    title={text('title', 'Default card title')}
   >
     <div>
       Use knobs to try out the different card sizes
     </div>
   </Card>
+);
+
+export const Sizes = () => (
+  <>
+    <Card
+      size={CardSizes.EXTRA_SMALL}
+      title="xs"
+    >
+      <code>CardSizes.EXTRA_SMALL</code>
+    </Card>
+    <Card
+      size={CardSizes.SMALL}
+      title="sm"
+    >
+      <code>CardSizes.SMALL</code>
+    </Card>
+    <Card
+      size={CardSizes.MEDIUM}
+      title="md"
+    >
+      <code>CardSizes.MEDIUM</code>
+    </Card>
+    <Card
+      size={CardSizes.LARGE}
+      title="lg"
+    >
+      <code>CardSizes.LARGE</code>
+    </Card>
+    <Card
+      title="default"
+    >
+      When no size is given, the Card takes up the full width of its parent container.
+    </Card>
+  </>
 );


### PR DESCRIPTION
closes #755 

I think it needs to be `max-width: 100%` instead of `width: 100%` now that `Card` takes up the entire width, but we don't want it to overflow its parent container on mobile. Examples below:

<img width="393" alt="Screen Shot 2022-10-03 at 11 37 01 AM" src="https://user-images.githubusercontent.com/37383785/193657917-7b760d42-d1e2-401a-9722-4026f452d6c0.png">

<img width="396" alt="Screen Shot 2022-10-03 at 11 36 50 AM" src="https://user-images.githubusercontent.com/37383785/193657940-decb46dc-d8eb-41b4-993a-05fdbf81e177.png">

<img width="390" alt="Screen Shot 2022-10-03 at 12 05 43 PM" src="https://user-images.githubusercontent.com/37383785/193658376-dd36ef42-a4c8-4391-b12c-74914c73612d.png">

<img width="391" alt="Screen Shot 2022-10-03 at 12 06 01 PM" src="https://user-images.githubusercontent.com/37383785/193658403-b3c5b51f-e752-4dd1-9f4e-f927ac6be2f6.png">
