### PR TITLE
add LoadingSkeleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.38.0",
   "dependencies": {
     "react-bootstrap": "^2.5.0",
+    "react-loading-skeleton": "^3.1.0",
     "react-router-dom": "^5.2.0",
     "react-select": "^5.0.0",
     "react-toggle": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.38.0",
   "dependencies": {
     "react-bootstrap": "^2.5.0",
+    "react-loading-skeleton": "^3.1.0",
     "react-router-dom": "^5.2.0",
     "react-select": "^5.0.0",
     "react-toggle": "4.1.1",
@@ -112,7 +113,6 @@
     "react": "16.14.0",
     "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "^16.12.0",
-    "react-loading-skeleton": "^3.1.0",
     "react-modal": "^3.12.1",
     "react-popper": "^2.2.3",
     "react-test-renderer": "^16.12.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.38.0",
   "dependencies": {
     "react-bootstrap": "^2.5.0",
-    "react-loading-skeleton": "^3.1.0",
     "react-router-dom": "^5.2.0",
     "react-select": "^5.0.0",
     "react-toggle": "4.1.1",
@@ -113,6 +112,7 @@
     "react": "16.14.0",
     "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "^16.12.0",
+    "react-loading-skeleton": "^3.1.0",
     "react-modal": "^3.12.1",
     "react-popper": "^2.2.3",
     "react-test-renderer": "^16.12.0",

--- a/src/LoadingSkeleton/LoadingSkeleton.jsx
+++ b/src/LoadingSkeleton/LoadingSkeleton.jsx
@@ -7,29 +7,10 @@ import 'react-loading-skeleton/dist/skeleton.css';
 
 import colors from '../Styles/colors/palette';
 
-const LoadingSkeleton = ({
- borderRadius,
- circle,
- className,
- containerClassName,
- containerTestId,
- count,
- height,
- inline,
- width,
- ...props
-}) => (
+const LoadingSkeleton = ({ className, ...props }) => (
   <SkeletonTheme baseColor={colors.UX_GRAY_300}>
     <Skeleton
-      borderRadius={borderRadius}
-      circle={circle}
       className={classNames('LoadingSkeleton', className)}
-      containerClassName={containerClassName}
-      containerTestId={containerTestId}
-      count={count}
-      height={height}
-      inline={inline}
-      width={width}
       {...props}
     />
   </SkeletonTheme>
@@ -46,7 +27,7 @@ LoadingSkeleton.propTypes = {
   circle: PropTypes.bool,
   className: PropTypes.string,
   /**
-  A custom class name for the <span> that wraps the individual skeleton elements.
+  A custom class name for the `<span>` that wraps the individual skeleton elements.
   */
   containerClassName: PropTypes.string,
   /**
@@ -64,7 +45,7 @@ LoadingSkeleton.propTypes = {
   */
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
-  By default, a <br /> is inserted after each skeleton so that each skeleton gets its own line.
+  By default, a `<br />` is inserted after each skeleton so that each skeleton gets its own line.
   When inline is true, no line breaks are inserted.
   */
   inline: PropTypes.bool,
@@ -75,15 +56,15 @@ LoadingSkeleton.propTypes = {
 };
 
 LoadingSkeleton.defaultProps = {
-  borderRadius: undefined,
+  borderRadius: '0.25rem',
   className: undefined,
-  circle: undefined,
+  circle: false,
   containerClassName: undefined,
   containerTestId: undefined,
-  count: undefined,
-  height: 20,
-  inline: undefined,
-  width: undefined,
+  count: 1,
+  height: undefined,
+  inline: false,
+  width: '100%',
 };
 
 export default LoadingSkeleton;

--- a/src/LoadingSkeleton/LoadingSkeleton.jsx
+++ b/src/LoadingSkeleton/LoadingSkeleton.jsx
@@ -8,27 +8,82 @@ import 'react-loading-skeleton/dist/skeleton.css';
 import colors from '../Styles/colors/palette';
 
 const LoadingSkeleton = ({
- className, count, height, ...props
+ borderRadius,
+ circle,
+ className,
+ containerClassName,
+ containerTestId,
+ count,
+ height,
+ inline,
+ width,
+ ...props
 }) => (
   <SkeletonTheme baseColor={colors.UX_GRAY_300}>
     <Skeleton
+      borderRadius={borderRadius}
+      circle={circle}
       className={classNames('LoadingSkeleton', className)}
+      containerClassName={containerClassName}
+      containerTestId={containerTestId}
       count={count}
       height={height}
+      inline={inline}
+      width={width}
       {...props}
     />
   </SkeletonTheme>
 );
 
 LoadingSkeleton.propTypes = {
+  /**
+  The border radius of the skeleton.
+  */
+  borderRadius: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+  Makes the skeleton circular by setting border-radius to 50%.
+  */
+  circle: PropTypes.bool,
   className: PropTypes.string,
+  /**
+  A custom class name for the <span> that wraps the individual skeleton elements.
+  */
+  containerClassName: PropTypes.string,
+  /**
+  A string that is added to the container element as a data-testid attribute.
+  Use it with screen.getByTestId('...') from React Testing Library.
+  */
+  containerTestId: PropTypes.string,
+  /**
+  The number of lines of skeletons to render. If count is a decimal number like 3.5,
+  three full skeletons and one half-width skeleton will be rendered.
+  */
   count: PropTypes.number,
-  height: PropTypes.number,
+  /**
+  The height of the skeleton.
+  */
+  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+  By default, a <br /> is inserted after each skeleton so that each skeleton gets its own line.
+  When inline is true, no line breaks are inserted.
+  */
+  inline: PropTypes.bool,
+  /**
+  The width of the skeleton.
+  */
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
 
 LoadingSkeleton.defaultProps = {
+  borderRadius: undefined,
   className: undefined,
-  count: 1,
+  circle: undefined,
+  containerClassName: undefined,
+  containerTestId: undefined,
+  count: undefined,
   height: 20,
+  inline: undefined,
+  width: undefined,
 };
+
 export default LoadingSkeleton;

--- a/src/LoadingSkeleton/LoadingSkeleton.jsx
+++ b/src/LoadingSkeleton/LoadingSkeleton.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import Skeleton, { SkeletonTheme } from 'react-loading-skeleton';
+import 'react-loading-skeleton/dist/skeleton.css';
+
+import colors from '../Styles/colors/palette';
+
+const LoadingSkeleton = ({
+ className, count, height, ...props
+}) => (
+  <SkeletonTheme baseColor={colors.UX_GRAY_300}>
+    <Skeleton
+      className={classNames('LoadingSkeleton', className)}
+      count={count}
+      height={height}
+      {...props}
+    />
+  </SkeletonTheme>
+);
+
+LoadingSkeleton.propTypes = {
+  className: PropTypes.string,
+  count: PropTypes.number,
+  height: PropTypes.number,
+};
+
+LoadingSkeleton.defaultProps = {
+  className: undefined,
+  count: 1,
+  height: 20,
+};
+export default LoadingSkeleton;

--- a/src/LoadingSkeleton/LoadingSkeleton.mdx
+++ b/src/LoadingSkeleton/LoadingSkeleton.mdx
@@ -1,0 +1,53 @@
+import { ArgsTable, Story, Canvas } from '@storybook/addon-docs/blocks';
+import LoadingSkeleton from './LoadingSkeleton';
+
+# LoadingSkeleton
+
+##
+
+<h4>
+  A LoadingSkeleton is used to provide a low fidelity representation of content before it 
+  renders on the page. It improves load time perception for users.
+</h4>
+
+<Canvas>
+  <Story id="components-loadingskeleton--default" />
+</Canvas>
+
+
+## Props
+
+<ArgsTable of={LoadingSkeleton} />
+
+
+## Stories 
+
+### Default
+
+<Canvas>
+  <Story id="components-loadingskeleton--default" />
+</Canvas>
+
+### Multi-line
+
+<Canvas>
+  <Story id="components-loadingskeleton--multi-line" />
+</Canvas>
+
+### Height and Width
+
+<Canvas>
+  <Story id="components-loadingskeleton--height-and-width" />
+</Canvas>
+
+### Circle
+
+<Canvas>
+  <Story id="components-loadingskeleton--circle" />
+</Canvas>
+
+### Card Content
+
+<Canvas>
+  <Story id="components-loadingskeleton--card-content" />
+</Canvas>

--- a/src/LoadingSkeleton/LoadingSkeleton.mdx
+++ b/src/LoadingSkeleton/LoadingSkeleton.mdx
@@ -3,7 +3,7 @@ import LoadingSkeleton from './LoadingSkeleton';
 
 # LoadingSkeleton
 
-##
+## 
 
 <h4>
   A LoadingSkeleton is used to provide a low fidelity representation of content before it 
@@ -14,6 +14,30 @@ import LoadingSkeleton from './LoadingSkeleton';
   <Story id="components-loadingskeleton--default" />
 </Canvas>
 
+### When to use 
+- For representing all content on initial page load 
+- For representing large or multiple content elements on a page (avoiding multiple LoadingOverlays at one time)
+- For components that are data-intesive and may take a few seconds to fully load 
+- Offering a simplified preview of loading content
+
+### When not to use
+- Do not use a LoadingSkeleton and LoadingOverlay together. Use the one that best fits the context.
+
+### LoadingSkeleton vs. LoadingOverlay?
+
+| Scenario                                                               | LoadingSkeleton                                   | LoadingOverlay                                                        |
+|------------------------------------------------------------------------|---------------------------------------------------|-----------------------------------------------------------------------|
+| Initial page load                                                      | ✅ Yes                                            | No                                                                    |
+| Dynamic data that requires loading                                     | ✅ Yes                                            | No                                                                    |
+| Static data that never changes (e.g. body text, copy, titles)          | ✅ Yes (helpful with large amount of content)     | No                                                                    |
+| User caused action (e.g. button press that causes UI change on screen) | No                                                | ✅ Yes (this indicates application processing)                        |
+| Form elements                                                          | ✅ Yes (to represent different form elements)     | No                                                                    |
+| Form submission                                                        | No                                                | ✅ Yes (typically full-screen, possibly with page refresh)            |
+| Page saving                                                            | No                                                | ✅ Yes (typically full-screen)                                        |
+| Card                                                                   | ✅ Yes (for Card content, not the container itself| No (unless there is a user action that changes that data in the card) |
+| Table                                                                  | ✅ Yes (for initial page load)                    | No                                                                    |
+| Avatar or ProfileCell                                                  | ✅ Yes                                            | No                                                                    |
+| Alert or Toast                                                         | No                                                | No
 
 ## Props
 

--- a/src/LoadingSkeleton/LoadingSkeleton.stories.jsx
+++ b/src/LoadingSkeleton/LoadingSkeleton.stories.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import {
+  withKnobs, boolean, number,
+} from '@storybook/addon-knobs';
+
+import Card from 'src/Card';
+
+import LoadingSkeleton from './LoadingSkeleton';
+import mdx from './LoadingSkeleton.mdx';
+
+export default {
+  title: 'Components/LoadingSkeleton',
+  component: LoadingSkeleton,
+  decorators: [withKnobs],
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+};
+
+export const Default = () => (
+  <LoadingSkeleton />
+);
+
+export const MultiLine = () => (
+  <LoadingSkeleton count={number('count', 3)} />
+);
+
+export const HeightAndWidth = () => (
+  <LoadingSkeleton height={number('height', 44)} width={number('width', 200)} />
+);
+
+export const Circle = () => (
+  <LoadingSkeleton circle={boolean('circle', true)} height={44} width={44} />
+);
+
+export const CardContent = () => (
+  <Card size="md" subTitle={`Research is better together 🕵️🕵. Invite as many team members as you'd like so they can view and copy any project.`} title="Invite Team members">
+    <LoadingSkeleton count={3} />
+    <br />
+    <LoadingSkeleton count={2.5} />
+  </Card>
+);

--- a/src/LoadingSkeleton/LoadingSkeleton.stories.jsx
+++ b/src/LoadingSkeleton/LoadingSkeleton.stories.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {
-  withKnobs, boolean, number,
+  withKnobs, boolean, number, text,
 } from '@storybook/addon-knobs';
 
 import Card from 'src/Card';
@@ -29,7 +29,7 @@ export const MultiLine = () => (
 );
 
 export const HeightAndWidth = () => (
-  <LoadingSkeleton height={number('height', 44)} width={number('width', 200)} />
+  <LoadingSkeleton height={text('height', '44px')} width={text('width', '200px')} />
 );
 
 export const Circle = () => (

--- a/src/LoadingSkeleton/index.js
+++ b/src/LoadingSkeleton/index.js
@@ -1,0 +1,5 @@
+import LoadingSkeleton from './LoadingSkeleton';
+
+export {
+  LoadingSkeleton,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ import IconCell from 'src/IconCell';
 import Input from 'src/Input';
 import InputLabel from 'src/InputLabel';
 import InputLegend from 'src/InputLegend';
+import { LoadingSkeleton } from 'src/LoadingSkeleton';
 import LoadingOverlay from 'src/LoadingOverlay';
 import {
   Modal,
@@ -121,6 +122,7 @@ export {
   InputLabel,
   InputLegend,
   LoadingOverlay,
+  LoadingSkeleton,
   MessageTypes,
   Modal,
   MODAL_SIZES,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11186,6 +11186,11 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-loading-skeleton@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-loading-skeleton/-/react-loading-skeleton-3.1.0.tgz#ce22942f1af77bfd60854417075792367f54f41e"
+  integrity sha512-j1U1CWWs68nBPOg7tkQqnlFcAMFF6oEK6MgqAo15f8A5p7mjH6xyKn2gHbkcimpwfO0VQXqxAswnSYVr8lWzjw==
+
 react-modal@^3.12.1:
   version "3.12.1"
   resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.12.1.tgz#38c33f70d81c33d02ff1ed115530443a3dc2afd3"


### PR DESCRIPTION
closes #798 

[Chromatic link](https://62d040e741710e4f085e0647-aautmrrylg.chromatic.com/?path=/docs/components-loadingskeleton--default#props)

- Add `react-loading-skeleton`
- Create guidelines on when to use `LoadingSkeleton` vs. `LoadingOverlay`

Future: possibly build `LoadingSkeleton` into existing components (e.g ProfileCell, Button, Table) to make it easier to automatically handle skeleton states during loading. Mostly wanting to make it as easy as possible to use LoadingSkeleton without having to [create many dedicated loading skeleton screens.](https://www.npmjs.com/package/react-loading-skeleton#:~:text=Don%27t%20make%20dedicated%20skeleton%20screens)

What it could look like: 

https://user-images.githubusercontent.com/37383785/208517987-2bbd7955-f6bf-420d-b546-0cc2831d1242.mov

Currently:

https://user-images.githubusercontent.com/37383785/208518000-291be00a-1f03-4e84-9385-e5f7506cdca8.mov

