### PR TITLE
add Flex component

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -25978,7 +25978,8 @@ exports[`Storyshots Layouts/Flex Default 1`] = `
   }
 >
   <div
-    className="sc-bdvvtL kAfiPy"
+    className="sc-bdvvtL bDYoDh"
+    height="100px"
   >
     <div
       style={
@@ -25990,7 +25991,7 @@ exports[`Storyshots Layouts/Flex Default 1`] = `
           "color": "#FFFFFF",
           "display": "flex",
           "fontSize": "1rem",
-          "height": "100px",
+          "height": "100%",
           "justifyContent": "center",
           "width": "100px",
         }
@@ -26008,7 +26009,7 @@ exports[`Storyshots Layouts/Flex Default 1`] = `
           "color": "#FFFFFF",
           "display": "flex",
           "fontSize": "1rem",
-          "height": "100px",
+          "height": "100%",
           "justifyContent": "center",
           "width": "100px",
         }
@@ -26026,7 +26027,7 @@ exports[`Storyshots Layouts/Flex Default 1`] = `
           "color": "#FFFFFF",
           "display": "flex",
           "fontSize": "1rem",
-          "height": "100px",
+          "height": "100%",
           "justifyContent": "center",
           "width": "100px",
         }
@@ -26057,7 +26058,8 @@ exports[`Storyshots Layouts/Flex Flex Container 1`] = `
     Properties for the parent (flex container)
   </h1>
   <div
-    className="sc-bdvvtL kAfiPy"
+    className="sc-bdvvtL bDYoDh"
+    height="100px"
   >
     <div
       style={
@@ -26069,7 +26071,7 @@ exports[`Storyshots Layouts/Flex Flex Container 1`] = `
           "color": "#FFFFFF",
           "display": "flex",
           "fontSize": "1rem",
-          "height": "100px",
+          "height": "100%",
           "justifyContent": "center",
           "width": "100px",
         }
@@ -26087,7 +26089,7 @@ exports[`Storyshots Layouts/Flex Flex Container 1`] = `
           "color": "#FFFFFF",
           "display": "flex",
           "fontSize": "1rem",
-          "height": "100px",
+          "height": "100%",
           "justifyContent": "center",
           "width": "100px",
         }
@@ -26105,7 +26107,7 @@ exports[`Storyshots Layouts/Flex Flex Container 1`] = `
           "color": "#FFFFFF",
           "display": "flex",
           "fontSize": "1rem",
-          "height": "100px",
+          "height": "100%",
           "justifyContent": "center",
           "width": "100px",
         }
@@ -26123,7 +26125,7 @@ exports[`Storyshots Layouts/Flex Flex Container 1`] = `
           "color": "#FFFFFF",
           "display": "flex",
           "fontSize": "1rem",
-          "height": "100px",
+          "height": "100%",
           "justifyContent": "center",
           "width": "100px",
         }
@@ -26141,7 +26143,7 @@ exports[`Storyshots Layouts/Flex Flex Container 1`] = `
           "color": "#FFFFFF",
           "display": "flex",
           "fontSize": "1rem",
-          "height": "100px",
+          "height": "100%",
           "justifyContent": "center",
           "width": "100px",
         }
@@ -26175,7 +26177,8 @@ exports[`Storyshots Layouts/Flex Flex Item 1`] = `
     className="sc-bdvvtL kAfiPy"
   >
     <div
-      className="sc-bdvvtL ctgHMk"
+      className="sc-bdvvtL gXfMQT"
+      height="100px"
     >
       <div
         style={
@@ -26187,7 +26190,7 @@ exports[`Storyshots Layouts/Flex Flex Item 1`] = `
             "color": "#FFFFFF",
             "display": "flex",
             "fontSize": "1rem",
-            "height": "100px",
+            "height": "100%",
             "justifyContent": "center",
             "width": "100px",
           }
@@ -26209,7 +26212,7 @@ exports[`Storyshots Layouts/Flex Flex Item 1`] = `
             "color": "#FFFFFF",
             "display": "flex",
             "fontSize": "1rem",
-            "height": "100px",
+            "height": "100%",
             "justifyContent": "center",
             "width": "100px",
           }
@@ -26231,7 +26234,7 @@ exports[`Storyshots Layouts/Flex Flex Item 1`] = `
             "color": "#FFFFFF",
             "display": "flex",
             "fontSize": "1rem",
-            "height": "100px",
+            "height": "100%",
             "justifyContent": "center",
             "width": "100px",
           }

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -20125,7 +20125,7 @@ exports[`Storyshots Components/Tabs Controlled 1`] = `
 >
   <div>
     <span
-      className="sc-gsDKAQ ldHumd"
+      className="sc-dkPtRN klomrB"
     >
       <ul
         className="nav nav-tabs"
@@ -20292,7 +20292,7 @@ exports[`Storyshots Components/Tabs Uncontrolled 1`] = `
 >
   <div>
     <span
-      className="sc-gsDKAQ ldHumd"
+      className="sc-dkPtRN klomrB"
     >
       <ul
         className="nav nav-tabs"
@@ -25968,6 +25968,282 @@ exports[`Storyshots Layouts/Container Setting One Column Width 1`] = `
             </h2>
           </div>
         </section>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Layouts/Flex Default 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="sc-bdvvtL kAfiPy"
+  >
+    <div
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#177863",
+          "border": "2px solid #011936",
+          "borderRadius": "4px",
+          "color": "#FFFFFF",
+          "display": "flex",
+          "fontSize": "1rem",
+          "height": "100px",
+          "justifyContent": "center",
+          "width": "100px",
+        }
+      }
+    >
+      Box 1
+    </div>
+    <div
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#177863",
+          "border": "2px solid #011936",
+          "borderRadius": "4px",
+          "color": "#FFFFFF",
+          "display": "flex",
+          "fontSize": "1rem",
+          "height": "100px",
+          "justifyContent": "center",
+          "width": "100px",
+        }
+      }
+    >
+      Box 2
+    </div>
+    <div
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#177863",
+          "border": "2px solid #011936",
+          "borderRadius": "4px",
+          "color": "#FFFFFF",
+          "display": "flex",
+          "fontSize": "1rem",
+          "height": "100px",
+          "justifyContent": "center",
+          "width": "100px",
+        }
+      }
+    >
+      Box 3
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Layouts/Flex Flex Container 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <h1
+    style={
+      Object {
+        "fontSize": "1.5rem",
+        "fontWeight": "700",
+      }
+    }
+  >
+    Properties for the parent (flex container)
+  </h1>
+  <div
+    className="sc-bdvvtL hHROJC"
+    direction="row"
+  >
+    <div
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#177863",
+          "border": "2px solid #011936",
+          "borderRadius": "4px",
+          "color": "#FFFFFF",
+          "display": "flex",
+          "fontSize": "1rem",
+          "height": "100px",
+          "justifyContent": "center",
+          "width": "100px",
+        }
+      }
+    >
+      Box 1
+    </div>
+    <div
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#177863",
+          "border": "2px solid #011936",
+          "borderRadius": "4px",
+          "color": "#FFFFFF",
+          "display": "flex",
+          "fontSize": "1rem",
+          "height": "100px",
+          "justifyContent": "center",
+          "width": "100px",
+        }
+      }
+    >
+      Box 2
+    </div>
+    <div
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#177863",
+          "border": "2px solid #011936",
+          "borderRadius": "4px",
+          "color": "#FFFFFF",
+          "display": "flex",
+          "fontSize": "1rem",
+          "height": "100px",
+          "justifyContent": "center",
+          "width": "100px",
+        }
+      }
+    >
+      Box 3
+    </div>
+    <div
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#177863",
+          "border": "2px solid #011936",
+          "borderRadius": "4px",
+          "color": "#FFFFFF",
+          "display": "flex",
+          "fontSize": "1rem",
+          "height": "100px",
+          "justifyContent": "center",
+          "width": "100px",
+        }
+      }
+    >
+      Box 4
+    </div>
+    <div
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#177863",
+          "border": "2px solid #011936",
+          "borderRadius": "4px",
+          "color": "#FFFFFF",
+          "display": "flex",
+          "fontSize": "1rem",
+          "height": "100px",
+          "justifyContent": "center",
+          "width": "100px",
+        }
+      }
+    >
+      Box 5
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Layouts/Flex Flex Item 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <h1
+    style={
+      Object {
+        "fontSize": "1.5rem",
+        "fontWeight": "700",
+      }
+    }
+  >
+    Properties for the children (flex item)
+  </h1>
+  <div
+    className="sc-bdvvtL kAfiPy"
+  >
+    <div
+      className="sc-bdvvtL ctgHMk"
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#177863",
+            "border": "2px solid #011936",
+            "borderRadius": "4px",
+            "color": "#FFFFFF",
+            "display": "flex",
+            "fontSize": "1rem",
+            "height": "100px",
+            "justifyContent": "center",
+            "width": "100px",
+          }
+        }
+      >
+        Adjust me
+      </div>
+    </div>
+    <div
+      className="sc-bdvvtL ctgHMk"
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#177863",
+            "border": "2px solid #011936",
+            "borderRadius": "4px",
+            "color": "#FFFFFF",
+            "display": "flex",
+            "fontSize": "1rem",
+            "height": "100px",
+            "justifyContent": "center",
+            "width": "100px",
+          }
+        }
+      >
+        Box 2
+      </div>
+    </div>
+    <div
+      className="sc-bdvvtL ctgHMk"
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#177863",
+            "border": "2px solid #011936",
+            "borderRadius": "4px",
+            "color": "#FFFFFF",
+            "display": "flex",
+            "fontSize": "1rem",
+            "height": "100px",
+            "justifyContent": "center",
+            "width": "100px",
+          }
+        }
+      >
+        Box 3
       </div>
     </div>
   </div>

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -24973,7 +24973,7 @@ exports[`Storyshots Layouts/CardStack Centered 1`] = `
   }
 >
   <div
-    className="sc-bdvvtL hGJUXy"
+    className="sc-bdvvtL eZLuym"
   >
     <div
       className="CardStack CardStack--sm"
@@ -25978,7 +25978,7 @@ exports[`Storyshots Layouts/Flex Default 1`] = `
   }
 >
   <div
-    className="sc-bdvvtL kAfiPy"
+    className="sc-bdvvtL lEYK"
   >
     <div
       style={
@@ -26057,7 +26057,7 @@ exports[`Storyshots Layouts/Flex Flex Container 1`] = `
     Properties for the parent (flex container)
   </h1>
   <div
-    className="sc-bdvvtL hHROJC"
+    className="sc-bdvvtL jutsFm"
     direction="row"
   >
     <div
@@ -26173,10 +26173,10 @@ exports[`Storyshots Layouts/Flex Flex Item 1`] = `
     Properties for the children (flex item)
   </h1>
   <div
-    className="sc-bdvvtL kAfiPy"
+    className="sc-bdvvtL lEYK"
   >
     <div
-      className="sc-bdvvtL ctgHMk"
+      className="sc-bdvvtL iZwXjU"
     >
       <div
         style={
@@ -26198,7 +26198,7 @@ exports[`Storyshots Layouts/Flex Flex Item 1`] = `
       </div>
     </div>
     <div
-      className="sc-bdvvtL ctgHMk"
+      className="sc-bdvvtL iZwXjU"
     >
       <div
         style={
@@ -26220,7 +26220,7 @@ exports[`Storyshots Layouts/Flex Flex Item 1`] = `
       </div>
     </div>
     <div
-      className="sc-bdvvtL ctgHMk"
+      className="sc-bdvvtL iZwXjU"
     >
       <div
         style={

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -25969,11 +25969,7 @@ exports[`Storyshots Layouts/Container Setting One Column Width 1`] = `
 </div>
 `;
 
-<<<<<<< HEAD
 exports[`Storyshots Layouts/Flex Default 1`] = `
-=======
-exports[`Storyshots Layouts/Main Accessibility 1`] = `
->>>>>>> develop
 <div
   style={
     Object {
@@ -25981,19 +25977,13 @@ exports[`Storyshots Layouts/Main Accessibility 1`] = `
     }
   }
 >
-<<<<<<< HEAD
   <div
     className="sc-bdvvtL bDYoDh"
     height="100px"
-=======
-  <main
-    className="Main container-fluid"
->>>>>>> develop
   >
     <div
       style={
         Object {
-<<<<<<< HEAD
           "alignItems": "center",
           "backgroundColor": "#177863",
           "border": "2px solid #011936",
@@ -26050,72 +26040,6 @@ exports[`Storyshots Layouts/Main Accessibility 1`] = `
 `;
 
 exports[`Storyshots Layouts/Flex Flex Container 1`] = `
-=======
-          "display": "flex",
-          "justifyContent": "center",
-        }
-      }
-    >
-      <div
-        className="CardStack CardStack--sm"
-      >
-        <h1
-          style={
-            Object {
-              "fontSize": "1.5rem",
-              "fontWeight": "700",
-            }
-          }
-        >
-          Accessibility information
-        </h1>
-        <section
-          className="Card"
-        >
-          <div
-            className="Card__header"
-          >
-            <h2
-              className="Card__title"
-            >
-              Why is it important to use Main?
-            </h2>
-          </div>
-          <p>
-            Any document needs to have a navigation point to the primary content of the page. Ensure all content is contained within a landmark region, designated with HTML5 landmark elements and/or ARIA landmark regions.
-          </p>
-          <p>
-            It is a best practice to use both HTML 5 and ARIA landmarks to ensure all content is contained within a navigational region. In HTML5, you should use elements like header, nav, main, and footer. Their ARIA counterparts are role="banner", role="navigation", role="main", and role="contentinfo", in that order. By using both HTML5 and ARIA markup, you make the webpage more robust and functional no matter what screen reader technology is used.
-          </p>
-          <p>
-            Once added, screen reader users can navigate to a section based on its ARIA landmark or HTML element. Landmarks provide a simple replacement for a skip navigation link, though the replacement is only useful for users of screen readers. Sighted users or users of screen enlargers wouldn’t get much benefit from the addition, so it can’t replace skip navigation links altogether.
-          </p>
-          <span>
-            Source: 
-            <a
-              href="https://dequeuniversity.com/rules/axe/4.2/landmark-one-main"
-            >
-              Source: Deque University - Landmark one main
-            </a>
-          </span>
-          <br />
-          <span>
-            Interactive example: 
-            <a
-              href="https://www.w3.org/WAI/ARIA/apg/example-index/landmarks/main.html"
-            >
-              W3C: ARIA Landmarks Example
-            </a>
-          </span>
-        </section>
-      </div>
-    </div>
-  </main>
-</div>
-`;
-
-exports[`Storyshots Layouts/Main Default 1`] = `
->>>>>>> develop
 <div
   style={
     Object {
@@ -26123,7 +26047,6 @@ exports[`Storyshots Layouts/Main Default 1`] = `
     }
   }
 >
-<<<<<<< HEAD
   <h1
     style={
       Object {
@@ -26233,32 +26156,6 @@ exports[`Storyshots Layouts/Main Default 1`] = `
 `;
 
 exports[`Storyshots Layouts/Flex Flex Item 1`] = `
-=======
-  <main
-    className="Main container-fluid"
-  >
-    <h1
-      style={
-        Object {
-          "fontSize": "1.5rem",
-          "fontWeight": "700",
-        }
-      }
-    >
-      This is a header
-    </h1>
-    <p>
-      With some paragraph text all wrapped in a 
-      <code>
-        &lt;Main&gt;
-      </code>
-    </p>
-  </main>
-</div>
-`;
-
-exports[`Storyshots Layouts/Main Page Example 1`] = `
->>>>>>> develop
 <div
   style={
     Object {
@@ -26266,7 +26163,6 @@ exports[`Storyshots Layouts/Main Page Example 1`] = `
     }
   }
 >
-<<<<<<< HEAD
   <h1
     style={
       Object {
@@ -26347,7 +26243,126 @@ exports[`Storyshots Layouts/Main Page Example 1`] = `
         Box 3
       </div>
     </div>
-=======
+  </div>
+</div>
+`;
+
+exports[`Storyshots Layouts/Main Accessibility 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <main
+    className="Main container-fluid"
+  >
+    <div
+      style={
+        Object {
+          "display": "flex",
+          "justifyContent": "center",
+        }
+      }
+    >
+      <div
+        className="CardStack CardStack--sm"
+      >
+        <h1
+          style={
+            Object {
+              "fontSize": "1.5rem",
+              "fontWeight": "700",
+            }
+          }
+        >
+          Accessibility information
+        </h1>
+        <section
+          className="Card"
+        >
+          <div
+            className="Card__header"
+          >
+            <h2
+              className="Card__title"
+            >
+              Why is it important to use Main?
+            </h2>
+          </div>
+          <p>
+            Any document needs to have a navigation point to the primary content of the page. Ensure all content is contained within a landmark region, designated with HTML5 landmark elements and/or ARIA landmark regions.
+          </p>
+          <p>
+            It is a best practice to use both HTML 5 and ARIA landmarks to ensure all content is contained within a navigational region. In HTML5, you should use elements like header, nav, main, and footer. Their ARIA counterparts are role="banner", role="navigation", role="main", and role="contentinfo", in that order. By using both HTML5 and ARIA markup, you make the webpage more robust and functional no matter what screen reader technology is used.
+          </p>
+          <p>
+            Once added, screen reader users can navigate to a section based on its ARIA landmark or HTML element. Landmarks provide a simple replacement for a skip navigation link, though the replacement is only useful for users of screen readers. Sighted users or users of screen enlargers wouldn’t get much benefit from the addition, so it can’t replace skip navigation links altogether.
+          </p>
+          <span>
+            Source: 
+            <a
+              href="https://dequeuniversity.com/rules/axe/4.2/landmark-one-main"
+            >
+              Source: Deque University - Landmark one main
+            </a>
+          </span>
+          <br />
+          <span>
+            Interactive example: 
+            <a
+              href="https://www.w3.org/WAI/ARIA/apg/example-index/landmarks/main.html"
+            >
+              W3C: ARIA Landmarks Example
+            </a>
+          </span>
+        </section>
+      </div>
+    </div>
+  </main>
+</div>
+`;
+
+exports[`Storyshots Layouts/Main Default 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <main
+    className="Main container-fluid"
+  >
+    <h1
+      style={
+        Object {
+          "fontSize": "1.5rem",
+          "fontWeight": "700",
+        }
+      }
+    >
+      This is a header
+    </h1>
+    <p>
+      With some paragraph text all wrapped in a 
+      <code>
+        &lt;Main&gt;
+      </code>
+    </p>
+  </main>
+</div>
+`;
+
+exports[`Storyshots Layouts/Main Page Example 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
   <div
     className="App"
   >
@@ -26442,7 +26457,6 @@ exports[`Storyshots Layouts/Main Page Example 1`] = `
         Having at least one main landmark on a page helps with accessibility and allows assistive technology (AT) users to orient themselves on a page.
       </p>
     </main>
->>>>>>> develop
   </div>
 </div>
 `;

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -26057,8 +26057,7 @@ exports[`Storyshots Layouts/Flex Flex Container 1`] = `
     Properties for the parent (flex container)
   </h1>
   <div
-    className="sc-bdvvtL jutsFm"
-    direction="row"
+    className="sc-bdvvtL lEYK"
   >
     <div
       style={

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -24973,12 +24973,7 @@ exports[`Storyshots Layouts/CardStack Centered 1`] = `
   }
 >
   <div
-    style={
-      Object {
-        "display": "flex",
-        "justifyContent": "center",
-      }
-    }
+    className="sc-bdvvtL hGJUXy"
   >
     <div
       className="CardStack CardStack--sm"

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -25978,7 +25978,7 @@ exports[`Storyshots Layouts/Flex Default 1`] = `
   }
 >
   <div
-    className="sc-bdvvtL lEYK"
+    className="sc-bdvvtL kAfiPy"
   >
     <div
       style={
@@ -26057,7 +26057,7 @@ exports[`Storyshots Layouts/Flex Flex Container 1`] = `
     Properties for the parent (flex container)
   </h1>
   <div
-    className="sc-bdvvtL lEYK"
+    className="sc-bdvvtL kAfiPy"
   >
     <div
       style={
@@ -26172,10 +26172,10 @@ exports[`Storyshots Layouts/Flex Flex Item 1`] = `
     Properties for the children (flex item)
   </h1>
   <div
-    className="sc-bdvvtL lEYK"
+    className="sc-bdvvtL kAfiPy"
   >
     <div
-      className="sc-bdvvtL iZwXjU"
+      className="sc-bdvvtL ctgHMk"
     >
       <div
         style={
@@ -26197,7 +26197,7 @@ exports[`Storyshots Layouts/Flex Flex Item 1`] = `
       </div>
     </div>
     <div
-      className="sc-bdvvtL iZwXjU"
+      className="sc-bdvvtL ctgHMk"
     >
       <div
         style={
@@ -26219,7 +26219,7 @@ exports[`Storyshots Layouts/Flex Flex Item 1`] = `
       </div>
     </div>
     <div
-      className="sc-bdvvtL iZwXjU"
+      className="sc-bdvvtL ctgHMk"
     >
       <div
         style={

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -24973,7 +24973,7 @@ exports[`Storyshots Layouts/CardStack Centered 1`] = `
   }
 >
   <div
-    className="sc-bdvvtL eZLuym"
+    className="sc-bdvvtL hGJUXy"
   >
     <div
       className="CardStack CardStack--sm"

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -25978,62 +25978,278 @@ exports[`Storyshots Layouts/Flex Default 1`] = `
   }
 >
   <div
-    className="sc-bdvvtL bDYoDh"
-    height="100px"
+    className="sc-bdvvtL kHhtyn"
+    height="100%"
   >
     <div
-      style={
-        Object {
-          "alignItems": "center",
-          "backgroundColor": "#177863",
-          "border": "2px solid #011936",
-          "borderRadius": "4px",
-          "color": "#FFFFFF",
-          "display": "flex",
-          "fontSize": "1rem",
-          "height": "100%",
-          "justifyContent": "center",
-          "width": "100px",
-        }
-      }
+      className="ProfileCell"
     >
-      Box 1
+      <div
+        className="ProfileCell__image"
+      >
+        <div
+          aria-hidden={false}
+          className="Avatar"
+        >
+          <div
+            className="Avatar__circle ui-mod ui-mod--1"
+          >
+            <span
+              className="Avatar__circle__initials"
+            >
+              RR
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ProfileCell__content"
+        style={
+          Object {
+            "maxWidth": "none",
+          }
+        }
+      >
+        <div
+          className="ProfileCell__content__name__container"
+        >
+          <h5
+            className="ProfileCell__content__name"
+          >
+            Riley Researcher
+          </h5>
+        </div>
+        <div
+          className="ProfileCell__content__subtitle"
+        >
+          riley+1@userinterviews.com
+        </div>
+      </div>
     </div>
     <div
-      style={
-        Object {
-          "alignItems": "center",
-          "backgroundColor": "#177863",
-          "border": "2px solid #011936",
-          "borderRadius": "4px",
-          "color": "#FFFFFF",
-          "display": "flex",
-          "fontSize": "1rem",
-          "height": "100%",
-          "justifyContent": "center",
-          "width": "100px",
-        }
-      }
+      className="ProfileCell"
     >
-      Box 2
+      <div
+        className="ProfileCell__image"
+      >
+        <div
+          aria-hidden={false}
+          className="Avatar"
+        >
+          <div
+            className="Avatar__circle ui-mod ui-mod--2"
+          >
+            <span
+              className="Avatar__circle__initials"
+            >
+              RR
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ProfileCell__content"
+        style={
+          Object {
+            "maxWidth": "none",
+          }
+        }
+      >
+        <div
+          className="ProfileCell__content__name__container"
+        >
+          <h5
+            className="ProfileCell__content__name"
+          >
+            Riley Researcher
+          </h5>
+        </div>
+        <div
+          className="ProfileCell__content__subtitle"
+        >
+          riley+2@userinterviews.com
+        </div>
+      </div>
     </div>
     <div
-      style={
-        Object {
-          "alignItems": "center",
-          "backgroundColor": "#177863",
-          "border": "2px solid #011936",
-          "borderRadius": "4px",
-          "color": "#FFFFFF",
-          "display": "flex",
-          "fontSize": "1rem",
-          "height": "100%",
-          "justifyContent": "center",
-          "width": "100px",
-        }
-      }
+      className="ProfileCell"
     >
-      Box 3
+      <div
+        className="ProfileCell__image"
+      >
+        <div
+          aria-hidden={false}
+          className="Avatar"
+        >
+          <div
+            className="Avatar__circle ui-mod ui-mod--3"
+          >
+            <span
+              className="Avatar__circle__initials"
+            >
+              RR
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ProfileCell__content"
+        style={
+          Object {
+            "maxWidth": "none",
+          }
+        }
+      >
+        <div
+          className="ProfileCell__content__name__container"
+        >
+          <h5
+            className="ProfileCell__content__name"
+          >
+            Riley Researcher
+          </h5>
+        </div>
+        <div
+          className="ProfileCell__content__subtitle"
+        >
+          riley+3@userinterviews.com
+        </div>
+      </div>
+    </div>
+    <div
+      className="ProfileCell"
+    >
+      <div
+        className="ProfileCell__image"
+      >
+        <div
+          aria-hidden={false}
+          className="Avatar"
+        >
+          <div
+            className="Avatar__circle ui-mod ui-mod--4"
+          >
+            <span
+              className="Avatar__circle__initials"
+            >
+              RR
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ProfileCell__content"
+        style={
+          Object {
+            "maxWidth": "none",
+          }
+        }
+      >
+        <div
+          className="ProfileCell__content__name__container"
+        >
+          <h5
+            className="ProfileCell__content__name"
+          >
+            Riley Researcher
+          </h5>
+        </div>
+        <div
+          className="ProfileCell__content__subtitle"
+        >
+          riley+4@userinterviews.com
+        </div>
+      </div>
+    </div>
+    <div
+      className="ProfileCell"
+    >
+      <div
+        className="ProfileCell__image"
+      >
+        <div
+          aria-hidden={false}
+          className="Avatar"
+        >
+          <div
+            className="Avatar__circle ui-mod ui-mod--5"
+          >
+            <span
+              className="Avatar__circle__initials"
+            >
+              RR
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ProfileCell__content"
+        style={
+          Object {
+            "maxWidth": "none",
+          }
+        }
+      >
+        <div
+          className="ProfileCell__content__name__container"
+        >
+          <h5
+            className="ProfileCell__content__name"
+          >
+            Riley Researcher
+          </h5>
+        </div>
+        <div
+          className="ProfileCell__content__subtitle"
+        >
+          riley+5@userinterviews.com
+        </div>
+      </div>
+    </div>
+    <div
+      className="ProfileCell"
+    >
+      <div
+        className="ProfileCell__image"
+      >
+        <div
+          aria-hidden={false}
+          className="Avatar"
+        >
+          <div
+            className="Avatar__circle ui-mod ui-mod--0"
+          >
+            <span
+              className="Avatar__circle__initials"
+            >
+              RR
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ProfileCell__content"
+        style={
+          Object {
+            "maxWidth": "none",
+          }
+        }
+      >
+        <div
+          className="ProfileCell__content__name__container"
+        >
+          <h5
+            className="ProfileCell__content__name"
+          >
+            Riley Researcher
+          </h5>
+        </div>
+        <div
+          className="ProfileCell__content__subtitle"
+        >
+          riley+6@userinterviews.com
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -26058,98 +26274,278 @@ exports[`Storyshots Layouts/Flex Flex Container 1`] = `
     Properties for the parent (flex container)
   </h1>
   <div
-    className="sc-bdvvtL bDYoDh"
-    height="100px"
+    className="sc-bdvvtL kHhtyn"
+    height="100%"
   >
     <div
-      style={
-        Object {
-          "alignItems": "center",
-          "backgroundColor": "#177863",
-          "border": "2px solid #011936",
-          "borderRadius": "4px",
-          "color": "#FFFFFF",
-          "display": "flex",
-          "fontSize": "1rem",
-          "height": "100%",
-          "justifyContent": "center",
-          "width": "100px",
-        }
-      }
+      className="ProfileCell"
     >
-      Box 1
+      <div
+        className="ProfileCell__image"
+      >
+        <div
+          aria-hidden={false}
+          className="Avatar"
+        >
+          <div
+            className="Avatar__circle ui-mod ui-mod--1"
+          >
+            <span
+              className="Avatar__circle__initials"
+            >
+              RR
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ProfileCell__content"
+        style={
+          Object {
+            "maxWidth": "none",
+          }
+        }
+      >
+        <div
+          className="ProfileCell__content__name__container"
+        >
+          <h5
+            className="ProfileCell__content__name"
+          >
+            Riley Researcher
+          </h5>
+        </div>
+        <div
+          className="ProfileCell__content__subtitle"
+        >
+          riley+1@userinterviews.com
+        </div>
+      </div>
     </div>
     <div
-      style={
-        Object {
-          "alignItems": "center",
-          "backgroundColor": "#177863",
-          "border": "2px solid #011936",
-          "borderRadius": "4px",
-          "color": "#FFFFFF",
-          "display": "flex",
-          "fontSize": "1rem",
-          "height": "100%",
-          "justifyContent": "center",
-          "width": "100px",
-        }
-      }
+      className="ProfileCell"
     >
-      Box 2
+      <div
+        className="ProfileCell__image"
+      >
+        <div
+          aria-hidden={false}
+          className="Avatar"
+        >
+          <div
+            className="Avatar__circle ui-mod ui-mod--2"
+          >
+            <span
+              className="Avatar__circle__initials"
+            >
+              RR
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ProfileCell__content"
+        style={
+          Object {
+            "maxWidth": "none",
+          }
+        }
+      >
+        <div
+          className="ProfileCell__content__name__container"
+        >
+          <h5
+            className="ProfileCell__content__name"
+          >
+            Riley Researcher
+          </h5>
+        </div>
+        <div
+          className="ProfileCell__content__subtitle"
+        >
+          riley+2@userinterviews.com
+        </div>
+      </div>
     </div>
     <div
-      style={
-        Object {
-          "alignItems": "center",
-          "backgroundColor": "#177863",
-          "border": "2px solid #011936",
-          "borderRadius": "4px",
-          "color": "#FFFFFF",
-          "display": "flex",
-          "fontSize": "1rem",
-          "height": "100%",
-          "justifyContent": "center",
-          "width": "100px",
-        }
-      }
+      className="ProfileCell"
     >
-      Box 3
+      <div
+        className="ProfileCell__image"
+      >
+        <div
+          aria-hidden={false}
+          className="Avatar"
+        >
+          <div
+            className="Avatar__circle ui-mod ui-mod--3"
+          >
+            <span
+              className="Avatar__circle__initials"
+            >
+              RR
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ProfileCell__content"
+        style={
+          Object {
+            "maxWidth": "none",
+          }
+        }
+      >
+        <div
+          className="ProfileCell__content__name__container"
+        >
+          <h5
+            className="ProfileCell__content__name"
+          >
+            Riley Researcher
+          </h5>
+        </div>
+        <div
+          className="ProfileCell__content__subtitle"
+        >
+          riley+3@userinterviews.com
+        </div>
+      </div>
     </div>
     <div
-      style={
-        Object {
-          "alignItems": "center",
-          "backgroundColor": "#177863",
-          "border": "2px solid #011936",
-          "borderRadius": "4px",
-          "color": "#FFFFFF",
-          "display": "flex",
-          "fontSize": "1rem",
-          "height": "100%",
-          "justifyContent": "center",
-          "width": "100px",
-        }
-      }
+      className="ProfileCell"
     >
-      Box 4
+      <div
+        className="ProfileCell__image"
+      >
+        <div
+          aria-hidden={false}
+          className="Avatar"
+        >
+          <div
+            className="Avatar__circle ui-mod ui-mod--4"
+          >
+            <span
+              className="Avatar__circle__initials"
+            >
+              RR
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ProfileCell__content"
+        style={
+          Object {
+            "maxWidth": "none",
+          }
+        }
+      >
+        <div
+          className="ProfileCell__content__name__container"
+        >
+          <h5
+            className="ProfileCell__content__name"
+          >
+            Riley Researcher
+          </h5>
+        </div>
+        <div
+          className="ProfileCell__content__subtitle"
+        >
+          riley+4@userinterviews.com
+        </div>
+      </div>
     </div>
     <div
-      style={
-        Object {
-          "alignItems": "center",
-          "backgroundColor": "#177863",
-          "border": "2px solid #011936",
-          "borderRadius": "4px",
-          "color": "#FFFFFF",
-          "display": "flex",
-          "fontSize": "1rem",
-          "height": "100%",
-          "justifyContent": "center",
-          "width": "100px",
-        }
-      }
+      className="ProfileCell"
     >
-      Box 5
+      <div
+        className="ProfileCell__image"
+      >
+        <div
+          aria-hidden={false}
+          className="Avatar"
+        >
+          <div
+            className="Avatar__circle ui-mod ui-mod--5"
+          >
+            <span
+              className="Avatar__circle__initials"
+            >
+              RR
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ProfileCell__content"
+        style={
+          Object {
+            "maxWidth": "none",
+          }
+        }
+      >
+        <div
+          className="ProfileCell__content__name__container"
+        >
+          <h5
+            className="ProfileCell__content__name"
+          >
+            Riley Researcher
+          </h5>
+        </div>
+        <div
+          className="ProfileCell__content__subtitle"
+        >
+          riley+5@userinterviews.com
+        </div>
+      </div>
+    </div>
+    <div
+      className="ProfileCell"
+    >
+      <div
+        className="ProfileCell__image"
+      >
+        <div
+          aria-hidden={false}
+          className="Avatar"
+        >
+          <div
+            className="Avatar__circle ui-mod ui-mod--0"
+          >
+            <span
+              className="Avatar__circle__initials"
+            >
+              RR
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ProfileCell__content"
+        style={
+          Object {
+            "maxWidth": "none",
+          }
+        }
+      >
+        <div
+          className="ProfileCell__content__name__container"
+        >
+          <h5
+            className="ProfileCell__content__name"
+          >
+            Riley Researcher
+          </h5>
+        </div>
+        <div
+          className="ProfileCell__content__subtitle"
+        >
+          riley+6@userinterviews.com
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -26177,70 +26573,150 @@ exports[`Storyshots Layouts/Flex Flex Item 1`] = `
     className="sc-bdvvtL kAfiPy"
   >
     <div
-      className="sc-bdvvtL gXfMQT"
-      height="100px"
+      className="sc-bdvvtL bAKtcE"
     >
       <div
-        style={
-          Object {
-            "alignItems": "center",
-            "backgroundColor": "#177863",
-            "border": "2px solid #011936",
-            "borderRadius": "4px",
-            "color": "#FFFFFF",
-            "display": "flex",
-            "fontSize": "1rem",
-            "height": "100%",
-            "justifyContent": "center",
-            "width": "100px",
-          }
-        }
+        className="ProfileCell"
       >
-        Adjust me
+        <div
+          className="ProfileCell__image"
+        >
+          <div
+            aria-hidden={false}
+            className="Avatar"
+          >
+            <div
+              className="Avatar__circle ui-mod ui-mod--1"
+            >
+              <span
+                className="Avatar__circle__initials"
+              >
+                CM
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ProfileCell__content"
+          style={
+            Object {
+              "maxWidth": "none",
+            }
+          }
+        >
+          <div
+            className="ProfileCell__content__name__container"
+          >
+            <h5
+              className="ProfileCell__content__name"
+            >
+              Change Me
+            </h5>
+          </div>
+          <div
+            className="ProfileCell__content__subtitle"
+          >
+            change@userinterviews.com
+          </div>
+        </div>
       </div>
     </div>
     <div
-      className="sc-bdvvtL ctgHMk"
+      className="sc-bdvvtL gZrZHX"
     >
       <div
-        style={
-          Object {
-            "alignItems": "center",
-            "backgroundColor": "#177863",
-            "border": "2px solid #011936",
-            "borderRadius": "4px",
-            "color": "#FFFFFF",
-            "display": "flex",
-            "fontSize": "1rem",
-            "height": "100%",
-            "justifyContent": "center",
-            "width": "100px",
-          }
-        }
+        className="ProfileCell"
       >
-        Box 2
+        <div
+          className="ProfileCell__image"
+        >
+          <div
+            aria-hidden={false}
+            className="Avatar"
+          >
+            <div
+              className="Avatar__circle ui-mod ui-mod--2"
+            >
+              <span
+                className="Avatar__circle__initials"
+              >
+                RR
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ProfileCell__content"
+          style={
+            Object {
+              "maxWidth": "none",
+            }
+          }
+        >
+          <div
+            className="ProfileCell__content__name__container"
+          >
+            <h5
+              className="ProfileCell__content__name"
+            >
+              Riley Researcher
+            </h5>
+          </div>
+          <div
+            className="ProfileCell__content__subtitle"
+          >
+            riley+2@userinterviews.com
+          </div>
+        </div>
       </div>
     </div>
     <div
-      className="sc-bdvvtL ctgHMk"
+      className="sc-bdvvtL gZrZHX"
     >
       <div
-        style={
-          Object {
-            "alignItems": "center",
-            "backgroundColor": "#177863",
-            "border": "2px solid #011936",
-            "borderRadius": "4px",
-            "color": "#FFFFFF",
-            "display": "flex",
-            "fontSize": "1rem",
-            "height": "100%",
-            "justifyContent": "center",
-            "width": "100px",
-          }
-        }
+        className="ProfileCell"
       >
-        Box 3
+        <div
+          className="ProfileCell__image"
+        >
+          <div
+            aria-hidden={false}
+            className="Avatar"
+          >
+            <div
+              className="Avatar__circle ui-mod ui-mod--3"
+            >
+              <span
+                className="Avatar__circle__initials"
+              >
+                RR
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ProfileCell__content"
+          style={
+            Object {
+              "maxWidth": "none",
+            }
+          }
+        >
+          <div
+            className="ProfileCell__content__name__container"
+          >
+            <h5
+              className="ProfileCell__content__name"
+            >
+              Riley Researcher
+            </h5>
+          </div>
+          <div
+            className="ProfileCell__content__subtitle"
+          >
+            riley+3@userinterviews.com
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/CardStack/CardStack.stories.jsx
+++ b/src/CardStack/CardStack.stories.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import Card, { CardSizes } from 'src/Card';
 import { withKnobs, select } from '@storybook/addon-knobs';
+import Flex from 'src/Flex';
 import CardStack from './CardStack';
 
 import mdx from './CardStack.mdx';
@@ -30,7 +31,7 @@ export const Default = () => (
 );
 
 export const Centered = () => (
-  <div style={{ display: 'flex', justifyContent: 'center' }}>
+  <Flex container justifyContent="center">
     <CardStack size={select('size', Object.values(CardSizes), CardSizes.SMALL)}>
       <h1 style={{ fontSize: '1.5rem', fontWeight: 700 }}>CardStack</h1>
       <Card title="Card 1">
@@ -43,5 +44,5 @@ export const Centered = () => (
       <Card title="Card 2" />
       <Card title="Card 3" />
     </CardStack>
-  </div>
+  </Flex>
 );

--- a/src/CardStack/CardStack.stories.jsx
+++ b/src/CardStack/CardStack.stories.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Card, { CardSizes } from 'src/Card';
 import { withKnobs, select } from '@storybook/addon-knobs';
-import Flex from 'src/Flex';
+import { Flex } from 'src/Flex';
 import CardStack from './CardStack';
 
 import mdx from './CardStack.mdx';

--- a/src/Container/Container.mdx
+++ b/src/Container/Container.mdx
@@ -3,8 +3,11 @@ import Container from './Container'
 
 # Container
 
-Utilizing Bootstrap's grid system makes use of a series of containers, rows, and columns to layout and align content. 
-It's built with flexbox and is fully responsive.
+<h4>
+  A high level grid system to help create responsive application layouts. 
+  Makes use of a series of Containers, Rows, and Columns to layout and align content.
+  It's built with flexbox and is fully responsive.
+</h4>
 
 For official documentation, visit [React Bootstrap Grid system](https://react-bootstrap.github.io/layout/grid/)
 

--- a/src/Flex/Flex.jsx
+++ b/src/Flex/Flex.jsx
@@ -18,9 +18,9 @@ Flex.propTypes = {
     If `true`, `display: flex;` otherwise `display: block;`
   */
   container: PropTypes.bool,
-  direction: PropTypes.oneOf(Object.values(FLEX_PROPS.direction)),
   flex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   flexBasis: PropTypes.string,
+  flexDirection: PropTypes.oneOf(Object.values(FLEX_PROPS.flexDirection)),
   flexGrow: PropTypes.number,
   flexShrink: PropTypes.number,
   flexWrap: PropTypes.oneOf(Object.values(FLEX_PROPS.flexWrap)),
@@ -49,9 +49,9 @@ Flex.defaultProps = {
   alignSelf: undefined,
   className: undefined,
   container: undefined,
-  direction: undefined,
   flex: undefined,
   flexBasis: undefined,
+  flexDirection: undefined,
   flexGrow: undefined,
   flexShrink: undefined,
   flexWrap: undefined,

--- a/src/Flex/Flex.jsx
+++ b/src/Flex/Flex.jsx
@@ -25,10 +25,6 @@ Flex.propTypes = {
   flexShrink: PropTypes.number,
   flexWrap: PropTypes.oneOf(Object.values(FLEX_PROPS.flexWrap)),
   /**
-    row-gap column-gap (e.g. '10px 20px' => `gap: 10px 20px;`)
-  */
-  gap: PropTypes.string,
-  /**
     rem or px
   */
   height: PropTypes.string,
@@ -59,7 +55,6 @@ Flex.defaultProps = {
   flexGrow: undefined,
   flexShrink: undefined,
   flexWrap: undefined,
-  gap: undefined,
   height: undefined,
   justifyContent: undefined,
   justifySelf: undefined,

--- a/src/Flex/Flex.jsx
+++ b/src/Flex/Flex.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { FlexWrapper } from './FlexWrapper.styles';
+
+const Flex = ({ className, children, ...props }) => (
+  <FlexWrapper className={className} {...props}>
+    {children}
+  </FlexWrapper>
+);
+
+Flex.propTypes = {
+  alignItems: PropTypes.oneOf([
+    'stretch',
+    'center',
+    'flex-start',
+    'flex-end',
+    'baseline',
+    'initial',
+    'inherit',
+  ]),
+  alignSelf: PropTypes.oneOf([
+    'stretch',
+    'center',
+    'start',
+    'end',
+  ]),
+  className: PropTypes.string,
+  /**
+    If `true`, `display: flex;` otherwise `display: block;`
+  */
+  container: PropTypes.bool,
+  direction: PropTypes.oneOf(['column', 'row']),
+  flex: PropTypes.string,
+  flexBasis: PropTypes.string,
+  flexGrow: PropTypes.number,
+  flexShrink: PropTypes.number,
+  flexWrap: PropTypes.oneOf(['wrap', 'nowrap', 'reverse']),
+  /**
+    rem or px
+  */
+  height: PropTypes.string,
+  justifyContent: PropTypes.oneOf([
+    'flex-start',
+    'flex-end',
+    'space-between',
+    'space-around',
+    'center',
+    'initial',
+    'inherit',
+  ]),
+  justifySelf: PropTypes.oneOf([
+    'stretch',
+    'center',
+    'start',
+    'end',
+  ]),
+  /**
+    rem or px
+  */
+  maxHeight: PropTypes.string,
+  /**
+    rem or px
+  */
+  maxWidth: PropTypes.string,
+  /**
+    rem or px
+  */
+  width: PropTypes.string,
+};
+
+Flex.defaultProps = {
+  alignItems: undefined,
+  alignSelf: undefined,
+  className: undefined,
+  container: undefined,
+  direction: undefined,
+  flex: undefined,
+  flexBasis: undefined,
+  flexGrow: undefined,
+  flexShrink: undefined,
+  flexWrap: undefined,
+  height: undefined,
+  justifyContent: undefined,
+  justifySelf: undefined,
+  maxHeight: undefined,
+  maxWidth: undefined,
+  width: undefined,
+};
+
+export default Flex;

--- a/src/Flex/Flex.jsx
+++ b/src/Flex/Flex.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { FLEX_PROPS } from './Flex.types';
 import { FlexWrapper } from './FlexWrapper.styles';
 
 const Flex = ({ className, children, ...props }) => (
@@ -10,32 +11,19 @@ const Flex = ({ className, children, ...props }) => (
 );
 
 Flex.propTypes = {
-  alignItems: PropTypes.oneOf([
-    'stretch',
-    'center',
-    'flex-start',
-    'flex-end',
-    'baseline',
-    'initial',
-    'inherit',
-  ]),
-  alignSelf: PropTypes.oneOf([
-    'stretch',
-    'center',
-    'start',
-    'end',
-  ]),
+  alignItems: PropTypes.oneOf(Object.values(FLEX_PROPS.alignItems)),
+  alignSelf: PropTypes.oneOf(Object.values(FLEX_PROPS.alignSelf)),
   className: PropTypes.string,
   /**
     If `true`, `display: flex;` otherwise `display: block;`
   */
   container: PropTypes.bool,
-  direction: PropTypes.oneOf(['column', 'row']),
+  direction: PropTypes.oneOf(Object.values(FLEX_PROPS.direction)),
   flex: PropTypes.string,
   flexBasis: PropTypes.string,
   flexGrow: PropTypes.number,
   flexShrink: PropTypes.number,
-  flexWrap: PropTypes.oneOf(['wrap', 'nowrap', 'reverse']),
+  flexWrap: PropTypes.oneOf(Object.values(FLEX_PROPS.flexWrap)),
   /**
     row-gap column-gap (e.g. '10px 20px' => `gap: 10px 20px;`)
   */
@@ -44,21 +32,8 @@ Flex.propTypes = {
     rem or px
   */
   height: PropTypes.string,
-  justifyContent: PropTypes.oneOf([
-    'flex-start',
-    'flex-end',
-    'space-between',
-    'space-around',
-    'center',
-    'initial',
-    'inherit',
-  ]),
-  justifySelf: PropTypes.oneOf([
-    'stretch',
-    'center',
-    'start',
-    'end',
-  ]),
+  justifyContent: PropTypes.oneOf(Object.values(FLEX_PROPS.justifyContent)),
+  justifySelf: PropTypes.oneOf(Object.values(FLEX_PROPS.justifySelf)),
   /**
     rem or px
   */

--- a/src/Flex/Flex.jsx
+++ b/src/Flex/Flex.jsx
@@ -37,6 +37,10 @@ Flex.propTypes = {
   flexShrink: PropTypes.number,
   flexWrap: PropTypes.oneOf(['wrap', 'nowrap', 'reverse']),
   /**
+    row-gap column-gap (e.g. '10px 20px' => `gap: 10px 20px;`)
+  */
+  gap: PropTypes.string,
+  /**
     rem or px
   */
   height: PropTypes.string,
@@ -80,6 +84,7 @@ Flex.defaultProps = {
   flexGrow: undefined,
   flexShrink: undefined,
   flexWrap: undefined,
+  gap: undefined,
   height: undefined,
   justifyContent: undefined,
   justifySelf: undefined,

--- a/src/Flex/Flex.jsx
+++ b/src/Flex/Flex.jsx
@@ -19,7 +19,7 @@ Flex.propTypes = {
   */
   container: PropTypes.bool,
   direction: PropTypes.oneOf(Object.values(FLEX_PROPS.direction)),
-  flex: PropTypes.string,
+  flex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   flexBasis: PropTypes.string,
   flexGrow: PropTypes.number,
   flexShrink: PropTypes.number,

--- a/src/Flex/Flex.mdx
+++ b/src/Flex/Flex.mdx
@@ -1,0 +1,46 @@
+import { ArgsTable, Story, Canvas } from '@storybook/addon-docs/blocks';
+import Flex from './Flex';
+
+# Flex
+
+##
+
+<h4>
+  Flex provides a layout container using CSS Flexbox.
+</h4>
+
+The <code>Flex</code> component provides a Flexbox container. Learn more about some of the available 
+Flexbox CSS properties in the following documentation:
+
+<ul>
+  <li><a href='https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox'>Flex layout - MDN</a></li>
+  <li><a href='https://css-tricks.com/snippets/css/a-guide-to-flexbox/'>A Complete Guide to Flex - CSS Tricks</a></li>
+</ul>
+
+<Canvas>
+  <Story id="layouts-flex--default" />
+</Canvas>
+
+## Props
+
+<ArgsTable of={Flex} />
+
+## Stories
+
+### Default
+
+<Canvas>
+  <Story id="layouts-flex--default" />
+</Canvas>
+
+### Flex Container
+
+<Canvas>
+  <Story id="layouts-flex--flex-container" />
+</Canvas>
+
+### Flex Item
+
+<Canvas>
+  <Story id="layouts-flex--flex-item" />
+</Canvas>

--- a/src/Flex/Flex.mdx
+++ b/src/Flex/Flex.mdx
@@ -6,7 +6,7 @@ import Flex from './Flex';
 ##
 
 <h4>
-  Flex provides a layout container using CSS Flexbox.
+  Flex is a utility component for creating consistent spacing between items. Use this for quick alignment and spacing in your layouts.
 </h4>
 
 The <code>Flex</code> component provides a Flexbox container. Learn more about some of the available 

--- a/src/Flex/Flex.stories.jsx
+++ b/src/Flex/Flex.stories.jsx
@@ -9,6 +9,7 @@ import {
 
 import { colors } from 'src/Styles';
 import Flex from './Flex';
+import { FLEX_PROPS } from './Flex.types';
 
 import mdx from './Flex.mdx';
 
@@ -43,49 +44,19 @@ const Box = ({ children }) => (
 
 export const Default = () => (
   <Flex
-    alignItems={radios('alignItems',
-      [
-        'stretch',
-        'center',
-        'flex-start',
-        'flex-end',
-        'baseline',
-        'initial',
-        'inherit',
-      ])}
-    alignSelf={radios('alignSelf',
-      [
-        'stretch',
-        'center',
-        'start',
-        'end',
-      ])}
+    alignItems={radios('alignItems', Object.values(FLEX_PROPS.alignItems))}
+    alignSelf={radios('alignSelf', Object.values(FLEX_PROPS.alignSelf))}
     container={boolean('container', true)}
-    direction={radios('direction', ['row', 'column'])}
+    direction={radios('direction', Object.values(FLEX_PROPS.direction))}
     flex={text('flex')}
     flexBasis={text('flexBasis')}
     flexGrow={text('flexGrow')}
     flexShrink={text('flexShrink')}
-    flexWrap={radios('flexWrap', ['wrap', 'nowrap', 'reverse'])}
+    flexWrap={radios('flexWrap', Object.values(FLEX_PROPS.flexWrap))}
     gap={text('gap')}
     height={text('height')}
-    justifyContent={radios('justifyContent',
-      [
-        'flex-start',
-        'flex-end',
-        'space-between',
-        'space-around',
-        'center',
-        'initial',
-        'inherit',
-      ])}
-    justifySelf={radios('justifySelf',
-      [
-        'stretch',
-        'center',
-        'start',
-        'end',
-      ])}
+    justifyContent={radios('justifyContent', Object.values(FLEX_PROPS.justifyContent))}
+    justifySelf={radios('justifySelf', Object.values(FLEX_PROPS.justifySelf))}
     maxHeight={text('maxHeight')}
     maxWidth={text('maxWidth')}
     width={text('width')}
@@ -100,30 +71,12 @@ export const FlexContainer = () => (
   <>
     <h1 style={{ fontSize: '1.5rem', fontWeight: '700' }}>Properties for the parent (flex container)</h1>
     <Flex
-      alignItems={radios('alignItems',
-      [
-        'stretch',
-        'center',
-        'flex-start',
-        'flex-end',
-        'baseline',
-        'initial',
-        'inherit',
-      ])}
+      alignItems={radios('alignItems', Object.values(FLEX_PROPS.alignItems))}
       container
-      direction={radios('direction', ['row', 'column'], 'row')}
-      flexWrap={radios('flexWrap', ['wrap', 'nowrap', 'reverse'])}
+      direction={radios('direction', Object.values(FLEX_PROPS.direction))}
+      flexWrap={radios('flexWrap', Object.values(FLEX_PROPS.flexWrap))}
       gap={text('gap')}
-      justifyContent={radios('justifyContent',
-      [
-        'flex-start',
-        'flex-end',
-        'space-between',
-        'space-around',
-        'center',
-        'initial',
-        'inherit',
-      ])}
+      justifyContent={radios('justifyContent', Object.values(FLEX_PROPS.justifyContent))}
     >
       <Box>Box 1</Box>
       <Box>Box 2</Box>
@@ -139,24 +92,12 @@ export const FlexItem = () => (
     <h1 style={{ fontSize: '1.5rem', fontWeight: '700' }}>Properties for the children (flex item)</h1>
     <Flex container>
       <Flex
-        alignSelf={radios('alignSelf',
-          [
-            'stretch',
-            'center',
-            'start',
-            'end',
-          ])}
+        alignSelf={radios('alignSelf', Object.values(FLEX_PROPS.alignSelf))}
         flex={text('flex')}
         flexBasis={text('flexBasis')}
         flexGrow={text('flexGrow')}
         flexShrink={text('flexShrink')}
-        justifySelf={radios('justifySelf',
-          [
-            'stretch',
-            'center',
-            'start',
-            'end',
-          ])}
+        justifySelf={radios('justifySelf', Object.values(FLEX_PROPS.justifySelf))}
       >
         <Box>Adjust me</Box>
       </Flex>

--- a/src/Flex/Flex.stories.jsx
+++ b/src/Flex/Flex.stories.jsx
@@ -47,9 +47,9 @@ export const Default = () => (
     alignItems={radios('alignItems', Object.values(FLEX_PROPS.alignItems))}
     alignSelf={radios('alignSelf', Object.values(FLEX_PROPS.alignSelf))}
     container={boolean('container', true)}
-    direction={radios('direction', Object.values(FLEX_PROPS.direction))}
     flex={text('flex')}
     flexBasis={text('flexBasis')}
+    flexDirection={radios('flexDirection', Object.values(FLEX_PROPS.flexDirection))}
     flexGrow={text('flexGrow')}
     flexShrink={text('flexShrink')}
     flexWrap={radios('flexWrap', Object.values(FLEX_PROPS.flexWrap))}
@@ -72,7 +72,7 @@ export const FlexContainer = () => (
     <Flex
       alignItems={radios('alignItems', Object.values(FLEX_PROPS.alignItems))}
       container
-      direction={radios('direction', Object.values(FLEX_PROPS.direction))}
+      flexDirection={radios('flexDirection', Object.values(FLEX_PROPS.flexDirection))}
       flexWrap={radios('flexWrap', Object.values(FLEX_PROPS.flexWrap))}
       height="100px"
       justifyContent={radios('justifyContent', Object.values(FLEX_PROPS.justifyContent))}

--- a/src/Flex/Flex.stories.jsx
+++ b/src/Flex/Flex.stories.jsx
@@ -7,9 +7,9 @@ import {
   withKnobs,
 } from '@storybook/addon-knobs';
 
-import { colors } from 'src/Styles';
 import Flex from './Flex';
 import { FLEX_PROPS } from './Flex.types';
+import ProfileCell from '../ProfileCell';
 
 import mdx from './Flex.mdx';
 
@@ -24,23 +24,10 @@ export default {
   },
 };
 
-const Box = ({ children }) => (
-  <div style={{
-    height: '100%',
-    width: '100px',
-    backgroundColor: colors.UX_EMERALD_600,
-    borderRadius: '4px',
-    color: colors.UX_WHITE,
-    fontSize: '1rem',
-    border: `2px solid ${colors.UX_NAVY}`,
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-  }}
-  >
-    {children}
-  </div>
-);
+const userNoImage = {
+  initials: 'RR',
+  name: 'Riley Researcher',
+};
 
 export const Default = () => (
   <Flex
@@ -52,17 +39,44 @@ export const Default = () => (
     flexDirection={radios('flexDirection', Object.values(FLEX_PROPS.flexDirection))}
     flexGrow={text('flexGrow')}
     flexShrink={text('flexShrink')}
-    flexWrap={radios('flexWrap', Object.values(FLEX_PROPS.flexWrap))}
-    height={text('height', '100px')}
+    flexWrap={radios('flexWrap', Object.values(FLEX_PROPS.flexWrap), 'wrap')}
+    height={text('height', '100%')}
     justifyContent={radios('justifyContent', Object.values(FLEX_PROPS.justifyContent))}
     justifySelf={radios('justifySelf', Object.values(FLEX_PROPS.justifySelf))}
     maxHeight={text('maxHeight')}
     maxWidth={text('maxWidth')}
     width={text('width')}
   >
-    <Box>Box 1</Box>
-    <Box>Box 2</Box>
-    <Box>Box 3</Box>
+    <ProfileCell
+      colorId={1}
+      subtitle="riley+1@userinterviews.com"
+      user={userNoImage}
+    />
+    <ProfileCell
+      colorId={2}
+      subtitle="riley+2@userinterviews.com"
+      user={userNoImage}
+    />
+    <ProfileCell
+      colorId={3}
+      subtitle="riley+3@userinterviews.com"
+      user={userNoImage}
+    />
+    <ProfileCell
+      colorId={4}
+      subtitle="riley+4@userinterviews.com"
+      user={userNoImage}
+    />
+    <ProfileCell
+      colorId={5}
+      subtitle="riley+5@userinterviews.com"
+      user={userNoImage}
+    />
+    <ProfileCell
+      colorId={6}
+      subtitle="riley+6@userinterviews.com"
+      user={userNoImage}
+    />
   </Flex>
   );
 
@@ -73,15 +87,40 @@ export const FlexContainer = () => (
       alignItems={radios('alignItems', Object.values(FLEX_PROPS.alignItems))}
       container
       flexDirection={radios('flexDirection', Object.values(FLEX_PROPS.flexDirection))}
-      flexWrap={radios('flexWrap', Object.values(FLEX_PROPS.flexWrap))}
-      height="100px"
+      flexWrap={radios('flexWrap', Object.values(FLEX_PROPS.flexWrap), 'wrap')}
+      height="100%"
       justifyContent={radios('justifyContent', Object.values(FLEX_PROPS.justifyContent))}
     >
-      <Box>Box 1</Box>
-      <Box>Box 2</Box>
-      <Box>Box 3</Box>
-      <Box>Box 4</Box>
-      <Box>Box 5</Box>
+      <ProfileCell
+        colorId={1}
+        subtitle="riley+1@userinterviews.com"
+        user={userNoImage}
+      />
+      <ProfileCell
+        colorId={2}
+        subtitle="riley+2@userinterviews.com"
+        user={userNoImage}
+      />
+      <ProfileCell
+        colorId={3}
+        subtitle="riley+3@userinterviews.com"
+        user={userNoImage}
+      />
+      <ProfileCell
+        colorId={4}
+        subtitle="riley+4@userinterviews.com"
+        user={userNoImage}
+      />
+      <ProfileCell
+        colorId={5}
+        subtitle="riley+5@userinterviews.com"
+        user={userNoImage}
+      />
+      <ProfileCell
+        colorId={6}
+        subtitle="riley+6@userinterviews.com"
+        user={userNoImage}
+      />
     </Flex>
   </>
 );
@@ -92,20 +131,31 @@ export const FlexItem = () => (
     <Flex container>
       <Flex
         alignSelf={radios('alignSelf', Object.values(FLEX_PROPS.alignSelf))}
-        flex={text('flex')}
+        flex={text('flex', '2')}
         flexBasis={text('flexBasis')}
         flexGrow={text('flexGrow')}
         flexShrink={text('flexShrink')}
-        height="100px"
         justifySelf={radios('justifySelf', Object.values(FLEX_PROPS.justifySelf))}
       >
-        <Box>Adjust me</Box>
+        <ProfileCell
+          colorId={1}
+          subtitle="change@userinterviews.com"
+          user={{ name: 'Change Me', initials: 'CM' }}
+        />
       </Flex>
-      <Flex>
-        <Box>Box 2</Box>
+      <Flex flex={1}>
+        <ProfileCell
+          colorId={2}
+          subtitle="riley+2@userinterviews.com"
+          user={userNoImage}
+        />
       </Flex>
-      <Flex>
-        <Box>Box 3</Box>
+      <Flex flex={1}>
+        <ProfileCell
+          colorId={3}
+          subtitle="riley+3@userinterviews.com"
+          user={userNoImage}
+        />
       </Flex>
     </Flex>
   </>

--- a/src/Flex/Flex.stories.jsx
+++ b/src/Flex/Flex.stories.jsx
@@ -26,7 +26,7 @@ export default {
 
 const Box = ({ children }) => (
   <div style={{
-    height: '100px',
+    height: '100%',
     width: '100px',
     backgroundColor: colors.UX_EMERALD_600,
     borderRadius: '4px',
@@ -53,7 +53,7 @@ export const Default = () => (
     flexGrow={text('flexGrow')}
     flexShrink={text('flexShrink')}
     flexWrap={radios('flexWrap', Object.values(FLEX_PROPS.flexWrap))}
-    height={text('height')}
+    height={text('height', '100px')}
     justifyContent={radios('justifyContent', Object.values(FLEX_PROPS.justifyContent))}
     justifySelf={radios('justifySelf', Object.values(FLEX_PROPS.justifySelf))}
     maxHeight={text('maxHeight')}
@@ -74,6 +74,7 @@ export const FlexContainer = () => (
       container
       direction={radios('direction', Object.values(FLEX_PROPS.direction))}
       flexWrap={radios('flexWrap', Object.values(FLEX_PROPS.flexWrap))}
+      height="100px"
       justifyContent={radios('justifyContent', Object.values(FLEX_PROPS.justifyContent))}
     >
       <Box>Box 1</Box>
@@ -95,6 +96,7 @@ export const FlexItem = () => (
         flexBasis={text('flexBasis')}
         flexGrow={text('flexGrow')}
         flexShrink={text('flexShrink')}
+        height="100px"
         justifySelf={radios('justifySelf', Object.values(FLEX_PROPS.justifySelf))}
       >
         <Box>Adjust me</Box>

--- a/src/Flex/Flex.stories.jsx
+++ b/src/Flex/Flex.stories.jsx
@@ -67,6 +67,7 @@ export const Default = () => (
     flexGrow={text('flexGrow')}
     flexShrink={text('flexShrink')}
     flexWrap={radios('flexWrap', ['wrap', 'nowrap', 'reverse'])}
+    gap={text('gap')}
     height={text('height')}
     justifyContent={radios('justifyContent',
       [
@@ -112,6 +113,7 @@ export const FlexContainer = () => (
       container
       direction={radios('direction', ['row', 'column'], 'row')}
       flexWrap={radios('flexWrap', ['wrap', 'nowrap', 'reverse'])}
+      gap={text('gap')}
       justifyContent={radios('justifyContent',
       [
         'flex-start',

--- a/src/Flex/Flex.stories.jsx
+++ b/src/Flex/Flex.stories.jsx
@@ -53,7 +53,6 @@ export const Default = () => (
     flexGrow={text('flexGrow')}
     flexShrink={text('flexShrink')}
     flexWrap={radios('flexWrap', Object.values(FLEX_PROPS.flexWrap))}
-    gap={text('gap')}
     height={text('height')}
     justifyContent={radios('justifyContent', Object.values(FLEX_PROPS.justifyContent))}
     justifySelf={radios('justifySelf', Object.values(FLEX_PROPS.justifySelf))}
@@ -75,7 +74,6 @@ export const FlexContainer = () => (
       container
       direction={radios('direction', Object.values(FLEX_PROPS.direction))}
       flexWrap={radios('flexWrap', Object.values(FLEX_PROPS.flexWrap))}
-      gap={text('gap')}
       justifyContent={radios('justifyContent', Object.values(FLEX_PROPS.justifyContent))}
     >
       <Box>Box 1</Box>

--- a/src/Flex/Flex.stories.jsx
+++ b/src/Flex/Flex.stories.jsx
@@ -1,0 +1,169 @@
+import React from 'react';
+
+import {
+  boolean,
+  radios,
+  text,
+  withKnobs,
+} from '@storybook/addon-knobs';
+
+import { colors } from 'src/Styles';
+import Flex from './Flex';
+
+import mdx from './Flex.mdx';
+
+export default {
+  title: 'Layouts/Flex',
+  component: Flex,
+  decorators: [withKnobs],
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+};
+
+const Box = ({ children }) => (
+  <div style={{
+    height: '100px',
+    width: '100px',
+    backgroundColor: colors.UX_EMERALD_600,
+    borderRadius: '4px',
+    color: colors.UX_WHITE,
+    fontSize: '1rem',
+    border: `2px solid ${colors.UX_NAVY}`,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  }}
+  >
+    {children}
+  </div>
+);
+
+export const Default = () => (
+  <Flex
+    alignItems={radios('alignItems',
+      [
+        'stretch',
+        'center',
+        'flex-start',
+        'flex-end',
+        'baseline',
+        'initial',
+        'inherit',
+      ])}
+    alignSelf={radios('alignSelf',
+      [
+        'stretch',
+        'center',
+        'start',
+        'end',
+      ])}
+    container={boolean('container', true)}
+    direction={radios('direction', ['row', 'column'])}
+    flex={text('flex')}
+    flexBasis={text('flexBasis')}
+    flexGrow={text('flexGrow')}
+    flexShrink={text('flexShrink')}
+    flexWrap={radios('flexWrap', ['wrap', 'nowrap', 'reverse'])}
+    height={text('height')}
+    justifyContent={radios('justifyContent',
+      [
+        'flex-start',
+        'flex-end',
+        'space-between',
+        'space-around',
+        'center',
+        'initial',
+        'inherit',
+      ])}
+    justifySelf={radios('justifySelf',
+      [
+        'stretch',
+        'center',
+        'start',
+        'end',
+      ])}
+    maxHeight={text('maxHeight')}
+    maxWidth={text('maxWidth')}
+    width={text('width')}
+  >
+    <Box>Box 1</Box>
+    <Box>Box 2</Box>
+    <Box>Box 3</Box>
+  </Flex>
+  );
+
+export const FlexContainer = () => (
+  <>
+    <h1 style={{ fontSize: '1.5rem', fontWeight: '700' }}>Properties for the parent (flex container)</h1>
+    <Flex
+      alignItems={radios('alignItems',
+      [
+        'stretch',
+        'center',
+        'flex-start',
+        'flex-end',
+        'baseline',
+        'initial',
+        'inherit',
+      ])}
+      container
+      direction={radios('direction', ['row', 'column'], 'row')}
+      flexWrap={radios('flexWrap', ['wrap', 'nowrap', 'reverse'])}
+      justifyContent={radios('justifyContent',
+      [
+        'flex-start',
+        'flex-end',
+        'space-between',
+        'space-around',
+        'center',
+        'initial',
+        'inherit',
+      ])}
+    >
+      <Box>Box 1</Box>
+      <Box>Box 2</Box>
+      <Box>Box 3</Box>
+      <Box>Box 4</Box>
+      <Box>Box 5</Box>
+    </Flex>
+  </>
+);
+
+export const FlexItem = () => (
+  <>
+    <h1 style={{ fontSize: '1.5rem', fontWeight: '700' }}>Properties for the children (flex item)</h1>
+    <Flex container>
+      <Flex
+        alignSelf={radios('alignSelf',
+          [
+            'stretch',
+            'center',
+            'start',
+            'end',
+          ])}
+        flex={text('flex')}
+        flexBasis={text('flexBasis')}
+        flexGrow={text('flexGrow')}
+        flexShrink={text('flexShrink')}
+        justifySelf={radios('justifySelf',
+          [
+            'stretch',
+            'center',
+            'start',
+            'end',
+          ])}
+      >
+        <Box>Adjust me</Box>
+      </Flex>
+      <Flex>
+        <Box>Box 2</Box>
+      </Flex>
+      <Flex>
+        <Box>Box 3</Box>
+      </Flex>
+    </Flex>
+  </>
+);

--- a/src/Flex/Flex.types.js
+++ b/src/Flex/Flex.types.js
@@ -23,7 +23,7 @@ export const FLEX_PROPS = {
   flexWrap: {
     wrap: 'wrap',
     noWrap: 'no-wrap',
-    reverse: 'reverse',
+    wrapReverse: 'wrap-reverse',
   },
   justifyContent: {
     flexStart: 'flex-start',

--- a/src/Flex/Flex.types.js
+++ b/src/Flex/Flex.types.js
@@ -1,0 +1,41 @@
+export const FLEX_PROPS = {
+  alignItems: {
+    stretch: 'stretch',
+    center: 'center',
+    flexStart: 'flex-start',
+    flexEnd: 'flex-end',
+    baseline: 'baseline',
+    initial: 'initial',
+    inherit: 'inherit',
+  },
+  alignSelf: {
+    stretch: 'stretch',
+    center: 'center',
+    start: 'start',
+    end: 'end',
+  },
+  direction: {
+    column: 'column',
+    row: 'row',
+  },
+  flexWrap: {
+    wrap: 'wrap',
+    noWrap: 'no-wrap',
+    reverse: 'reverse',
+  },
+  justifyContent: {
+    flexStart: 'flex-start',
+    flexEnd: 'flex-end',
+    spaceBetween: 'space-between',
+    spaceAround: 'space-around',
+    center: 'center',
+    initial: 'initial',
+    inherit: 'inherit',
+  },
+  justifySelf: {
+    stretch: 'stretch',
+    center: 'center',
+    start: 'start',
+    end: 'end',
+  },
+};

--- a/src/Flex/Flex.types.js
+++ b/src/Flex/Flex.types.js
@@ -14,9 +14,11 @@ export const FLEX_PROPS = {
     start: 'start',
     end: 'end',
   },
-  direction: {
+  flexDirection: {
     column: 'column',
+    columnReverse: 'column-reverse',
     row: 'row',
+    rowReverse: 'row-reverse',
   },
   flexWrap: {
     wrap: 'wrap',

--- a/src/Flex/FlexWrapper.styles.js
+++ b/src/Flex/FlexWrapper.styles.js
@@ -6,7 +6,6 @@ export const FlexWrapper = styled.div`
     direction,
     flexWrap,
     alignItems,
-    gap,
     justifyContent,
     height,
     maxHeight,
@@ -42,12 +41,6 @@ export const FlexWrapper = styled.div`
     css`
       align-items: ${alignItems};
     `}
-
-    ${gap &&
-    css`
-      gap: ${gap};
-    `
-    }
 
     ${height &&
     css`

--- a/src/Flex/FlexWrapper.styles.js
+++ b/src/Flex/FlexWrapper.styles.js
@@ -1,0 +1,95 @@
+import styled, { css } from 'styled-components';
+
+export const FlexWrapper = styled.div`
+  ${({
+    container,
+    direction,
+    flexWrap,
+    alignItems,
+    justifyContent,
+    height,
+    maxHeight,
+    flex,
+    flexBasis,
+    flexGrow,
+    flexShrink,
+    width,
+    maxWidth,
+    justifySelf,
+    alignSelf,
+  }) =>
+
+    css`
+    display: ${container ? 'flex' : 'block'};
+
+    ${direction &&
+    css`
+      flex-direction: ${direction};
+    `}
+
+    ${flexWrap &&
+    css`
+      flex-wrap: ${flexWrap};
+    `}
+
+    ${justifyContent &&
+    css`
+      justify-content: ${justifyContent};
+    `}
+
+    ${alignItems &&
+    css`
+      align-items: ${alignItems};
+    `}
+
+    ${height &&
+    css`
+      height: ${height};
+    `}
+
+    ${maxHeight &&
+    css`
+      max-height: ${maxHeight};
+    `}
+
+    ${width &&
+    css`
+      width: ${width};
+    `}
+
+    ${maxWidth &&
+    css`
+      max-width: ${maxWidth};
+    `}
+
+    ${flex &&
+    css`
+      flex: ${flex};
+    `}
+
+    ${flexGrow &&
+    css`
+      flex-grow: ${flexGrow};
+    `}
+
+    ${flexShrink &&
+    css`
+      flex-shrink: ${flexShrink};
+    `}
+
+    ${flexBasis &&
+    css`
+      flex-basis: ${flexBasis};
+    `}
+
+    ${alignSelf &&
+    css`
+      align-self: ${alignSelf};
+    `}
+
+    ${justifySelf &&
+    css`
+      justify-self: ${justifySelf};
+    `}
+  `}
+`;

--- a/src/Flex/FlexWrapper.styles.js
+++ b/src/Flex/FlexWrapper.styles.js
@@ -6,6 +6,7 @@ export const FlexWrapper = styled.div`
     direction,
     flexWrap,
     alignItems,
+    gap,
     justifyContent,
     height,
     maxHeight,
@@ -41,6 +42,12 @@ export const FlexWrapper = styled.div`
     css`
       align-items: ${alignItems};
     `}
+
+    ${gap &&
+    css`
+      gap: ${gap};
+    `
+    }
 
     ${height &&
     css`

--- a/src/Flex/FlexWrapper.styles.js
+++ b/src/Flex/FlexWrapper.styles.js
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 export const FlexWrapper = styled.div`
   ${({
     container,
-    direction,
+    flexDirection,
     flexWrap,
     alignItems,
     justifyContent,
@@ -22,9 +22,9 @@ export const FlexWrapper = styled.div`
     css`
     display: ${container ? 'flex' : 'block'};
 
-    ${direction &&
+    ${flexDirection &&
     css`
-      flex-direction: ${direction};
+      flex-direction: ${flexDirection};
     `}
 
     ${flexWrap &&

--- a/src/Flex/index.js
+++ b/src/Flex/index.js
@@ -1,0 +1,3 @@
+import Flex from './Flex';
+
+export default Flex;

--- a/src/Flex/index.js
+++ b/src/Flex/index.js
@@ -1,3 +1,7 @@
 import Flex from './Flex';
+import { FLEX_PROPS } from './Flex.types';
 
-export default Flex;
+export {
+  Flex,
+  FLEX_PROPS,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ import {
   DropdownMenu,
 } from 'src/Dropdown';
 import FadeTransition from 'src/FadeTransition';
-import Flex from 'src/Flex';
+import { Flex, FLEX_PROPS } from 'src/Flex';
 import Form from 'src/Form';
 import FormControlLabel from 'src/FormControlLabel';
 import FormGroup from 'src/FormGroup';
@@ -108,6 +108,7 @@ export {
   DropdownMenu,
   FadeTransition,
   Flex,
+  FLEX_PROPS,
   Form,
   FormControlLabel,
   FormGroup,

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ import {
   DropdownMenu,
 } from 'src/Dropdown';
 import FadeTransition from 'src/FadeTransition';
+import Flex from 'src/Flex';
 import Form from 'src/Form';
 import FormControlLabel from 'src/FormControlLabel';
 import FormGroup from 'src/FormGroup';
@@ -106,6 +107,7 @@ export {
   DropdownItem,
   DropdownMenu,
   FadeTransition,
+  Flex,
   Form,
   FormControlLabel,
   FormGroup,


### PR DESCRIPTION
closes #780 

![Screen Shot 2022-11-14 at 4 11 24 PM](https://user-images.githubusercontent.com/37383785/201794382-a5f3e1fd-62f6-4db1-ac9b-4a18fd216f21.png)

The `<Flex>` layout component makes use of `styled-components`. I thought it would make more sense to use this instead of the usual classnames convention since there are so many possible flex properties that you can use. This is probably only my second time using styled-components so let me know if there are some best practices or conventions I'm overlooking.

Also I added what I thought were the most commonly used flex properties, but let me know if you want another one added or changed! Play around with the Storybook knobs in the build below:

Chromatic build: https://62d040e741710e4f085e0647-ukafrrrmop.chromatic.com/?path=/story/layouts-flex--default