### PR TITLE
add fa-fw to DropdownItem

### DIFF
--- a/src/Dropdown/DropdownItem.jsx
+++ b/src/Dropdown/DropdownItem.jsx
@@ -41,7 +41,7 @@ const DropdownItem = ({
     onClick={onClick}
     {...props}
   >
-    { leadingIcon && <FontAwesomeIcon className="icon-left" icon={leadingIcon} /> }
+    { leadingIcon && <FontAwesomeIcon className="icon-left fa-fw" icon={leadingIcon} /> }
     { children }
   </RBDropdown.Item>
   );
@@ -74,6 +74,9 @@ DropdownItem.propTypes = {
    */
   href: PropTypes.string,
   leadingIcon: PropTypes.object,
+  /**
+    Optional variant for controlling color and hover states (e.g. destructive actions)
+   */
   variant: PropTypes.oneOf(Object.values(DropdownItemVariants)),
   /**
     Callback fired when the menu item is clicked.


### PR DESCRIPTION
closes #889 

Pretty 💅 but realized not all icons are the same size and is important for [aligning fixed width](https://fontawesome.com/v4/examples/#:~:text=sufficient%20line%2Dheight.-,Fixed%20Width%20Icons,-View%20LESS%20View) all DropdownItems in a menu 

Before:

![Screen Shot 2023-04-03 at 2 45 54 PM](https://user-images.githubusercontent.com/37383785/229635231-e112fcd2-36b8-44cd-bc8d-9c999159623e.png)

After:

![Screen Shot 2023-04-03 at 2 46 20 PM](https://user-images.githubusercontent.com/37383785/229635246-650ef6b2-acf8-4523-8680-3970e4231682.png)
