### PR TITLE
update cursor to pointer on select control

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -9071,7 +9071,7 @@ exports[`Storyshots Components/Selects/Async Default 1`] = `
       className="css-1f43avz-a11yText-A11yText"
     />
     <div
-      className=" css-15ub2n0-control"
+      className=" css-cijnja-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -9233,7 +9233,7 @@ exports[`Storyshots Components/Selects/Async In Modal 1`] = `
             className="css-1f43avz-a11yText-A11yText"
           />
           <div
-            className=" css-15ub2n0-control"
+            className=" css-cijnja-control"
             onMouseDown={[Function]}
             onTouchEnd={[Function]}
           >
@@ -9372,7 +9372,7 @@ exports[`Storyshots Components/Selects/Async Labeled 1`] = `
       className="css-1f43avz-a11yText-A11yText"
     />
     <div
-      className=" css-15ub2n0-control"
+      className=" css-cijnja-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -9482,7 +9482,7 @@ exports[`Storyshots Components/Selects/AsyncCreatable Default 1`] = `
       className="css-1f43avz-a11yText-A11yText"
     />
     <div
-      className=" css-15ub2n0-control"
+      className=" css-cijnja-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -9644,7 +9644,7 @@ exports[`Storyshots Components/Selects/AsyncCreatable In Modal 1`] = `
             className="css-1f43avz-a11yText-A11yText"
           />
           <div
-            className=" css-15ub2n0-control"
+            className=" css-cijnja-control"
             onMouseDown={[Function]}
             onTouchEnd={[Function]}
           >
@@ -9776,7 +9776,7 @@ exports[`Storyshots Components/Selects/Creatable Default 1`] = `
       className="css-1f43avz-a11yText-A11yText"
     />
     <div
-      className=" css-15ub2n0-control"
+      className=" css-cijnja-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -9936,7 +9936,7 @@ exports[`Storyshots Components/Selects/Creatable In Modal 1`] = `
             className="css-1f43avz-a11yText-A11yText"
           />
           <div
-            className=" css-15ub2n0-control"
+            className=" css-cijnja-control"
             onMouseDown={[Function]}
             onTouchEnd={[Function]}
           >
@@ -10074,7 +10074,7 @@ exports[`Storyshots Components/Selects/Single Custom Option With Checkbox 1`] = 
       className="css-1f43avz-a11yText-A11yText"
     />
     <div
-      className=" css-15ub2n0-control"
+      className=" css-cijnja-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -10167,7 +10167,7 @@ exports[`Storyshots Components/Selects/Single Custom Option With Indeterminate C
       className="css-1f43avz-a11yText-A11yText"
     />
     <div
-      className=" css-15ub2n0-control"
+      className=" css-cijnja-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -10260,7 +10260,7 @@ exports[`Storyshots Components/Selects/Single Custom Value Container 1`] = `
       className="css-1f43avz-a11yText-A11yText"
     />
     <div
-      className=" css-15ub2n0-control"
+      className=" css-cijnja-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -10346,7 +10346,7 @@ exports[`Storyshots Components/Selects/Single Default 1`] = `
       className="css-1f43avz-a11yText-A11yText"
     />
     <div
-      className=" css-15ub2n0-control"
+      className=" css-cijnja-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -10484,7 +10484,7 @@ exports[`Storyshots Components/Selects/Single In Modal 1`] = `
             className="css-1f43avz-a11yText-A11yText"
           />
           <div
-            className=" css-15ub2n0-control"
+            className=" css-cijnja-control"
             onMouseDown={[Function]}
             onTouchEnd={[Function]}
           >
@@ -10599,7 +10599,7 @@ exports[`Storyshots Components/Selects/Single Labeled 1`] = `
       className="css-1f43avz-a11yText-A11yText"
     />
     <div
-      className=" css-15ub2n0-control"
+      className=" css-cijnja-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -10685,7 +10685,7 @@ exports[`Storyshots Components/Selects/Single Loading 1`] = `
       className="css-1f43avz-a11yText-A11yText"
     />
     <div
-      className=" css-1930729-control"
+      className=" css-1lnko50-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -10778,7 +10778,7 @@ exports[`Storyshots Components/Selects/Single Multi Select 1`] = `
       className="css-1f43avz-a11yText-A11yText"
     />
     <div
-      className=" css-15ub2n0-control"
+      className=" css-cijnja-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -10864,7 +10864,7 @@ exports[`Storyshots Components/Selects/Single Searchable 1`] = `
       className="css-1f43avz-a11yText-A11yText"
     />
     <div
-      className=" css-15ub2n0-control"
+      className=" css-cijnja-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >

--- a/src/Select/styles.js
+++ b/src/Select/styles.js
@@ -37,6 +37,7 @@ const defaultStyles = ({ size }) => ({
       ':hover': {
         ...styles[':hover'],
         ...getBorderStyles(isFocused, isSelected),
+        cursor: 'pointer',
       },
     }),
     clearIndicator: (styles) => ({


### PR DESCRIPTION
closes #764 

Discussed in gardening. Gives more visual indication that the entire select is interactive, not just on the chevron. 

https://user-images.githubusercontent.com/37383785/194646459-aeba5043-6c7c-463c-b68a-9616c7c471f6.mov

