### PR TITLE
update TableCell compact variant to 0.75rem top padding

### DIFF
--- a/src/Table/TableCell.scss
+++ b/src/Table/TableCell.scss
@@ -20,7 +20,7 @@
   }
 
   &--compact {
-    padding: $ux-spacing-40 $ux-spacing-50;
+    padding: $ux-spacing-30 $ux-spacing-50;
     max-height: 3.25rem;
   }
 


### PR DESCRIPTION
closes #792 

Decrease <TableCell compact /> padding from 1rem to 0.75rem which we only use on `app/javascript/researcher/participant_search/filtered_view/private_participant_table.jsx` and `app/javascript/researcher/account_project_dashboard/admin_controls.jsx`. We believed that it would be better for displaying more data rows. (Will follow up with making the "View" button on Hub table the small variant as well).

[Chromatic link to see the diff](https://www.chromatic.com/test?appId=62d040e741710e4f085e0647&id=638fc3b0a91e893b12eade54)