### PR TITLE
Removes bottom padding from form group helper & error text

### DIFF
--- a/scss/forms/form_group.scss
+++ b/scss/forms/form_group.scss
@@ -60,7 +60,7 @@
     @include font-type-20--medium;
     font-weight: 100;
     color: $ux-gray-900;
-    padding: .375rem 0;
+    padding: .375rem 0 0;
     margin: 0;
 
     &--pre {
@@ -71,7 +71,7 @@
   &__invalid-feedback {
     @include font-type-20--medium;
     color: $ux-red;
-    padding: .375rem 0;
+    padding: .375rem 0 0;
     margin: 0;
 
     &__list {


### PR DESCRIPTION
Resolves #766 

_Note:_ This will affect the spacing of FormGroup components throughout rails-server.  