### PR TITLE
add labelDescription to OptionWithDescription

### DIFF
--- a/src/Select/OptionWithDescription.jsx
+++ b/src/Select/OptionWithDescription.jsx
@@ -22,9 +22,11 @@ const OptionWithDescription = ({ ...props }) => (
         {props.label}&nbsp;
         {props.data.labelDescription}
       </label>
-      <div className="OptionWithDescription__description">
-        {props.data.description}
-      </div>
+      {!props.data.hideDescription && (
+        <div className="OptionWithDescription__description">
+          {props.data.description}
+        </div>
+      )}
     </div>
   </components.Option>
   );

--- a/src/Select/OptionWithDescription.jsx
+++ b/src/Select/OptionWithDescription.jsx
@@ -19,7 +19,8 @@ const OptionWithDescription = ({ ...props }) => (
   >
     <div className="OptionWithDescription">
       <label className="OptionWithDescription__label">
-        {props.label}
+        {props.label}&nbsp;
+        {props.data.labelDescription}
       </label>
       <div className="OptionWithDescription__description">
         {props.data.description}

--- a/src/Select/OptionWithDescription.jsx
+++ b/src/Select/OptionWithDescription.jsx
@@ -12,7 +12,7 @@ import './OptionWithDescription.scss';
 // See: https://react-select.com/components#replaceable-components
 
 /* eslint-disable react/prop-types */
-const OptionWithDescription = ({ ...props }) => (
+const OptionWithDescription = ({ hideDescription, ...props }) => (
   <components.Option
     innerProps={{ 'aria-label': `${props.label}. ${props.data.description}` }}
     {...props}
@@ -22,7 +22,7 @@ const OptionWithDescription = ({ ...props }) => (
         {props.label}&nbsp;
         {props.data.labelDescription}
       </label>
-      {!props.data.hideDescription && (
+      {!hideDescription && (
         <div className="OptionWithDescription__description">
           {props.data.description}
         </div>

--- a/src/Select/SingleSelect.stories.jsx
+++ b/src/Select/SingleSelect.stories.jsx
@@ -114,10 +114,18 @@ export const InModal = () => (
 
 export const CustomOptionWithDescription = () => {
   const optionsWithDescriptions = [
-    { label: 'Org Admin', value: 1, description: 'Short description of role capabilities' },
-    { label: 'Administrator', value: 2, description: 'Short description of role capabilities' },
-    { label: 'Researcher', value: 3, description: 'Short description of role capabilities' },
-    { label: 'Teammate', value: 4, description: 'Short description of role capabilities' },
+    {
+ label: 'Org Admin', value: 1, description: 'Short description of role capabilities', labelDescription: '(Full access)',
+},
+    {
+ label: 'Administrator', value: 2, description: 'Short description of role capabilities', labelDescription: '(Full access)',
+},
+    {
+ label: 'Researcher', value: 3, description: 'Short description of role capabilities', labelDescription: '(Standard access)',
+},
+    {
+ label: 'Teammate', value: 4, description: 'Short description of role capabilities', labelDescription: '(Limited access)',
+},
   ];
 
   return (


### PR DESCRIPTION
closes #784 

Chromatic: https://62d040e741710e4f085e0647-yopxegfste.chromatic.com/?path=/story/components-selects-single--custom-option-with-description

- adds `labelDescription` in cases where the `label` needs additional context
- uses `hideDescription` in cases where you need to hide the description when viewing on mobile

![Screen Shot 2022-11-22 at 12 52 06 PM](https://user-images.githubusercontent.com/37383785/203418932-4faaaabc-cda2-4c08-af48-ea690fb43416.png)
