### PR TITLE
Adding optional props to Tabs component

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -20626,7 +20626,7 @@ exports[`Storyshots Components/Tabs Controlled 1`] = `
 >
   <div>
     <span
-      className="sc-dkPtRN klomrB"
+      className="sc-dkPtRN gfzzIq"
     >
       <ul
         className="nav nav-tabs"
@@ -20793,7 +20793,7 @@ exports[`Storyshots Components/Tabs Uncontrolled 1`] = `
 >
   <div>
     <span
-      className="sc-dkPtRN klomrB"
+      className="sc-dkPtRN gfzzIq"
     >
       <ul
         className="nav nav-tabs"

--- a/src/Tabs/Tabs.jsx
+++ b/src/Tabs/Tabs.jsx
@@ -7,9 +7,14 @@ import { StyledTabsWrapper } from './Tabs.styles';
 
 const Tabs = ({
   children,
+  flexWrapUnset,
+  navItemButtonFullHeight,
   ...props
 }) => (
-  <StyledTabsWrapper>
+  <StyledTabsWrapper
+    flexWrapUnset={flexWrapUnset}
+    navItemButtonFullHeight={navItemButtonFullHeight}
+  >
     <ReactBootstrapTabs variant="tabs" {...props}>
       {children}
     </ReactBootstrapTabs>
@@ -21,8 +26,10 @@ export default Tabs;
 Tabs.propTypes = {
   activeKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   defaultActiveKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  flexWrapUnset: PropTypes.bool,
   id: PropTypes.string.isRequired,
   mountOnEnter: PropTypes.bool,
+  navItemButtonFullHeight: PropTypes.bool,
   transition: PropTypes.oneOfType([
       PropTypes.oneOf([false]),
       PropTypes.elementType,
@@ -34,7 +41,9 @@ Tabs.propTypes = {
 Tabs.defaultProps = {
   activeKey: undefined,
   defaultActiveKey: 1,
+  flexWrapUnset: false,
   mountOnEnter: undefined,
+  navItemButtonFullHeight: false,
   transition: undefined,
   unmountOnExit: undefined,
   onSelect: undefined,

--- a/src/Tabs/Tabs.styles.js
+++ b/src/Tabs/Tabs.styles.js
@@ -6,6 +6,20 @@ const borderWidth = '0.125rem';
 const fontType30 = '400 0.875rem/1.25rem DM Sans, sans-serif';
 
 export const StyledTabsWrapper = styled.span`
+  ${({ flexWrapUnset }) => flexWrapUnset && `
+    .nav {
+      flex-wrap: nowrap;
+    }
+  `}
+
+  ${({ navItemButtonFullHeight }) => navItemButtonFullHeight && `
+    .nav-item {
+      button {
+        height: calc(100% + ${borderWidth});
+      }
+    }
+  `}
+
   .nav-tabs {
     border-bottom: ${borderWidth} solid ${colors.UX_GRAY_400};
   }

--- a/src/Tabs/__snapshots__/Tabs.test.jsx.snap
+++ b/src/Tabs/__snapshots__/Tabs.test.jsx.snap
@@ -6,7 +6,7 @@ Object {
   "baseElement": <body>
     <div>
       <span
-        class="sc-bdvvtL eGviLc"
+        class="sc-bdvvtL leMoEj"
       >
         <ul
           class="nav nav-tabs"
@@ -98,7 +98,7 @@ Object {
   </body>,
   "container": <div>
     <span
-      class="sc-bdvvtL eGviLc"
+      class="sc-bdvvtL leMoEj"
     >
       <ul
         class="nav nav-tabs"
@@ -247,7 +247,7 @@ Object {
   "baseElement": <body>
     <div>
       <span
-        class="sc-bdvvtL eGviLc"
+        class="sc-bdvvtL leMoEj"
       >
         <ul
           class="nav nav-tabs"
@@ -339,7 +339,7 @@ Object {
   </body>,
   "container": <div>
     <span
-      class="sc-bdvvtL eGviLc"
+      class="sc-bdvvtL leMoEj"
     >
       <ul
         class="nav nav-tabs"


### PR DESCRIPTION
Fix #809

Current state and without `flexWrapUnset` nor `navItemButtonFullHeight`

https://user-images.githubusercontent.com/54962889/212375185-2120164d-b375-4c07-8ffb-bc8fc8c96fbc.mov

With `flexWrapUnset` but without `navItemButtonFullHeight`

https://user-images.githubusercontent.com/54962889/212375298-69fc33ab-e0f7-4b4e-822e-57568e303494.mov

With `flexWrapUnset` and `navItemButtonFullHeight`

https://user-images.githubusercontent.com/54962889/212375375-16d6fa38-6dd0-475d-85ff-c463e6184752.mov




I think there's a case to be made that both of these css changes should be by default added to this component without those props, but it's up to @jasonbasuil to decide