### PR TITLE
Update setMessage to accept object in useToast.js and add Toast.mdx doc file

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -21409,7 +21409,7 @@ exports[`Storyshots Components/Text Weight 1`] = `
 </div>
 `;
 
-exports[`Storyshots Components/Toast Manual Dismiss Toast 1`] = `
+exports[`Storyshots Components/Toast Default 1`] = `
 <div
   style={
     Object {
@@ -21437,7 +21437,7 @@ exports[`Storyshots Components/Toast Manual Dismiss Toast 1`] = `
 </div>
 `;
 
-exports[`Storyshots Components/Toast Toast 1`] = `
+exports[`Storyshots Components/Toast Manual Dismiss Toast 1`] = `
 <div
   style={
     Object {

--- a/src/Toast/Toast.jsx
+++ b/src/Toast/Toast.jsx
@@ -43,6 +43,10 @@ Toast.propTypes = {
   header: PropTypes.bool,
   messages: PropTypes.arrayOf(
     PropTypes.shape({
+      action: PropTypes.shape({
+        content: PropTypes.string,
+        url: PropTypes.string,
+      }),
       id: PropTypes.string,
       message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
       title: PropTypes.string,

--- a/src/Toast/Toast.mdx
+++ b/src/Toast/Toast.mdx
@@ -6,8 +6,12 @@ import Toast from './Toast';
 ##
 
 <h4>
-	Toasts communciate important messages and provide immediate feedback without disrupting the user experience.
+	Toasts communicate important messages and provide immediate feedback without disrupting the user experience.
 </h4>
+
+<Canvas>
+  <Story id="components-toast--default" />
+</Canvas>
 
 ## Props
 
@@ -22,7 +26,7 @@ This custom hook returns the following four values to aid the implementation of 
 - Array of objects with shape:
 ```
 {
-  type: 'success' (one of MessageTypes),
+  type: MessageTypes.SUCCESS, (one of MessageTypes)
   title: 'A good title',
   message: 'A good message',
   action: {
@@ -40,7 +44,7 @@ This custom hook returns the following four values to aid the implementation of 
 - Accepts parameter of object with shape:
 ```
 {
-  type: 'success' (one of MessageTypes),
+  type: MessageTypes.SUCCESS, (one of MessageTypes)
   title: 'A good title',
   message: 'A good message',
   action: {

--- a/src/Toast/Toast.mdx
+++ b/src/Toast/Toast.mdx
@@ -1,0 +1,16 @@
+import { ArgsTable, Story, Canvas } from '@storybook/addon-docs/blocks';
+import Toast from './Toast';
+
+# Toast
+
+##
+
+<h4>
+	Toasts communciate important messages and provide immediate feedback without disrupting the user experience.
+</h4>
+
+## Props
+
+<ArgsTable of={Toast} />
+
+

--- a/src/Toast/Toast.mdx
+++ b/src/Toast/Toast.mdx
@@ -14,3 +14,40 @@ import Toast from './Toast';
 <ArgsTable of={Toast} />
 
 
+## useToast
+
+This custom hook returns the following four values to aid the implementation of toast components.
+
+#### messages
+- Array of objects with shape:
+```
+{
+  type: 'success' (one of MessageTypes),
+  title: 'A good title',
+  message: 'A good message',
+  action: {
+    url: 'www.url.com'
+    content: 'Action name'
+  }
+}
+```
+#### clearMessages
+- Function that resets `messages` value to an empty array.
+#### dismissMessage
+- Function that removes message from `messages` array, by `messageId`
+#### setMessage
+- Function that adds message to `messages` array.
+- Accepts parameter of object with shape:
+```
+{
+  type: 'success' (one of MessageTypes),
+  title: 'A good title',
+  message: 'A good message',
+  action: {
+    url: 'www.url.com'
+    content: 'Action name'
+  }
+}
+```
+
+

--- a/src/Toast/Toast.stories.jsx
+++ b/src/Toast/Toast.stories.jsx
@@ -40,7 +40,7 @@ const DummyComponent = ({
 DummyComponent.propTypes = withToastPropTypes;
 const ToastDummyComponent = withToast(DummyComponent);
 
-export const Toast = () => (
+export const Default = () => (
   <ToastDummyComponent
     message={text('Message', 'Your action was a success!')}
     title={text('Title', 'Title')}

--- a/src/Toast/Toast.stories.jsx
+++ b/src/Toast/Toast.stories.jsx
@@ -4,6 +4,7 @@ import { withKnobs, text, radios } from '@storybook/addon-knobs';
 import { MessageTypes } from 'src/Alert';
 import Button from 'src/Button';
 import { withToast, withToastPropTypes } from 'src/Toast';
+import mdx from './Toast.mdx';
 
 import '../../scss/global.scss';
 
@@ -11,6 +12,11 @@ export default {
   title: 'Components/Toast',
   component: withToast,
   decorators: [withKnobs],
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
 };
 
 const DummyComponent = ({
@@ -18,7 +24,17 @@ const DummyComponent = ({
 }) => (
   <div>
     <p>Click the button to see a toast message.  Use the knobs to try different types!</p>
-    <Button variant="primary" onClick={() => setToastMessage(type, message, action, title)}>Submit</Button>
+    <Button
+      variant="primary"
+      onClick={() => setToastMessage({
+        type,
+        message,
+        action,
+        title,
+      })}
+    >
+      Submit
+    </Button>
   </div>
   );
 DummyComponent.propTypes = withToastPropTypes;

--- a/src/Toast/useToast.js
+++ b/src/Toast/useToast.js
@@ -1,12 +1,17 @@
 import { useCallback, useReducer } from 'react';
 import { v4 as generateUUID } from 'uuid';
 
-const createMessage = (messageType, messageText, messageAction, messageTitle) => ({
+const createMessage = (
+  type,
+  title,
+  message,
+  action,
+) => ({
   id: generateUUID(),
-  message: messageText,
-  type: messageType,
-  action: messageAction,
-  title: messageTitle,
+  type,
+  title,
+  message,
+  action,
 });
 
 const ACTIONS = {
@@ -21,10 +26,10 @@ const messagesReducer = (state, { type, payload }) => {
       return [
         ...state,
         createMessage(
-          payload.messageAction,
-          payload.messageType,
-          payload.messageText,
-          payload.messageTitle,
+          payload?.type,
+          payload?.title,
+          payload?.message,
+          payload?.action,
         ),
       ];
     case ACTIONS.CLEAR_MESSAGES:
@@ -43,11 +48,16 @@ const useToast = (initialMessages = []) => {
     dispatch({ type: ACTIONS.CLEAR_MESSAGES });
   }, []);
 
-  const setMessage = useCallback((messageAction, messageType, messageText, messageTitle) => {
+  const setMessage = useCallback(({
+    action,
+    type,
+    message,
+    title,
+  }) => {
     dispatch({
  type: ACTIONS.SET_MESSAGE,
 payload: {
- messageAction, messageType, messageText, messageTitle,
+ action, type, message, title,
 },
 });
   }, []);

--- a/src/Toast/useToast.test.js
+++ b/src/Toast/useToast.test.js
@@ -16,13 +16,18 @@ describe('useToast', () => {
     const { result } = renderHook(() => useToast());
 
     act(() => {
-      result.current.setMessage(MessageTypes.SUCCESS, newMessage);
+      result.current.setMessage({
+        type: MessageTypes.SUCCESS,
+        message: newMessage,
+      });
     });
 
     expect(result.current.messages).toEqual([{
       id: GENERATED_UUID,
       type: MessageTypes.SUCCESS,
       message: newMessage,
+      action: undefined,
+      title: undefined,
     }]);
   });
 
@@ -31,7 +36,10 @@ describe('useToast', () => {
     const { result } = renderHook(() => useToast());
 
     act(() => {
-      result.current.setMessage(MessageTypes.SUCCESS, newMessage);
+      result.current.setMessage({
+        type: MessageTypes.SUCCESS,
+        message: newMessage,
+      });
     });
 
     expect(result.current.messages).toEqual([{
@@ -54,7 +62,10 @@ describe('useToast', () => {
     newMessages.forEach(
       (message) => {
         act(() => {
-          result.current.setMessage(MessageTypes.ERROR, message);
+          result.current.setMessage({
+            type: MessageTypes.ERROR,
+            message,
+          });
         });
       },
     );
@@ -63,6 +74,8 @@ describe('useToast', () => {
       newMessages.map((message) => ({
         id: GENERATED_UUID,
         type: MessageTypes.ERROR,
+        action: undefined,
+        title: undefined,
         message,
       })),
     );
@@ -70,10 +83,10 @@ describe('useToast', () => {
 
   test('can clear all messages', () => {
     const messages = ['A new', 'message'].map(
-      (msg, i) => ({
+      (message, i) => ({
           id: i,
           type: MessageTypes.SUCCESS,
-          message: msg,
+          message,
         }),
     );
 

--- a/src/Toast/withToast.test.jsx
+++ b/src/Toast/withToast.test.jsx
@@ -22,7 +22,10 @@ describe('test withToast', () => {
     const component = toast.root.findByType(WrappedComponent);
 
     act(() => {
-      component.props.setToastMessage(MessageTypes.SUCCESS, newMessage);
+      component.props.setToastMessage({
+        type: MessageTypes.SUCCESS,
+        message: newMessage,
+      });
     });
 
     expect(toast).toMatchSnapshot();


### PR DESCRIPTION
Resolves #836 

Update `setMessage` in `useToast.jsx`  to expect an object with `message`, `title`, `action`, and `type` keys and become order agnostic.

Add Toast.mdx with Props table and `useToast` documentation:
![Screen Shot 2023-02-08 at 4 20 42 PM](https://user-images.githubusercontent.com/65029597/217681954-3cb6ef51-91c3-481f-ad50-eed7c0df0acd.png)
