### PR TITLE
Input label tooltip color

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -6325,7 +6325,7 @@ exports[`Storyshots Components/Form Elements/Form Group With Label Tooltip 1`] =
       Label
       <span
         aria-hidden="true"
-        className="Tooltip__icon Tooltip__icon--gray"
+        className="Tooltip__icon Tooltip__icon"
         onClick={[Function]}
         onKeyPress={[Function]}
         tabIndex="0"

--- a/src/InputLabel/InputLabel.jsx
+++ b/src/InputLabel/InputLabel.jsx
@@ -21,7 +21,7 @@ const InputLabel = ({
       {text}
       {required && <span className="InputLabel__helper-text">&nbsp;(Required)</span>}
       {labelHelperText && <span className="InputLabel__helper-text">&nbsp;({labelHelperText})</span>}
-      {tooltipText && <Tooltip iconClasses="Tooltip__icon--gray" placement="right" text={tooltipText} />}
+      {tooltipText && <Tooltip iconClasses="Tooltip__icon" placement="right" text={tooltipText} />}
     </>
   );
 

--- a/src/InputLegend/InputLegend.jsx
+++ b/src/InputLegend/InputLegend.jsx
@@ -22,7 +22,7 @@ const InputLegend = ({
       {text}
       {required && <span className="InputLegend__helper-text">&nbsp;(Required)</span>}
       {labelHelperText && <span className="InputLegend__helper-text">&nbsp;({labelHelperText})</span>}
-      {tooltipText && <Tooltip iconClasses="Tooltip__icon--gray" placement="right" text={tooltipText} />}
+      {tooltipText && <Tooltip iconClasses="Tooltip__icon" placement="right" text={tooltipText} />}
     </>
   );
 


### PR DESCRIPTION
Removes the `-gray` css suffix from the tooltips in `<InputLabel/>` and `<InputLegend/>`