### PR TITLE
add ProfileCellSkeleton

### DIFF
--- a/scss/avatars.scss
+++ b/scss/avatars.scss
@@ -1,0 +1,5 @@
+$avatar-small-height: 2.75rem;
+$avatar-small-width: 2.75rem;
+
+$avatar-large-height: 5rem;
+$avatar-large-width: 5rem;

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -1,4 +1,5 @@
 @import './anchors';
+@import './avatars';
 @import './bootstrap';
 @import './borders';
 @import './box_shadow';

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -9386,6 +9386,69 @@ exports[`Storyshots Components/Profile Cell Loading 1`] = `
       </span>
     </div>
   </div>
+  <br />
+  <div
+    className="ProfileCellSkeleton"
+  >
+    <div
+      className="ProfileCellSkeleton__avatar"
+    >
+      <span
+        aria-busy={true}
+        aria-live="polite"
+      >
+        <span
+          className="react-loading-skeleton LoadingSkeleton"
+          style={
+            Object {
+              "--base-color": "#E1E1E1",
+              "borderRadius": "50%",
+              "height": 44,
+              "width": 44,
+            }
+          }
+        >
+          ‌
+        </span>
+        <br />
+      </span>
+    </div>
+    <div
+      className="ProfileCellSkeleton__info"
+    >
+      <span
+        aria-busy={true}
+        aria-live="polite"
+      >
+        <span
+          className="react-loading-skeleton LoadingSkeleton"
+          style={
+            Object {
+              "--base-color": "#E1E1E1",
+              "borderRadius": "0.25rem",
+              "width": "",
+            }
+          }
+        >
+          ‌
+        </span>
+        <br />
+        <span
+          className="react-loading-skeleton LoadingSkeleton"
+          style={
+            Object {
+              "--base-color": "#E1E1E1",
+              "borderRadius": "0.25rem",
+              "width": "",
+            }
+          }
+        >
+          ‌
+        </span>
+        <br />
+      </span>
+    </div>
+  </div>
 </div>
 `;
 

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -9316,6 +9316,79 @@ exports[`Storyshots Components/Profile Cell Large 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Profile Cell Loading 1`] = `
+<div
+  style={
+    Object {
+      "padding": "1rem",
+    }
+  }
+>
+  <div
+    className="ProfileCellSkeleton"
+  >
+    <div
+      className="ProfileCellSkeleton__avatar"
+    >
+      <span
+        aria-busy={true}
+        aria-live="polite"
+      >
+        <span
+          className="react-loading-skeleton LoadingSkeleton"
+          style={
+            Object {
+              "--base-color": "#E1E1E1",
+              "borderRadius": "50%",
+              "height": 44,
+              "width": 44,
+            }
+          }
+        >
+          ‌
+        </span>
+        <br />
+      </span>
+    </div>
+    <div
+      className="ProfileCellSkeleton__info"
+    >
+      <span
+        aria-busy={true}
+        aria-live="polite"
+      >
+        <span
+          className="react-loading-skeleton LoadingSkeleton"
+          style={
+            Object {
+              "--base-color": "#E1E1E1",
+              "borderRadius": "0.25rem",
+              "width": "100%",
+            }
+          }
+        >
+          ‌
+        </span>
+        <br />
+        <span
+          className="react-loading-skeleton LoadingSkeleton"
+          style={
+            Object {
+              "--base-color": "#E1E1E1",
+              "borderRadius": "0.25rem",
+              "width": "100%",
+            }
+          }
+        >
+          ‌
+        </span>
+        <br />
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Components/Profile Cell Small 1`] = `
 <div
   style={

--- a/src/Avatar/Avatar.scss
+++ b/src/Avatar/Avatar.scss
@@ -3,8 +3,8 @@
 .Avatar {
   position: relative;
   display: inline-block;
-  height: 2.75rem;
-  width: 2.75rem;
+  height: $avatar-small-height;
+  width: $avatar-small-width;
 
   &__alert {
      background-color: $ux-red-400;
@@ -49,8 +49,8 @@
   }
 
   &--large {
-    height: 5rem;
-    width: 5rem;
+    height: $avatar-large-height;
+    width: $avatar-large-width;
 
     .Avatar {
       &__circle__initials {

--- a/src/ProfileCell/ProfileCell.jsx
+++ b/src/ProfileCell/ProfileCell.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+
 import Avatar from 'src/Avatar';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import ProfileCellSkeleton from './ProfileCellSkeleton';
 
 import './ProfileCell.scss';
 
@@ -13,36 +16,42 @@ function ProfileCell(props) {
   };
 
   return (
-    <div
-      className={classNames(
-        'ProfileCell',
-        { 'ProfileCell--large': props.large },
-      )}
-    >
-      <div className="ProfileCell__image">
-        <Avatar
-          colorId={props.colorId}
-          image={profileImage}
-          initials={props.user.initials}
-          large={props.large}
-          name={props.user.name}
-          showAlert={props.showAlert}
-        />
-      </div>
-      <div className="ProfileCell__content" style={contentStyle}>
-        <div className="ProfileCell__content__name__container">
-          <h5 className="ProfileCell__content__name">
-            {props.user.name}
-          </h5>
-          {props.trailingIcon && (
-            <FontAwesomeIcon className="ProfileCell__content__trailing_icon" icon={props.trailingIcon} />
+    <>
+      {props.isLoading ? (
+        <ProfileCellSkeleton maxWidth={props.maxWidth || '100%'} />
+      ) : (
+        <div
+          className={classNames(
+            'ProfileCell',
+            { 'ProfileCell--large': props.large },
           )}
+        >
+          <div className="ProfileCell__image">
+            <Avatar
+              colorId={props.colorId}
+              image={profileImage}
+              initials={props.user.initials}
+              large={props.large}
+              name={props.user.name}
+              showAlert={props.showAlert}
+            />
+          </div>
+          <div className="ProfileCell__content" style={contentStyle}>
+            <div className="ProfileCell__content__name__container">
+              <h5 className="ProfileCell__content__name">
+                {props.user.name}
+              </h5>
+              {props.trailingIcon && (
+                <FontAwesomeIcon className="ProfileCell__content__trailing_icon" icon={props.trailingIcon} />
+              )}
+            </div>
+            <div className="ProfileCell__content__subtitle">
+              {props.subtitle || ' '}
+            </div>
+          </div>
         </div>
-        <div className="ProfileCell__content__subtitle">
-          {props.subtitle || ' '}
-        </div>
-      </div>
-    </div>
+      )}
+    </>
   );
 }
 
@@ -64,6 +73,7 @@ const ProfileUser = PropTypes.shape({
 
 ProfileCell.propTypes = {
   colorId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  isLoading: PropTypes.bool,
   large: PropTypes.bool,
   maxWidth: PropTypes.string,
   showAlert: PropTypes.bool,
@@ -74,6 +84,7 @@ ProfileCell.propTypes = {
 
 ProfileCell.defaultProps = {
   colorId: undefined,
+  isLoading: undefined,
   large: false,
   maxWidth: undefined,
   showAlert: false,

--- a/src/ProfileCell/ProfileCell.mdx
+++ b/src/ProfileCell/ProfileCell.mdx
@@ -49,6 +49,22 @@ import ProfileCell from './ProfileCell';
   <Story id="components-profile-cell--with-image" />
 </Canvas>
 
+### With Trailing Icon
+
+<Canvas>
+  <Story id="components-profile-cell--with-trailing-icon" />
+</Canvas>
+
+### Loading
+
+Use the `isLoading` prop on `ProfileCell` to create a low fidelity representation of the ProfileCell.
+
+`ProfileCellSkeleton` is also available for use.
+
+<Canvas>
+  <Story id="components-profile-cell--loading" />
+</Canvas>
+
 
 ## Formatting
 

--- a/src/ProfileCell/ProfileCell.stories.jsx
+++ b/src/ProfileCell/ProfileCell.stories.jsx
@@ -4,11 +4,13 @@ import {
 } from '@storybook/addon-knobs';
 import { faShieldCheck } from '@fortawesome/pro-solid-svg-icons';
 import ProfileCell from 'src/ProfileCell';
+import ProfileCellSkeleton from './ProfileCellSkeleton';
 import mdx from './ProfileCell.mdx';
 
 export default {
   title: 'Components/Profile Cell',
   component: ProfileCell,
+  subcomponents: { ProfileCellSkeleton },
   decorators: [withKnobs],
   parameters: {
     docs: {
@@ -84,12 +86,16 @@ export const WithTrailingIcon = () => (
 );
 
 export const Loading = () => (
-  <ProfileCell
-    colorId={number('Color ID', undefined)}
-    isLoading
-    maxWidth={text('Max Text Width (e.g. 8rem)', '')}
-    showAlert={boolean('Show Alert', false)}
-    subtitle={text('Subtitle Text', `riley@userinterviews.com`)}
-    user={userNoImage}
-  />
+  <>
+    <ProfileCell
+      colorId={number('Color ID', undefined)}
+      isLoading
+      maxWidth={text('Max Text Width (e.g. 8rem)', '')}
+      showAlert={boolean('Show Alert', false)}
+      subtitle={text('Subtitle Text', `riley@userinterviews.com`)}
+      user={userNoImage}
+    />
+    <br />
+    <ProfileCellSkeleton maxWidth={text('Max Text Width (e.g. 8rem)', '')} />
+  </>
 );

--- a/src/ProfileCell/ProfileCell.stories.jsx
+++ b/src/ProfileCell/ProfileCell.stories.jsx
@@ -82,3 +82,14 @@ export const WithTrailingIcon = () => (
     user={userWithImage}
   />
 );
+
+export const Loading = () => (
+  <ProfileCell
+    colorId={number('Color ID', undefined)}
+    isLoading
+    maxWidth={text('Max Text Width (e.g. 8rem)', '')}
+    showAlert={boolean('Show Alert', false)}
+    subtitle={text('Subtitle Text', `riley@userinterviews.com`)}
+    user={userNoImage}
+  />
+);

--- a/src/ProfileCell/ProfileCellSkeleton.jsx
+++ b/src/ProfileCell/ProfileCellSkeleton.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { LoadingSkeleton } from 'src/LoadingSkeleton';
+
+import './ProfileCellSkeleton.scss';
+
+const ProfileCellSkeleton = ({ maxWidth, ...props }) => (
+  <div className="ProfileCellSkeleton" {...props}>
+    <div className="ProfileCellSkeleton__avatar">
+      <LoadingSkeleton circle height={44} width={44} />
+    </div>
+    <div className="ProfileCellSkeleton__info">
+      <LoadingSkeleton count={2} width={maxWidth} />
+    </div>
+  </div>
+  );
+
+ProfileCellSkeleton.propTypes = {
+  maxWidth: PropTypes.string,
+};
+
+ProfileCellSkeleton.defaultProps = {
+  maxWidth: '100%',
+};
+
+export default ProfileCellSkeleton;

--- a/src/ProfileCell/ProfileCellSkeleton.scss
+++ b/src/ProfileCell/ProfileCellSkeleton.scss
@@ -1,6 +1,10 @@
+@import '../../scss/theme';
+
+$profile-cell-avatar-small-width: $avatar-small-width;
+
 .ProfileCellSkeleton {
   display: grid;
-  grid-template-columns: 44px auto;
+  grid-template-columns: $profile-cell-avatar-small-width auto;
 
   &__avatar {
     grid-column-start: 1;

--- a/src/ProfileCell/ProfileCellSkeleton.scss
+++ b/src/ProfileCell/ProfileCellSkeleton.scss
@@ -1,0 +1,15 @@
+.ProfileCellSkeleton {
+  display: grid;
+  grid-template-columns: 44px auto;
+
+  &__avatar {
+    grid-column-start: 1;
+  }
+
+  &__info {
+    grid-column-start: 2;
+    margin-left: 1rem;
+    display: grid;
+    align-items: center;
+  }
+}

--- a/src/ProfileCell/index.js
+++ b/src/ProfileCell/index.js
@@ -1,1 +1,7 @@
+import ProfileCellSkeleton from './ProfileCellSkeleton';
+
+export {
+  ProfileCellSkeleton,
+};
+
 export { default } from './ProfileCell';

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ import { OverlayTrigger, OVERLAY_TRIGGER_PLACEMENT } from 'src/OverlayTrigger';
 import { Pill, Pills, PILL_COLORS } from 'src/Pill';
 import { Popover, PopoverBody, PopoverCard } from 'src/Popover';
 import Popper from 'src/Popper';
-import ProfileCell from 'src/ProfileCell';
+import ProfileCell, { ProfileCellSkeleton } from 'src/ProfileCell';
 import RadioButton from 'src/RadioButton';
 import RadioButtonGroup from 'src/RadioButtonGroup';
 import {
@@ -141,6 +141,7 @@ export {
   PopoverCard,
   Popper,
   ProfileCell,
+  ProfileCellSkeleton,
   RadioButton,
   RadioButtonGroup,
   Row,


### PR DESCRIPTION
closes #824 

[Chromatic](https://62d040e741710e4f085e0647-ikucpqxlpj.chromatic.com/?path=/story/components-profile-cell--loading)

Creating another pre-built skeleton for ProfileCell. Also exporting `ProfileCellSkeleton` as a convenience if loading state management isn't as easy to implement on the ProfileCell itself which I had to do in the example below:

Testing out on Messages page in RS:

Before:

https://user-images.githubusercontent.com/37383785/216151084-b9d40f90-57ba-4e8a-8c48-2cd179142269.mov


After:

https://user-images.githubusercontent.com/37383785/216150152-97e64084-5b3a-4536-832f-f1f5de961878.mov


