### PR TITLE
import skeleton.css directly

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -7679,6 +7679,268 @@ exports[`Storyshots Components/LoadingOverlay Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/LoadingSkeleton Card Content 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <section
+    className="Card Card--md"
+  >
+    <div
+      className="Card__header"
+    >
+      <h2
+        className="Card__title"
+      >
+        Invite Team members
+      </h2>
+    </div>
+    <h3
+      className="Card__subtitle"
+    >
+      Research is better together 🕵️🕵. Invite as many team members as you'd like so they can view and copy any project.
+    </h3>
+    <span
+      aria-busy={true}
+      aria-live="polite"
+    >
+      <span
+        className="react-loading-skeleton LoadingSkeleton"
+        style={
+          Object {
+            "--base-color": "#E1E1E1",
+            "borderRadius": "0.25rem",
+            "width": "100%",
+          }
+        }
+      >
+        ‌
+      </span>
+      <br />
+      <span
+        className="react-loading-skeleton LoadingSkeleton"
+        style={
+          Object {
+            "--base-color": "#E1E1E1",
+            "borderRadius": "0.25rem",
+            "width": "100%",
+          }
+        }
+      >
+        ‌
+      </span>
+      <br />
+      <span
+        className="react-loading-skeleton LoadingSkeleton"
+        style={
+          Object {
+            "--base-color": "#E1E1E1",
+            "borderRadius": "0.25rem",
+            "width": "100%",
+          }
+        }
+      >
+        ‌
+      </span>
+      <br />
+    </span>
+    <br />
+    <span
+      aria-busy={true}
+      aria-live="polite"
+    >
+      <span
+        className="react-loading-skeleton LoadingSkeleton"
+        style={
+          Object {
+            "--base-color": "#E1E1E1",
+            "borderRadius": "0.25rem",
+            "width": "100%",
+          }
+        }
+      >
+        ‌
+      </span>
+      <br />
+      <span
+        className="react-loading-skeleton LoadingSkeleton"
+        style={
+          Object {
+            "--base-color": "#E1E1E1",
+            "borderRadius": "0.25rem",
+            "width": "100%",
+          }
+        }
+      >
+        ‌
+      </span>
+      <br />
+      <span
+        className="react-loading-skeleton LoadingSkeleton"
+        style={
+          Object {
+            "--base-color": "#E1E1E1",
+            "borderRadius": "0.25rem",
+            "width": "calc(100% * 0.5)",
+          }
+        }
+      >
+        ‌
+      </span>
+      <br />
+    </span>
+  </section>
+</div>
+`;
+
+exports[`Storyshots Components/LoadingSkeleton Circle 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <span
+    aria-busy={true}
+    aria-live="polite"
+  >
+    <span
+      className="react-loading-skeleton LoadingSkeleton"
+      style={
+        Object {
+          "--base-color": "#E1E1E1",
+          "borderRadius": "50%",
+          "height": 44,
+          "width": 44,
+        }
+      }
+    >
+      ‌
+    </span>
+    <br />
+  </span>
+</div>
+`;
+
+exports[`Storyshots Components/LoadingSkeleton Default 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <span
+    aria-busy={true}
+    aria-live="polite"
+  >
+    <span
+      className="react-loading-skeleton LoadingSkeleton"
+      style={
+        Object {
+          "--base-color": "#E1E1E1",
+          "borderRadius": "0.25rem",
+          "width": "100%",
+        }
+      }
+    >
+      ‌
+    </span>
+    <br />
+  </span>
+</div>
+`;
+
+exports[`Storyshots Components/LoadingSkeleton Height And Width 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <span
+    aria-busy={true}
+    aria-live="polite"
+  >
+    <span
+      className="react-loading-skeleton LoadingSkeleton"
+      style={
+        Object {
+          "--base-color": "#E1E1E1",
+          "borderRadius": "0.25rem",
+          "height": "44px",
+          "width": "200px",
+        }
+      }
+    >
+      ‌
+    </span>
+    <br />
+  </span>
+</div>
+`;
+
+exports[`Storyshots Components/LoadingSkeleton Multi Line 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <span
+    aria-busy={true}
+    aria-live="polite"
+  >
+    <span
+      className="react-loading-skeleton LoadingSkeleton"
+      style={
+        Object {
+          "--base-color": "#E1E1E1",
+          "borderRadius": "0.25rem",
+          "width": "100%",
+        }
+      }
+    >
+      ‌
+    </span>
+    <br />
+    <span
+      className="react-loading-skeleton LoadingSkeleton"
+      style={
+        Object {
+          "--base-color": "#E1E1E1",
+          "borderRadius": "0.25rem",
+          "width": "100%",
+        }
+      }
+    >
+      ‌
+    </span>
+    <br />
+    <span
+      className="react-loading-skeleton LoadingSkeleton"
+      style={
+        Object {
+          "--base-color": "#E1E1E1",
+          "borderRadius": "0.25rem",
+          "width": "100%",
+        }
+      }
+    >
+      ‌
+    </span>
+    <br />
+  </span>
+</div>
+`;
+
 exports[`Storyshots Components/Modal Danger Modal 1`] = `
 <div
   style={

--- a/src/LoadingSkeleton/LoadingSkeleton.jsx
+++ b/src/LoadingSkeleton/LoadingSkeleton.jsx
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import Skeleton, { SkeletonTheme } from 'react-loading-skeleton';
-import 'react-loading-skeleton/dist/skeleton.css';
 
 import colors from '../Styles/colors/palette';
+
+import './LoadingSkeleton.scss';
 
 const LoadingSkeleton = ({ className, ...props }) => (
   <SkeletonTheme baseColor={colors.UX_GRAY_300}>

--- a/src/LoadingSkeleton/LoadingSkeleton.scss
+++ b/src/LoadingSkeleton/LoadingSkeleton.scss
@@ -1,0 +1,52 @@
+// Keep these default styles below.
+// This is copied from https://github.com/dvtng/react-loading-skeleton/blob/master/src/skeleton.css
+// We have some conflicting order webpack issues when used on 'rails-server'
+
+@keyframes react-loading-skeleton {
+  100% {
+      transform: translateX(100%);
+  }
+}
+
+.react-loading-skeleton {
+  --base-color: #ebebeb;
+  --highlight-color: #f5f5f5;
+  --animation-duration: 1.5s;
+  --animation-direction: normal;
+  --pseudo-element-display: block; /* Enable animation */
+
+  background-color: var(--base-color);
+
+  width: 100%;
+  border-radius: 0.25rem;
+  display: inline-flex;
+  line-height: 1;
+
+  position: relative;
+  overflow: hidden;
+  z-index: 1; /* Necessary for overflow: hidden to work correctly in Safari */
+}
+
+.react-loading-skeleton::after {
+  content: ' ';
+  display: var(--pseudo-element-display);
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 100%;
+  background-repeat: no-repeat;
+  background-image: linear-gradient(
+      90deg,
+      var(--base-color),
+      var(--highlight-color),
+      var(--base-color)
+  );
+  transform: translateX(-100%);
+
+  animation-name: react-loading-skeleton;
+  animation-direction: var(--animation-direction);
+  animation-duration: var(--animation-duration);
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+}


### PR DESCRIPTION
closes #805 

There's a conflicting order webpack issue when used on RS that I'm thinking is due to `import 'react-loading-skeleton/dist/skeleton.css';`. I just copied that code and made a separate `LoadingSkeleton.scss` 

![Screen Shot 2023-01-09 at 11 49 25 AM](https://user-images.githubusercontent.com/37383785/211396847-a237d83d-a15d-48d9-b4d9-7ddc845c8621.png)

I ran into a similar issue with [ToggleInput](https://github.com/user-interviews/ui-design-system/blob/develop/src/ToggleInput/ToggleInput.scss#L81) a while back where I did the same thing to resolve the issue. I'm hoping this will be the same fix 🤞 