### PR TITLE
add red Pill color

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -8204,6 +8204,11 @@ exports[`Storyshots Components/Pill Default 1`] = `
       yellow
     </span>
     <span
+      className="Pill Pill--red"
+    >
+      red
+    </span>
+    <span
       className="Pill Pill--green"
     >
       green

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -8227,6 +8227,56 @@ exports[`Storyshots Components/Pill Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Pill Statuses 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="Pills"
+  >
+    <span
+      className="Pill Pill--blue"
+    >
+      Informational
+    </span>
+    <span
+      className="Pill Pill--silver"
+    >
+      Informational
+    </span>
+    <span
+      className="Pill Pill--orange"
+    >
+      Partially complete
+    </span>
+    <span
+      className="Pill Pill--yellow"
+    >
+      Incomplete
+    </span>
+    <span
+      className="Pill Pill--red"
+    >
+      Attention
+    </span>
+    <span
+      className="Pill Pill--green"
+    >
+      Active
+    </span>
+    <span
+      className="Pill Pill--gray"
+    >
+      Inactive
+    </span>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Components/Pill With Close 1`] = `
 <div
   style={
@@ -8279,7 +8329,7 @@ exports[`Storyshots Components/Pill With Container 1`] = `
     className="Pills"
   >
     <span
-      className="Pill Pill--gray"
+      className="Pill Pill--silver"
     >
       <svg
         aria-hidden="true"
@@ -8301,7 +8351,7 @@ exports[`Storyshots Components/Pill With Container 1`] = `
       1-on-1 Interview
     </span>
     <span
-      className="Pill Pill--gray"
+      className="Pill Pill--silver"
     >
       <svg
         aria-hidden="true"
@@ -8323,7 +8373,7 @@ exports[`Storyshots Components/Pill With Container 1`] = `
       Online
     </span>
     <span
-      className="Pill Pill--gray"
+      className="Pill Pill--silver"
     >
       <svg
         aria-hidden="true"
@@ -8345,7 +8395,7 @@ exports[`Storyshots Components/Pill With Container 1`] = `
       $120 choice of dozens of digital gift cards
     </span>
     <span
-      className="Pill Pill--gray"
+      className="Pill Pill--silver"
     >
       <svg
         aria-hidden="true"

--- a/src/Pill/Pill.jsx
+++ b/src/Pill/Pill.jsx
@@ -7,7 +7,7 @@ import { faTimes } from '@fortawesome/pro-solid-svg-icons';
 import './Pill.scss';
 
 export const PILL_COLORS = {
- BLUE: 'blue', ORANGE: 'orange', YELLOW: 'yellow', GREEN: 'green', GRAY: 'gray', SILVER: 'silver',
+ BLUE: 'blue', ORANGE: 'orange', YELLOW: 'yellow', RED: 'red', GREEN: 'green', GRAY: 'gray', SILVER: 'silver',
 };
 
 const Pill = ({

--- a/src/Pill/Pill.mdx
+++ b/src/Pill/Pill.mdx
@@ -6,7 +6,7 @@ import Pill from './Pill';
 ##
 
 <h4>
-  Represents an object that can be viewed with or without an icon. Useful when describing or categorizing a property.
+  Pills are used to inform users of the status of an object or of an action that’s been taken.
 </h4>
 
 <Canvas>
@@ -18,10 +18,6 @@ import Pill from './Pill';
 - Use to highlight an item's status for quick recognition
 - Help users search for and find related content quickly and easily
 - Ideal to indicate meanings that users can learn and recognize across the app
-
-### When to not use
-- Reason 1
-- Reason 2
 
 ## Props
 
@@ -35,6 +31,33 @@ import Pill from './Pill';
 
 <Canvas>
   <Story id="components-pill--default" />
+</Canvas>
+
+### Statuses
+
+Use the appropriate color to indicate the status of an object 
+
+**Informational**
+- blue: neutral information ("Verified")
+- silver: typically represents project type info ("1-on-1 Interview", "Online")
+
+**Partially complete**
+- orange: ("Pending review", "Under investigation")
+
+**Incomplete**
+- yellow: ("Draft")
+
+**Attention**
+- red: ("Action required", "Missing field")
+
+**Active**
+- green: ("Active", "Confirmed")
+
+**Inactive**
+- gray: ("Completed", "Expired")
+
+<Canvas>
+  <Story id="components-pill--statuses" />
 </Canvas>
 
 ### With Container
@@ -69,27 +92,14 @@ import Pill from './Pill';
 
 ## Formatting
 
-### States
-
 ### Anatomy
 - **Content: ** main content area of the Pill. Can be provided plain text or a link (`<a>`) as `children`
 - **Icon: ** relevant icon that makes it easier for users to identify (always placed left of the Content)
 - **Close: ** users have the option to clear the pill (provided by default with the presence of the `onClose` function)
 
-### Sizing
-
-### Alignment
-
-
 ## Best practices
-
-### General
-
-### Behavior
 
 ### Implementation
 - Use the `PILL_COLORS` constant when setting the `color` prop
 - Can use either the `text` prop or provide an element via `children` for content. (Note: the `text` prop is planned to be retired in favor of `children` in a future release)
 - If using plain text or an element as the content via `children`, do not wrap in block-level elements (e.g. `<p>` or `div`)
-
-### UX Copy

--- a/src/Pill/Pill.scss
+++ b/src/Pill/Pill.scss
@@ -110,6 +110,31 @@
     }
   }
 
+  &--red {
+    background-color: $ux-red-100;
+    color: $ux-red-900;
+
+    .Pill__icon--lead {
+      color: $ux-red-900;
+      margin-right: $ux-spacing-10;
+    }
+
+    .Pill__button--close {
+      background-color: unset; 
+      border: none;
+      color: $ux-red-900;
+      margin-left: $ux-spacing-20;
+      margin-right: 0;
+      padding: 0;
+    }
+
+    &.Pill--closeable {
+      &:hover {
+        background-color: $ux-red-200;
+      }
+    }
+  }
+
   &--gray {
     background-color: $ux-gray-300;
     color: $ux-gray-800;

--- a/src/Pill/Pill.stories.jsx
+++ b/src/Pill/Pill.stories.jsx
@@ -75,28 +75,68 @@ export const Default = () => (
   </div>
 );
 
+export const Statuses = () => (
+  <Pills>
+    <Pill
+      color={PILL_COLORS.BLUE}
+    >
+      Informational
+    </Pill>
+    <Pill
+      color={PILL_COLORS.SILVER}
+    >
+      Informational
+    </Pill>
+    <Pill
+      color={PILL_COLORS.ORANGE}
+    >
+      Partially complete
+    </Pill>
+    <Pill
+      color={PILL_COLORS.YELLOW}
+    >
+      Incomplete
+    </Pill>
+    <Pill
+      color={PILL_COLORS.RED}
+    >
+      Attention
+    </Pill>
+    <Pill
+      color={PILL_COLORS.GREEN}
+    >
+      Active
+    </Pill>
+    <Pill
+      color={PILL_COLORS.GRAY}
+    >
+      Inactive
+    </Pill>
+  </Pills>
+);
+
 export const WithContainer = () => (
   <Pills>
     <Pill
-      color={PILL_COLORS.GRAY}
+      color={PILL_COLORS.SILVER}
       icon={faMicrophone}
     >
       1-on-1 Interview
     </Pill>
     <Pill
-      color={PILL_COLORS.GRAY}
+      color={PILL_COLORS.SILVER}
       icon={faGlobe}
     >
       Online
     </Pill>
     <Pill
-      color={PILL_COLORS.GRAY}
+      color={PILL_COLORS.SILVER}
       icon={faGiftCard}
     >
       $120 choice of dozens of digital gift cards
     </Pill>
     <Pill
-      color={PILL_COLORS.GRAY}
+      color={PILL_COLORS.SILVER}
       icon={faClock}
     >
       1 hour

--- a/src/Pill/Pill.stories.jsx
+++ b/src/Pill/Pill.stories.jsx
@@ -53,6 +53,11 @@ export const Default = () => (
       yellow
     </Pill>
     <Pill
+      color={PILL_COLORS.RED}
+    >
+      red
+    </Pill>
+    <Pill
       color={PILL_COLORS.GREEN}
     >
       green


### PR DESCRIPTION
closes #789 

![Screen Shot 2022-12-06 at 12 38 06 PM](https://user-images.githubusercontent.com/37383785/206017884-7be2b1b0-6951-4b00-99c6-dc9c2cef7520.png)

[Chromatic link](https://www.chromatic.com/build?appId=62d040e741710e4f085e0647&number=106)

- Adding a red Pill color

- Add Statuses story to give more meaning to the colors

*Future work: PD's are chatting about separating out `Pill` to handle statuses and create a generic `Label` or `Tag` to handle categorization. More to come on this!
