### PR TITLE
Button height updates

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -3505,7 +3505,7 @@ exports[`Storyshots Components/Button Danger 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      className="svg-inline--fa fa-file-alt icon-left"
       data-icon="file-alt"
       data-prefix="far"
       focusable="false"
@@ -3523,7 +3523,7 @@ exports[`Storyshots Components/Button Danger 1`] = `
     Delete
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      className="svg-inline--fa fa-caret-down icon-right"
       data-icon="caret-down"
       data-prefix="far"
       focusable="false"
@@ -3547,7 +3547,7 @@ exports[`Storyshots Components/Button Danger 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      className="svg-inline--fa fa-file-alt icon-left"
       data-icon="file-alt"
       data-prefix="far"
       focusable="false"
@@ -3565,7 +3565,7 @@ exports[`Storyshots Components/Button Danger 1`] = `
     Delete
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      className="svg-inline--fa fa-caret-down icon-right"
       data-icon="caret-down"
       data-prefix="far"
       focusable="false"
@@ -3590,7 +3590,7 @@ exports[`Storyshots Components/Button Danger 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      className="svg-inline--fa fa-file-alt icon-left"
       data-icon="file-alt"
       data-prefix="far"
       focusable="false"
@@ -3608,7 +3608,7 @@ exports[`Storyshots Components/Button Danger 1`] = `
     Delete
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      className="svg-inline--fa fa-caret-down icon-right"
       data-icon="caret-down"
       data-prefix="far"
       focusable="false"
@@ -3650,7 +3650,7 @@ exports[`Storyshots Components/Button Link 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-paper-plane fa-w-16 icon-left"
+      className="svg-inline--fa fa-paper-plane icon-left"
       data-icon="paper-plane"
       data-prefix="far"
       focusable="false"
@@ -3695,7 +3695,7 @@ exports[`Storyshots Components/Button Loading 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-spinner-third fa-w-16 icon-left btn-loading-spin"
+      className="svg-inline--fa fa-spinner-third icon-left btn-loading-spin"
       data-icon="spinner-third"
       data-prefix="far"
       focusable="false"
@@ -3721,7 +3721,7 @@ exports[`Storyshots Components/Button Loading 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-spinner-third fa-w-16 icon-left btn-loading-spin"
+      className="svg-inline--fa fa-spinner-third icon-left btn-loading-spin"
       data-icon="spinner-third"
       data-prefix="far"
       focusable="false"
@@ -3747,7 +3747,7 @@ exports[`Storyshots Components/Button Loading 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-spinner-third fa-w-16 icon-left btn-loading-spin"
+      className="svg-inline--fa fa-spinner-third icon-left btn-loading-spin"
       data-icon="spinner-third"
       data-prefix="far"
       focusable="false"
@@ -3773,7 +3773,7 @@ exports[`Storyshots Components/Button Loading 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-spinner-third fa-w-16 icon-left btn-loading-spin"
+      className="svg-inline--fa fa-spinner-third icon-left btn-loading-spin"
       data-icon="spinner-third"
       data-prefix="far"
       focusable="false"
@@ -3799,7 +3799,7 @@ exports[`Storyshots Components/Button Loading 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-spinner-third fa-w-16 icon-left btn-loading-spin"
+      className="svg-inline--fa fa-spinner-third icon-left btn-loading-spin"
       data-icon="spinner-third"
       data-prefix="far"
       focusable="false"
@@ -3825,7 +3825,7 @@ exports[`Storyshots Components/Button Loading 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-spinner-third fa-w-16 icon-left btn-loading-spin"
+      className="svg-inline--fa fa-spinner-third icon-left btn-loading-spin"
       data-icon="spinner-third"
       data-prefix="far"
       focusable="false"
@@ -3860,7 +3860,7 @@ exports[`Storyshots Components/Button Primary 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      className="svg-inline--fa fa-file-alt icon-left"
       data-icon="file-alt"
       data-prefix="far"
       focusable="false"
@@ -3878,7 +3878,7 @@ exports[`Storyshots Components/Button Primary 1`] = `
     Confirm
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      className="svg-inline--fa fa-caret-down icon-right"
       data-icon="caret-down"
       data-prefix="far"
       focusable="false"
@@ -3902,7 +3902,7 @@ exports[`Storyshots Components/Button Primary 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      className="svg-inline--fa fa-file-alt icon-left"
       data-icon="file-alt"
       data-prefix="far"
       focusable="false"
@@ -3920,7 +3920,7 @@ exports[`Storyshots Components/Button Primary 1`] = `
     Confirm
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      className="svg-inline--fa fa-caret-down icon-right"
       data-icon="caret-down"
       data-prefix="far"
       focusable="false"
@@ -3945,7 +3945,7 @@ exports[`Storyshots Components/Button Primary 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      className="svg-inline--fa fa-file-alt icon-left"
       data-icon="file-alt"
       data-prefix="far"
       focusable="false"
@@ -3963,7 +3963,7 @@ exports[`Storyshots Components/Button Primary 1`] = `
     Confirm
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      className="svg-inline--fa fa-caret-down icon-right"
       data-icon="caret-down"
       data-prefix="far"
       focusable="false"
@@ -3987,7 +3987,7 @@ exports[`Storyshots Components/Button Primary 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      className="svg-inline--fa fa-file-alt icon-left"
       data-icon="file-alt"
       data-prefix="far"
       focusable="false"
@@ -4005,7 +4005,7 @@ exports[`Storyshots Components/Button Primary 1`] = `
     Confirm
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      className="svg-inline--fa fa-caret-down icon-right"
       data-icon="caret-down"
       data-prefix="far"
       focusable="false"
@@ -4029,7 +4029,7 @@ exports[`Storyshots Components/Button Primary 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      className="svg-inline--fa fa-file-alt icon-left"
       data-icon="file-alt"
       data-prefix="far"
       focusable="false"
@@ -4047,7 +4047,7 @@ exports[`Storyshots Components/Button Primary 1`] = `
     Confirm
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      className="svg-inline--fa fa-caret-down icon-right"
       data-icon="caret-down"
       data-prefix="far"
       focusable="false"
@@ -4072,7 +4072,7 @@ exports[`Storyshots Components/Button Primary 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      className="svg-inline--fa fa-file-alt icon-left"
       data-icon="file-alt"
       data-prefix="far"
       focusable="false"
@@ -4090,7 +4090,7 @@ exports[`Storyshots Components/Button Primary 1`] = `
     Confirm
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      className="svg-inline--fa fa-caret-down icon-right"
       data-icon="caret-down"
       data-prefix="far"
       focusable="false"
@@ -4114,7 +4114,7 @@ exports[`Storyshots Components/Button Primary 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      className="svg-inline--fa fa-file-alt icon-left"
       data-icon="file-alt"
       data-prefix="far"
       focusable="false"
@@ -4132,7 +4132,7 @@ exports[`Storyshots Components/Button Primary 1`] = `
     Confirm
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      className="svg-inline--fa fa-caret-down icon-right"
       data-icon="caret-down"
       data-prefix="far"
       focusable="false"
@@ -4156,7 +4156,7 @@ exports[`Storyshots Components/Button Primary 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      className="svg-inline--fa fa-file-alt icon-left"
       data-icon="file-alt"
       data-prefix="far"
       focusable="false"
@@ -4174,7 +4174,7 @@ exports[`Storyshots Components/Button Primary 1`] = `
     Confirm
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      className="svg-inline--fa fa-caret-down icon-right"
       data-icon="caret-down"
       data-prefix="far"
       focusable="false"
@@ -4199,7 +4199,7 @@ exports[`Storyshots Components/Button Primary 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      className="svg-inline--fa fa-file-alt icon-left"
       data-icon="file-alt"
       data-prefix="far"
       focusable="false"
@@ -4217,7 +4217,7 @@ exports[`Storyshots Components/Button Primary 1`] = `
     Confirm
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      className="svg-inline--fa fa-caret-down icon-right"
       data-icon="caret-down"
       data-prefix="far"
       focusable="false"
@@ -22233,118 +22233,6 @@ exports[`Storyshots Components/Text Weight 1`] = `
   >
     Source from a pool of more than 2.1 million participants to reach nearly any target audience.
   </p>
-</div>
-`;
-
-exports[`Storyshots Components/Toast Default 1`] = `
-<div
-  style={
-    Object {
-      "padding": "1rem",
-    }
-  }
->
-  <div
-    aria-live="polite"
-    className="Toast"
-  />
-  <div>
-    <p>
-      Click the button to see a toast message.  Use the knobs to try different types!
-    </p>
-    <button
-      className="Button btn btn-primary btn-md"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Submit
-    </button>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Components/Toast Manual Dismiss Toast 1`] = `
-<div
-  style={
-    Object {
-      "padding": "1rem",
-    }
-  }
->
-  <div
-    aria-live="polite"
-    className="Toast"
-  />
-  <div>
-    <p>
-      Click the button to see a toast message.  Use the knobs to try different types!
-    </p>
-    <button
-      className="Button btn btn-primary btn-md"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Submit
-    </button>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Components/Toast Toast Custom Message 1`] = `
-<div
-  style={
-    Object {
-      "padding": "1rem",
-    }
-  }
->
-  <div
-    aria-live="polite"
-    className="Toast"
-  />
-  <div>
-    <p>
-      Click the button to see a toast message.  Use the knobs to try different types!
-    </p>
-    <button
-      className="Button btn btn-primary btn-md"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Submit
-    </button>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Components/Toast Toast With Action 1`] = `
-<div
-  style={
-    Object {
-      "padding": "1rem",
-    }
-  }
->
-  <div
-    aria-live="polite"
-    className="Toast"
-  />
-  <div>
-    <p>
-      Click the button to see a toast message.  Use the knobs to try different types!
-    </p>
-    <button
-      className="Button btn btn-primary btn-md"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Submit
-    </button>
-  </div>
 </div>
 `;
 

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -3497,6 +3497,133 @@ exports[`Storyshots Components/Button Danger 1`] = `
       />
     </svg>
   </button>
+   
+  <button
+    className="Button btn btn-danger btn-lg"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Delete
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+   
+  <button
+    className="Button btn btn-outline-danger btn-lg"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Delete
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+   
+  <button
+    aria-disabled={true}
+    className="Button btn btn-danger btn-lg"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Delete
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
 </div>
 `;
 
@@ -3641,6 +3768,58 @@ exports[`Storyshots Components/Button Loading 1`] = `
   <button
     aria-disabled={true}
     className="Button btn btn-outline-primary btn-md"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-spinner-third fa-w-16 icon-left btn-loading-spin"
+      data-icon="spinner-third"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M460.116 373.846l-20.823-12.022c-5.541-3.199-7.54-10.159-4.663-15.874 30.137-59.886 28.343-131.652-5.386-189.946-33.641-58.394-94.896-95.833-161.827-99.676C261.028 55.961 256 50.751 256 44.352V20.309c0-6.904 5.808-12.337 12.703-11.982 83.556 4.306 160.163 50.864 202.11 123.677 42.063 72.696 44.079 162.316 6.031 236.832-3.14 6.148-10.75 8.461-16.728 5.01z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Loading...
+  </button>
+   
+  <button
+    aria-disabled={true}
+    className="Button btn btn-primary btn-lg"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-spinner-third fa-w-16 icon-left btn-loading-spin"
+      data-icon="spinner-third"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M460.116 373.846l-20.823-12.022c-5.541-3.199-7.54-10.159-4.663-15.874 30.137-59.886 28.343-131.652-5.386-189.946-33.641-58.394-94.896-95.833-161.827-99.676C261.028 55.961 256 50.751 256 44.352V20.309c0-6.904 5.808-12.337 12.703-11.982 83.556 4.306 160.163 50.864 202.11 123.677 42.063 72.696 44.079 162.316 6.031 236.832-3.14 6.148-10.75 8.461-16.728 5.01z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Loading...
+  </button>
+   
+  <button
+    aria-disabled={true}
+    className="Button btn btn-outline-primary btn-lg"
     disabled={true}
     type="button"
   >
@@ -3888,6 +4067,133 @@ exports[`Storyshots Components/Button Primary 1`] = `
   <button
     aria-disabled={true}
     className="Button btn btn-primary btn-md"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Confirm
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+   
+  <button
+    className="Button btn btn-primary btn-lg"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Confirm
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+   
+  <button
+    className="Button btn btn-outline-primary btn-lg"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Confirm
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+   
+  <button
+    aria-disabled={true}
+    className="Button btn btn-primary btn-lg"
     disabled={true}
     type="button"
   >
@@ -4191,6 +4497,133 @@ exports[`Storyshots Components/Button Transparent 1`] = `
       />
     </svg>
   </button>
+   
+  <button
+    className="Button btn btn-transparent btn-lg"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Skip
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+   
+  <button
+    className="Button btn btn-outline-transparent btn-lg"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Skip
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+   
+  <button
+    aria-disabled={true}
+    className="Button btn btn-transparent btn-lg"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Skip
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
 </div>
 `;
 
@@ -4416,6 +4849,133 @@ exports[`Storyshots Components/Button Warning 1`] = `
   <button
     aria-disabled={true}
     className="Button btn btn-warning btn-md"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Edit
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+   
+  <button
+    className="Button btn btn-warning btn-lg"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Edit
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+   
+  <button
+    className="Button btn btn-outline-warning btn-lg"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt fa-w-12 icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Edit
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down fa-w-10 icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+   
+  <button
+    aria-disabled={true}
+    className="Button btn btn-warning btn-lg"
     disabled={true}
     type="button"
   >
@@ -5618,7 +6178,7 @@ exports[`Storyshots Components/Form Default 1`] = `
       </label>
     </div>
     <button
-      className="Button btn btn-primary"
+      className="Button btn btn-primary btn-md"
       disabled={false}
       type="submit"
     >
@@ -8376,7 +8936,7 @@ exports[`Storyshots Components/Modal Danger Modal 1`] = `
         className="ModalFooter"
       >
         <button
-          className="Button btn btn-transparent"
+          className="Button btn btn-transparent btn-md"
           disabled={false}
           onClick={[Function]}
           type="button"
@@ -8384,7 +8944,7 @@ exports[`Storyshots Components/Modal Danger Modal 1`] = `
           Cancel
         </button>
         <button
-          className="Button btn btn-danger"
+          className="Button btn btn-danger btn-md"
           disabled={false}
           type="button"
         >
@@ -8463,7 +9023,7 @@ exports[`Storyshots Components/Modal Default 1`] = `
         className="ModalFooter"
       >
         <button
-          className="Button btn btn-transparent"
+          className="Button btn btn-transparent btn-md"
           disabled={false}
           onClick={[Function]}
           type="button"
@@ -8471,7 +9031,7 @@ exports[`Storyshots Components/Modal Default 1`] = `
           Cancel
         </button>
         <button
-          className="Button btn btn-primary"
+          className="Button btn btn-primary btn-md"
           disabled={false}
           type="submit"
         >
@@ -8550,7 +9110,7 @@ exports[`Storyshots Components/Modal Large Modal 1`] = `
         className="ModalFooter"
       >
         <button
-          className="Button btn btn-transparent"
+          className="Button btn btn-transparent btn-md"
           disabled={false}
           onClick={[Function]}
           type="button"
@@ -8558,7 +9118,7 @@ exports[`Storyshots Components/Modal Large Modal 1`] = `
           Cancel
         </button>
         <button
-          className="Button btn btn-primary"
+          className="Button btn btn-primary btn-md"
           disabled={false}
           type="submit"
         >
@@ -8637,7 +9197,7 @@ exports[`Storyshots Components/Modal Medium Modal 1`] = `
         className="ModalFooter"
       >
         <button
-          className="Button btn btn-transparent"
+          className="Button btn btn-transparent btn-md"
           disabled={false}
           onClick={[Function]}
           type="button"
@@ -8645,7 +9205,7 @@ exports[`Storyshots Components/Modal Medium Modal 1`] = `
           Cancel
         </button>
         <button
-          className="Button btn btn-primary"
+          className="Button btn btn-primary btn-md"
           disabled={false}
           type="submit"
         >
@@ -8736,7 +9296,7 @@ exports[`Storyshots Components/Modal Transactional Modal 1`] = `
         className="ModalFooter"
       >
         <button
-          className="Button btn btn-transparent"
+          className="Button btn btn-transparent btn-md"
           disabled={false}
           onClick={[Function]}
           type="button"
@@ -8744,7 +9304,7 @@ exports[`Storyshots Components/Modal Transactional Modal 1`] = `
           Cancel
         </button>
         <button
-          className="Button btn btn-primary"
+          className="Button btn btn-primary btn-md"
           disabled={false}
           type="submit"
         >
@@ -8840,7 +9400,7 @@ exports[`Storyshots Components/Modal Warning Modal 1`] = `
         className="ModalFooter"
       >
         <button
-          className="Button btn btn-transparent"
+          className="Button btn btn-transparent btn-md"
           disabled={false}
           onClick={[Function]}
           type="button"
@@ -8932,7 +9492,7 @@ exports[`Storyshots Components/Modal With Subtitle Modal 1`] = `
         className="ModalFooter"
       >
         <button
-          className="Button btn btn-transparent"
+          className="Button btn btn-transparent btn-md"
           disabled={false}
           onClick={[Function]}
           type="button"
@@ -8940,7 +9500,7 @@ exports[`Storyshots Components/Modal With Subtitle Modal 1`] = `
           Cancel
         </button>
         <button
-          className="Button btn btn-primary"
+          className="Button btn btn-primary btn-md"
           disabled={false}
           type="submit"
         >
@@ -9281,7 +9841,7 @@ exports[`Storyshots Components/Popover Card Popover 1`] = `
   }
 >
   <button
-    className="Button btn btn-primary"
+    className="Button btn btn-primary btn-md"
     disabled={false}
     onClick={[Function]}
     type="button"
@@ -9300,7 +9860,7 @@ exports[`Storyshots Components/Popover Default 1`] = `
   }
 >
   <button
-    className="Button btn btn-primary"
+    className="Button btn btn-primary btn-md"
     disabled={false}
     onClick={[Function]}
     type="button"
@@ -9319,7 +9879,7 @@ exports[`Storyshots Components/Popover Placement 1`] = `
   }
 >
   <button
-    className="Button btn btn-primary"
+    className="Button btn btn-primary btn-md"
     disabled={false}
     onClick={[Function]}
     type="button"
@@ -9992,7 +10552,7 @@ exports[`Storyshots Components/Selects/Async In Modal 1`] = `
         className="ModalFooter"
       >
         <button
-          className="Button btn btn-transparent"
+          className="Button btn btn-transparent btn-md"
           disabled={false}
           onClick={[Function]}
           type="button"
@@ -10000,7 +10560,7 @@ exports[`Storyshots Components/Selects/Async In Modal 1`] = `
           Cancel
         </button>
         <button
-          className="Button btn btn-primary"
+          className="Button btn btn-primary btn-md"
           disabled={false}
           type="submit"
         >
@@ -10308,7 +10868,7 @@ exports[`Storyshots Components/Selects/AsyncCreatable In Modal 1`] = `
         className="ModalFooter"
       >
         <button
-          className="Button btn btn-transparent"
+          className="Button btn btn-transparent btn-md"
           disabled={false}
           onClick={[Function]}
           type="button"
@@ -10316,7 +10876,7 @@ exports[`Storyshots Components/Selects/AsyncCreatable In Modal 1`] = `
           Cancel
         </button>
         <button
-          className="Button btn btn-primary"
+          className="Button btn btn-primary btn-md"
           disabled={false}
           type="submit"
         >
@@ -10624,7 +11184,7 @@ exports[`Storyshots Components/Selects/Creatable In Modal 1`] = `
         className="ModalFooter"
       >
         <button
-          className="Button btn btn-transparent"
+          className="Button btn btn-transparent btn-md"
           disabled={false}
           onClick={[Function]}
           type="button"
@@ -10632,7 +11192,7 @@ exports[`Storyshots Components/Selects/Creatable In Modal 1`] = `
           Cancel
         </button>
         <button
-          className="Button btn btn-primary"
+          className="Button btn btn-primary btn-md"
           disabled={false}
           type="submit"
         >
@@ -11367,7 +11927,7 @@ exports[`Storyshots Components/Selects/Single In Modal 1`] = `
         className="ModalFooter"
       >
         <button
-          className="Button btn btn-transparent"
+          className="Button btn btn-transparent btn-md"
           disabled={false}
           onClick={[Function]}
           type="button"
@@ -11375,7 +11935,7 @@ exports[`Storyshots Components/Selects/Single In Modal 1`] = `
           Cancel
         </button>
         <button
-          className="Button btn btn-primary"
+          className="Button btn btn-primary btn-md"
           disabled={false}
           type="submit"
         >
@@ -13892,7 +14452,7 @@ exports[`Storyshots Components/Table Table With Compact Option 1`] = `
 >
   <div>
     <button
-      className="Button btn btn-outline-primary"
+      className="Button btn btn-outline-primary btn-md"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -18017,7 +18577,7 @@ exports[`Storyshots Components/Table Table With Multiple Sticky Columns And Head
           }
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -18130,7 +18690,7 @@ exports[`Storyshots Components/Table Table With Multiple Sticky Columns And Head
           }
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -18243,7 +18803,7 @@ exports[`Storyshots Components/Table Table With Multiple Sticky Columns And Head
           }
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -18356,7 +18916,7 @@ exports[`Storyshots Components/Table Table With Multiple Sticky Columns And Head
           }
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -18469,7 +19029,7 @@ exports[`Storyshots Components/Table Table With Multiple Sticky Columns And Head
           }
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -18582,7 +19142,7 @@ exports[`Storyshots Components/Table Table With Multiple Sticky Columns And Head
           }
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -18695,7 +19255,7 @@ exports[`Storyshots Components/Table Table With Multiple Sticky Columns And Head
           }
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -18808,7 +19368,7 @@ exports[`Storyshots Components/Table Table With Multiple Sticky Columns And Head
           }
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -18921,7 +19481,7 @@ exports[`Storyshots Components/Table Table With Multiple Sticky Columns And Head
           }
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -19034,7 +19594,7 @@ exports[`Storyshots Components/Table Table With Multiple Sticky Columns And Head
           }
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -19184,7 +19744,7 @@ exports[`Storyshots Components/Table Table With Single Action Column 1`] = `
           style={Object {}}
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -19259,7 +19819,7 @@ exports[`Storyshots Components/Table Table With Single Action Column 1`] = `
           style={Object {}}
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -19334,7 +19894,7 @@ exports[`Storyshots Components/Table Table With Single Action Column 1`] = `
           style={Object {}}
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -19409,7 +19969,7 @@ exports[`Storyshots Components/Table Table With Single Action Column 1`] = `
           style={Object {}}
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -19484,7 +20044,7 @@ exports[`Storyshots Components/Table Table With Single Action Column 1`] = `
           style={Object {}}
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -19559,7 +20119,7 @@ exports[`Storyshots Components/Table Table With Single Action Column 1`] = `
           style={Object {}}
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -19634,7 +20194,7 @@ exports[`Storyshots Components/Table Table With Single Action Column 1`] = `
           style={Object {}}
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -19709,7 +20269,7 @@ exports[`Storyshots Components/Table Table With Single Action Column 1`] = `
           style={Object {}}
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -19784,7 +20344,7 @@ exports[`Storyshots Components/Table Table With Single Action Column 1`] = `
           style={Object {}}
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -19859,7 +20419,7 @@ exports[`Storyshots Components/Table Table With Single Action Column 1`] = `
           style={Object {}}
         >
           <button
-            className="Button btn btn-outline-primary"
+            className="Button btn btn-outline-primary btn-md"
             disabled={false}
             type="button"
           >
@@ -21557,7 +22117,7 @@ exports[`Storyshots Components/Toast Default 1`] = `
       Click the button to see a toast message.  Use the knobs to try different types!
     </p>
     <button
-      className="Button btn btn-primary"
+      className="Button btn btn-primary btn-md"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -21585,7 +22145,7 @@ exports[`Storyshots Components/Toast Manual Dismiss Toast 1`] = `
       Click the button to see a toast message.  Use the knobs to try different types!
     </p>
     <button
-      className="Button btn btn-primary"
+      className="Button btn btn-primary btn-md"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -21613,7 +22173,7 @@ exports[`Storyshots Components/Toast Toast Custom Message 1`] = `
       Click the button to see a toast message.  Use the knobs to try different types!
     </p>
     <button
-      className="Button btn btn-primary"
+      className="Button btn btn-primary btn-md"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -21641,7 +22201,7 @@ exports[`Storyshots Components/Toast Toast With Action 1`] = `
       Click the button to see a toast message.  Use the knobs to try different types!
     </p>
     <button
-      className="Button btn btn-primary"
+      className="Button btn btn-primary btn-md"
       disabled={false}
       onClick={[Function]}
       type="button"

--- a/src/Button/Button.jsx
+++ b/src/Button/Button.jsx
@@ -8,6 +8,12 @@ import { Button as RBButton } from 'react-bootstrap';
 
 import './Button.scss';
 
+const BUTTON_SIZES = {
+  LARGE: 'lg',
+  MEDIUM: 'md',
+  SMALL: 'sm',
+};
+
 const Button = forwardRef(({
   children,
   className,
@@ -15,6 +21,7 @@ const Button = forwardRef(({
   isLoading,
   leadingIcon,
   loadingText,
+  size,
   trailingIcon,
   ...props
 }, ref) => (
@@ -23,6 +30,7 @@ const Button = forwardRef(({
     className={classNames('Button', className)}
     disabled={disabled || isLoading}
     ref={ref}
+    size={size}
     {...props}
   >
     { !isLoading ? (
@@ -47,6 +55,7 @@ Button.propTypes = {
   isLoading: PropTypes.bool,
   leadingIcon: PropTypes.object,
   loadingText: PropTypes.string,
+  size: PropTypes.oneOf(Object.values(BUTTON_SIZES)),
   trailingIcon: PropTypes.object,
 };
 
@@ -57,6 +66,7 @@ Button.defaultProps = {
   isLoading: undefined,
   leadingIcon: undefined,
   loadingText: 'Loading...',
+  size: BUTTON_SIZES.MEDIUM,
   trailingIcon: undefined,
 };
 export default Button;

--- a/src/Button/Button.jsx
+++ b/src/Button/Button.jsx
@@ -8,7 +8,7 @@ import { Button as RBButton } from 'react-bootstrap';
 
 import './Button.scss';
 
-const BUTTON_SIZES = {
+export const BUTTON_SIZES = {
   LARGE: 'lg',
   MEDIUM: 'md',
   SMALL: 'sm',

--- a/src/Button/Button.scss
+++ b/src/Button/Button.scss
@@ -1,7 +1,6 @@
 @import '../../scss/theme';
 
 .Button {
-  //@include font-type-30--bold;
 
   i, svg {
     &.icon-left {

--- a/src/Button/Button.scss
+++ b/src/Button/Button.scss
@@ -1,7 +1,7 @@
 @import '../../scss/theme';
 
 .Button {
-  @include font-type-30--bold;
+  //@include font-type-30--bold;
 
   i, svg {
     &.icon-left {
@@ -28,15 +28,18 @@
 
   &.btn-sm {
     border-radius: $ux-border-radius;
-    padding: .188rem .5rem;
+    @include font-type-30--medium;
+    padding: 3px 10px;
   }
 
   &.btn-md {
-    padding: .438rem .75rem;
+    @include font-type-40--medium;
+    padding: 6px 12px;
   }
 
   &.btn-lg {
-    padding: .563rem 1rem;
+    @include font-type-50--medium;
+    padding: 9px 14px;
   }
 
   &.btn-primary {

--- a/src/Button/Button.scss
+++ b/src/Button/Button.scss
@@ -28,6 +28,15 @@
 
   &.btn-sm {
     border-radius: $ux-border-radius;
+    padding: .188rem .5rem;
+  }
+
+  &.btn-md {
+    padding: .438rem .75rem;
+  }
+
+  &.btn-lg {
+    padding: .563rem 1rem;
   }
 
   &.btn-primary {

--- a/src/Button/Buttons.stories.jsx
+++ b/src/Button/Buttons.stories.jsx
@@ -77,6 +77,34 @@ export const Primary = () => (
     >
       Confirm
     </Button>
+    {' '}
+    <Button
+      leadingIcon={faFileAlt}
+      size="lg"
+      trailingIcon={faCaretDown}
+      variant="primary"
+    >
+      Confirm
+    </Button>
+    {' '}
+    <Button
+      leadingIcon={faFileAlt}
+      size="lg"
+      trailingIcon={faCaretDown}
+      variant="outline-primary"
+    >
+      Confirm
+    </Button>
+    {' '}
+    <Button
+      disabled
+      leadingIcon={faFileAlt}
+      size="lg"
+      trailingIcon={faCaretDown}
+      variant="primary"
+    >
+      Confirm
+    </Button>
   </>
 );
 
@@ -132,6 +160,34 @@ export const Danger = () => (
       disabled
       leadingIcon={faFileAlt}
       size="md"
+      trailingIcon={faCaretDown}
+      variant="danger"
+    >
+      Delete
+    </Button>
+    {' '}
+    <Button
+      leadingIcon={faFileAlt}
+      size="lg"
+      trailingIcon={faCaretDown}
+      variant="danger"
+    >
+      Delete
+    </Button>
+    {' '}
+    <Button
+      leadingIcon={faFileAlt}
+      size="lg"
+      trailingIcon={faCaretDown}
+      variant="outline-danger"
+    >
+      Delete
+    </Button>
+    {' '}
+    <Button
+      disabled
+      leadingIcon={faFileAlt}
+      size="lg"
       trailingIcon={faCaretDown}
       variant="danger"
     >
@@ -197,6 +253,34 @@ export const Warning = () => (
     >
       Edit
     </Button>
+    {' '}
+    <Button
+      leadingIcon={faFileAlt}
+      size="lg"
+      trailingIcon={faCaretDown}
+      variant="warning"
+    >
+      Edit
+    </Button>
+    {' '}
+    <Button
+      leadingIcon={faFileAlt}
+      size="lg"
+      trailingIcon={faCaretDown}
+      variant="outline-warning"
+    >
+      Edit
+    </Button>
+    {' '}
+    <Button
+      disabled
+      leadingIcon={faFileAlt}
+      size="lg"
+      trailingIcon={faCaretDown}
+      variant="warning"
+    >
+      Edit
+    </Button>
   </>
 );
 
@@ -252,6 +336,34 @@ export const Transparent = () => (
       disabled
       leadingIcon={faFileAlt}
       size="md"
+      trailingIcon={faCaretDown}
+      variant="transparent"
+    >
+      Skip
+    </Button>
+    {' '}
+    <Button
+      leadingIcon={faFileAlt}
+      size="lg"
+      trailingIcon={faCaretDown}
+      variant="transparent"
+    >
+      Skip
+    </Button>
+    {' '}
+    <Button
+      leadingIcon={faFileAlt}
+      size="lg"
+      trailingIcon={faCaretDown}
+      variant="outline-transparent"
+    >
+      Skip
+    </Button>
+    {' '}
+    <Button
+      disabled
+      leadingIcon={faFileAlt}
+      size="lg"
       trailingIcon={faCaretDown}
       variant="transparent"
     >
@@ -465,6 +577,26 @@ export const Loading = () => (
       leadingIcon={faFileAlt}
       loadingText={text('loadingText')}
       size="md"
+      variant="outline-primary"
+    >
+      Confirm
+    </Button>
+    {' '}
+    <Button
+      isLoading={boolean('isLoading', true)}
+      leadingIcon={faFileAlt}
+      loadingText={text('loadingText')}
+      size="lg"
+      variant="primary"
+    >
+      Confirm
+    </Button>
+    {' '}
+    <Button
+      isLoading={boolean('isLoading', true)}
+      leadingIcon={faFileAlt}
+      loadingText={text('loadingText')}
+      size="lg"
       variant="outline-primary"
     >
       Confirm

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -1,3 +1,1 @@
-import Button from './Button';
-
-export default Button;
+export { default, BUTTON_SIZES } from './Button';

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import {
   AccordionToggle,
 } from 'src/Accordion';
 import { Alert, MessageTypes } from 'src/Alert';
-import Button from 'src/Button';
+import Button, { BUTTON_SIZES } from 'src/Button';
 import Avatar from 'src/Avatar';
 import Card, { CardSizes } from 'src/Card';
 import { CardStack } from 'src/CardStack';
@@ -95,6 +95,7 @@ export {
   AsyncCreatableSelect,
   bugsnagClient,
   Button,
+  BUTTON_SIZES,
   BUTTON_GROUP_ORIENTATIONS,
   Card,
   CardSizes,


### PR DESCRIPTION
closes #848 

![Screen Shot 2023-03-09 at 10 38 03 AM](https://user-images.githubusercontent.com/37383785/224123188-057e6cc1-96d0-4091-b0d3-8b2509022ee9.png)

"Explore how proposed button sizes impact usability and aesthetics of buttons in product, and create a new proposal for new button sizes. "

- exposes `large` Button variant
- updates Button typography for each size (small = `font-type-30--medium`, medium = `font-type-40--medium`, large = `font-type-50--medium`)
- updates padding and thus changing heights (`28px`, `36px`, `44px`) 

[Chromatic](https://62d040e741710e4f085e0647-qdqgjeugex.chromatic.com/?path=/story/components-button--primary)

Related to product design initiative: [Button size testing (2/2)](https://www.notion.so/user-interviews/Button-Size-Testing-2-2-18dd05c26d814b05bdcb91adfe7692c8)

Design reviewed ✅ 

"Status as of 03.08 We’ve reviewed the buttons created by Jason in chromatic. Next steps are to have Jason update buttons in product that don’t align with the DS (which involves updating button styling that relies on Bootstrap & up-sizing/down-sizing Buttons), review the sizing changes in-product together, and then make the changes."