### PR TITLE
Bug/746 fix asyncselect modal stories

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -9910,7 +9910,7 @@ exports[`Storyshots Components/Selects/Async Default 1`] = `
     >
       <span
         className="css-1f43avz-a11yText-A11yText"
-        id="react-select-4-live-region"
+        id="react-select-3-live-region"
       />
       <span
         aria-atomic="false"
@@ -9928,7 +9928,7 @@ exports[`Storyshots Components/Selects/Async Default 1`] = `
         >
           <div
             className=" css-177do1b-placeholder"
-            id="react-select-4-placeholder"
+            id="react-select-3-placeholder"
           >
             Select...
           </div>
@@ -9938,7 +9938,7 @@ exports[`Storyshots Components/Selects/Async Default 1`] = `
           >
             <input
               aria-autocomplete="list"
-              aria-describedby="react-select-4-placeholder"
+              aria-describedby="react-select-3-placeholder"
               aria-expanded={false}
               aria-haspopup={true}
               autoCapitalize="none"
@@ -10014,192 +10014,14 @@ exports[`Storyshots Components/Selects/Async In Modal 1`] = `
     }
   }
 >
-  <div
-    className="ReactModal__Overlay"
+  <button
+    className="Button btn btn-primary"
+    disabled={false}
     onClick={[Function]}
-    onMouseDown={[Function]}
-    style={
-      Object {
-        "backgroundColor": "rgba(255, 255, 255, 0.75)",
-        "bottom": 0,
-        "left": 0,
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
+    type="button"
   >
-    <div
-      aria-label="AsyncSelect in Modal"
-      aria-modal={true}
-      className="ReactModal__Content AsyncSelectInModal"
-      onClick={[Function]}
-      onKeyDown={[Function]}
-      onMouseDown={[Function]}
-      onMouseUp={[Function]}
-      role="dialog"
-      style={Object {}}
-      tabIndex="-1"
-    >
-      <header
-        className="ModalHeader"
-      >
-        <div
-          className="ModalHeader__heading"
-        >
-          <h1
-            className="ModalHeader__title"
-            id="in-modal-async-select"
-          >
-            In Modal AsyncSelect
-          </h1>
-        </div>
-        <button
-          aria-label="Close"
-          className="btn btn-sm btn-close"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-        />
-      </header>
-      <div
-        className="ModalBody"
-      >
-        <div
-          className="FormGroup"
-        >
-          <label
-            className="InputLabel"
-            htmlFor="in-modal-async-select"
-          >
-            In Modal async select
-          </label>
-          <div
-            className="AsyncSelect css-b62m3t-container"
-            onKeyDown={[Function]}
-          >
-            <span
-              className="css-1f43avz-a11yText-A11yText"
-              id="react-select-5-live-region"
-            />
-            <span
-              aria-atomic="false"
-              aria-live="polite"
-              aria-relevant="additions text"
-              className="css-1f43avz-a11yText-A11yText"
-            />
-            <div
-              className=" css-9435u6-control"
-              onMouseDown={[Function]}
-              onTouchEnd={[Function]}
-            >
-              <div
-                className=" css-1fdsijx-ValueContainer"
-              >
-                <div
-                  className=" css-177do1b-placeholder"
-                  id="react-select-5-placeholder"
-                >
-                  Select...
-                </div>
-                <div
-                  className=" css-qbdosj-Input"
-                  data-value=""
-                >
-                  <input
-                    aria-autocomplete="list"
-                    aria-describedby="react-select-5-placeholder"
-                    aria-expanded={false}
-                    aria-haspopup={true}
-                    autoCapitalize="none"
-                    autoComplete="off"
-                    autoCorrect="off"
-                    className=""
-                    disabled={false}
-                    id="in-modal-async-select"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    role="combobox"
-                    spellCheck="false"
-                    style={
-                      Object {
-                        "background": 0,
-                        "border": 0,
-                        "color": "inherit",
-                        "font": "inherit",
-                        "gridArea": "1 / 2",
-                        "label": "input",
-                        "margin": 0,
-                        "minWidth": "2px",
-                        "opacity": 1,
-                        "outline": 0,
-                        "padding": 0,
-                        "width": "100%",
-                      }
-                    }
-                    tabIndex={0}
-                    type="text"
-                    value=""
-                  />
-                </div>
-              </div>
-              <div
-                className=" css-1hb7zxy-IndicatorsContainer"
-              >
-                <span
-                  className=" css-1uei4ir-indicatorSeparator"
-                />
-                <div
-                  aria-hidden="true"
-                  className=" css-1r0gan2-indicatorContainer"
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                >
-                  <svg
-                    aria-hidden="true"
-                    className="css-tj5bde-Svg"
-                    focusable="false"
-                    height={20}
-                    viewBox="0 0 20 20"
-                    width={20}
-                  >
-                    <path
-                      d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                    />
-                  </svg>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="FormGroup__helper-text"
-          >
-            Select menu is able to overflow the Modal container
-          </div>
-        </div>
-      </div>
-      <div
-        className="ModalFooter"
-      >
-        <button
-          className="Button btn btn-transparent"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-        >
-          Cancel
-        </button>
-        <button
-          className="Button btn btn-primary"
-          disabled={false}
-          type="submit"
-        >
-          Confirm
-        </button>
-      </div>
-    </div>
-  </div>
+    Click to open modal
+  </button>
 </div>
 `;
 
@@ -10330,192 +10152,14 @@ exports[`Storyshots Components/Selects/AsyncCreatable In Modal 1`] = `
     }
   }
 >
-  <div
-    className="ReactModal__Overlay"
+  <button
+    className="Button btn btn-primary"
+    disabled={false}
     onClick={[Function]}
-    onMouseDown={[Function]}
-    style={
-      Object {
-        "backgroundColor": "rgba(255, 255, 255, 0.75)",
-        "bottom": 0,
-        "left": 0,
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
+    type="button"
   >
-    <div
-      aria-label="AsyncCreatableSelect in Modal"
-      aria-modal={true}
-      className="ReactModal__Content AsyncCreatableSelectInModal"
-      onClick={[Function]}
-      onKeyDown={[Function]}
-      onMouseDown={[Function]}
-      onMouseUp={[Function]}
-      role="dialog"
-      style={Object {}}
-      tabIndex="-1"
-    >
-      <header
-        className="ModalHeader"
-      >
-        <div
-          className="ModalHeader__heading"
-        >
-          <h1
-            className="ModalHeader__title"
-            id="in-modal-async-creatable-select"
-          >
-            In Modal AsyncCreatable select
-          </h1>
-        </div>
-        <button
-          aria-label="Close"
-          className="btn btn-sm btn-close"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-        />
-      </header>
-      <div
-        className="ModalBody"
-      >
-        <div
-          className="FormGroup"
-        >
-          <label
-            className="InputLabel"
-            htmlFor="in-modal-creatable-select"
-          >
-            In Modal AsyncCreatable select
-          </label>
-          <div
-            className="AsyncSelect css-b62m3t-container"
-            onKeyDown={[Function]}
-          >
-            <span
-              className="css-1f43avz-a11yText-A11yText"
-              id="react-select-3-live-region"
-            />
-            <span
-              aria-atomic="false"
-              aria-live="polite"
-              aria-relevant="additions text"
-              className="css-1f43avz-a11yText-A11yText"
-            />
-            <div
-              className=" css-9435u6-control"
-              onMouseDown={[Function]}
-              onTouchEnd={[Function]}
-            >
-              <div
-                className=" css-1fdsijx-ValueContainer"
-              >
-                <div
-                  className=" css-177do1b-placeholder"
-                  id="react-select-3-placeholder"
-                >
-                  Select...
-                </div>
-                <div
-                  className=" css-qbdosj-Input"
-                  data-value=""
-                >
-                  <input
-                    aria-autocomplete="list"
-                    aria-describedby="react-select-3-placeholder"
-                    aria-expanded={false}
-                    aria-haspopup={true}
-                    autoCapitalize="none"
-                    autoComplete="off"
-                    autoCorrect="off"
-                    className=""
-                    disabled={false}
-                    id="in-modal-creatable-select"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    role="combobox"
-                    spellCheck="false"
-                    style={
-                      Object {
-                        "background": 0,
-                        "border": 0,
-                        "color": "inherit",
-                        "font": "inherit",
-                        "gridArea": "1 / 2",
-                        "label": "input",
-                        "margin": 0,
-                        "minWidth": "2px",
-                        "opacity": 1,
-                        "outline": 0,
-                        "padding": 0,
-                        "width": "100%",
-                      }
-                    }
-                    tabIndex={0}
-                    type="text"
-                    value=""
-                  />
-                </div>
-              </div>
-              <div
-                className=" css-1hb7zxy-IndicatorsContainer"
-              >
-                <span
-                  className=" css-1uei4ir-indicatorSeparator"
-                />
-                <div
-                  aria-hidden="true"
-                  className=" css-1r0gan2-indicatorContainer"
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                >
-                  <svg
-                    aria-hidden="true"
-                    className="css-tj5bde-Svg"
-                    focusable="false"
-                    height={20}
-                    viewBox="0 0 20 20"
-                    width={20}
-                  >
-                    <path
-                      d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                    />
-                  </svg>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="FormGroup__helper-text"
-          >
-            Select menu is able to overflow the Modal container
-          </div>
-        </div>
-      </div>
-      <div
-        className="ModalFooter"
-      >
-        <button
-          className="Button btn btn-transparent"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-        >
-          Cancel
-        </button>
-        <button
-          className="Button btn btn-primary"
-          disabled={false}
-          type="submit"
-        >
-          Confirm
-        </button>
-      </div>
-    </div>
-  </div>
+    Click to open modal
+  </button>
 </div>
 `;
 
@@ -10542,7 +10186,7 @@ exports[`Storyshots Components/Selects/Creatable Default 1`] = `
     >
       <span
         className="css-1f43avz-a11yText-A11yText"
-        id="react-select-6-live-region"
+        id="react-select-4-live-region"
       />
       <span
         aria-atomic="false"
@@ -10560,7 +10204,7 @@ exports[`Storyshots Components/Selects/Creatable Default 1`] = `
         >
           <div
             className=" css-177do1b-placeholder"
-            id="react-select-6-placeholder"
+            id="react-select-4-placeholder"
           >
             Select...
           </div>
@@ -10570,7 +10214,7 @@ exports[`Storyshots Components/Selects/Creatable Default 1`] = `
           >
             <input
               aria-autocomplete="list"
-              aria-describedby="react-select-6-placeholder"
+              aria-describedby="react-select-4-placeholder"
               aria-expanded={false}
               aria-haspopup={true}
               autoCapitalize="none"
@@ -10646,192 +10290,14 @@ exports[`Storyshots Components/Selects/Creatable In Modal 1`] = `
     }
   }
 >
-  <div
-    className="ReactModal__Overlay"
+  <button
+    className="Button btn btn-primary"
+    disabled={false}
     onClick={[Function]}
-    onMouseDown={[Function]}
-    style={
-      Object {
-        "backgroundColor": "rgba(255, 255, 255, 0.75)",
-        "bottom": 0,
-        "left": 0,
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
+    type="button"
   >
-    <div
-      aria-label="CreatableSelect in Modal"
-      aria-modal={true}
-      className="ReactModal__Content CreatableSelectInModal"
-      onClick={[Function]}
-      onKeyDown={[Function]}
-      onMouseDown={[Function]}
-      onMouseUp={[Function]}
-      role="dialog"
-      style={Object {}}
-      tabIndex="-1"
-    >
-      <header
-        className="ModalHeader"
-      >
-        <div
-          className="ModalHeader__heading"
-        >
-          <h1
-            className="ModalHeader__title"
-            id="in-modal-creatable-select"
-          >
-            In Modal creatable select
-          </h1>
-        </div>
-        <button
-          aria-label="Close"
-          className="btn btn-sm btn-close"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-        />
-      </header>
-      <div
-        className="ModalBody"
-      >
-        <div
-          className="FormGroup"
-        >
-          <label
-            className="InputLabel"
-            htmlFor="in-modal-creatable-select"
-          >
-            In Modal creatable select
-          </label>
-          <div
-            className="CreatableSelect css-b62m3t-container"
-            onKeyDown={[Function]}
-          >
-            <span
-              className="css-1f43avz-a11yText-A11yText"
-              id="react-select-7-live-region"
-            />
-            <span
-              aria-atomic="false"
-              aria-live="polite"
-              aria-relevant="additions text"
-              className="css-1f43avz-a11yText-A11yText"
-            />
-            <div
-              className=" css-9435u6-control"
-              onMouseDown={[Function]}
-              onTouchEnd={[Function]}
-            >
-              <div
-                className=" css-1fdsijx-ValueContainer"
-              >
-                <div
-                  className=" css-177do1b-placeholder"
-                  id="react-select-7-placeholder"
-                >
-                  Select...
-                </div>
-                <div
-                  className=" css-qbdosj-Input"
-                  data-value=""
-                >
-                  <input
-                    aria-autocomplete="list"
-                    aria-describedby="react-select-7-placeholder"
-                    aria-expanded={false}
-                    aria-haspopup={true}
-                    autoCapitalize="none"
-                    autoComplete="off"
-                    autoCorrect="off"
-                    className=""
-                    disabled={false}
-                    id="in-modal-creatable-select"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    role="combobox"
-                    spellCheck="false"
-                    style={
-                      Object {
-                        "background": 0,
-                        "border": 0,
-                        "color": "inherit",
-                        "font": "inherit",
-                        "gridArea": "1 / 2",
-                        "label": "input",
-                        "margin": 0,
-                        "minWidth": "2px",
-                        "opacity": 1,
-                        "outline": 0,
-                        "padding": 0,
-                        "width": "100%",
-                      }
-                    }
-                    tabIndex={0}
-                    type="text"
-                    value=""
-                  />
-                </div>
-              </div>
-              <div
-                className=" css-1hb7zxy-IndicatorsContainer"
-              >
-                <span
-                  className=" css-1uei4ir-indicatorSeparator"
-                />
-                <div
-                  aria-hidden="true"
-                  className=" css-1r0gan2-indicatorContainer"
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                >
-                  <svg
-                    aria-hidden="true"
-                    className="css-tj5bde-Svg"
-                    focusable="false"
-                    height={20}
-                    viewBox="0 0 20 20"
-                    width={20}
-                  >
-                    <path
-                      d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                    />
-                  </svg>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="FormGroup__helper-text"
-          >
-            Select menu is able to overflow the Modal container
-          </div>
-        </div>
-      </div>
-      <div
-        className="ModalFooter"
-      >
-        <button
-          className="Button btn btn-transparent"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-        >
-          Cancel
-        </button>
-        <button
-          className="Button btn btn-primary"
-          disabled={false}
-          type="submit"
-        >
-          Confirm
-        </button>
-      </div>
-    </div>
-  </div>
+    Click to open modal
+  </button>
 </div>
 `;
 
@@ -10858,7 +10324,7 @@ exports[`Storyshots Components/Selects/Single Custom Option With Checkbox 1`] = 
     >
       <span
         className="css-1f43avz-a11yText-A11yText"
-        id="react-select-8-live-region"
+        id="react-select-5-live-region"
       />
       <span
         aria-atomic="false"
@@ -10876,13 +10342,13 @@ exports[`Storyshots Components/Selects/Single Custom Option With Checkbox 1`] = 
         >
           <div
             className=" css-177do1b-placeholder"
-            id="react-select-8-placeholder"
+            id="react-select-5-placeholder"
           >
             Select...
           </div>
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-8-placeholder"
+            aria-describedby="react-select-5-placeholder"
             aria-expanded={false}
             aria-haspopup={true}
             aria-readonly={true}
@@ -10953,7 +10419,7 @@ exports[`Storyshots Components/Selects/Single Custom Option With Description 1`]
     >
       <span
         className="css-1f43avz-a11yText-A11yText"
-        id="react-select-9-live-region"
+        id="react-select-6-live-region"
       />
       <span
         aria-atomic="false"
@@ -10971,13 +10437,13 @@ exports[`Storyshots Components/Selects/Single Custom Option With Description 1`]
         >
           <div
             className=" css-177do1b-placeholder"
-            id="react-select-9-placeholder"
+            id="react-select-6-placeholder"
           >
             Select...
           </div>
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-9-placeholder"
+            aria-describedby="react-select-6-placeholder"
             aria-expanded={false}
             aria-haspopup={true}
             aria-readonly={true}
@@ -11048,7 +10514,7 @@ exports[`Storyshots Components/Selects/Single Custom Option With Indeterminate C
     >
       <span
         className="css-1f43avz-a11yText-A11yText"
-        id="react-select-10-live-region"
+        id="react-select-7-live-region"
       />
       <span
         aria-atomic="false"
@@ -11066,13 +10532,13 @@ exports[`Storyshots Components/Selects/Single Custom Option With Indeterminate C
         >
           <div
             className=" css-177do1b-placeholder"
-            id="react-select-10-placeholder"
+            id="react-select-7-placeholder"
           >
             Select...
           </div>
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-10-placeholder"
+            aria-describedby="react-select-7-placeholder"
             aria-expanded={false}
             aria-haspopup={true}
             aria-readonly={true}
@@ -11143,7 +10609,7 @@ exports[`Storyshots Components/Selects/Single Custom Value Container 1`] = `
     >
       <span
         className="css-1f43avz-a11yText-A11yText"
-        id="react-select-11-live-region"
+        id="react-select-8-live-region"
       />
       <span
         aria-atomic="false"
@@ -11161,13 +10627,13 @@ exports[`Storyshots Components/Selects/Single Custom Value Container 1`] = `
         >
           <div
             className=" css-177do1b-placeholder"
-            id="react-select-11-placeholder"
+            id="react-select-8-placeholder"
           >
             Select...
           </div>
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-11-placeholder"
+            aria-describedby="react-select-8-placeholder"
             aria-expanded={false}
             aria-haspopup={true}
             aria-readonly={true}
@@ -11238,7 +10704,7 @@ exports[`Storyshots Components/Selects/Single Default 1`] = `
     >
       <span
         className="css-1f43avz-a11yText-A11yText"
-        id="react-select-12-live-region"
+        id="react-select-9-live-region"
       />
       <span
         aria-atomic="false"
@@ -11256,13 +10722,13 @@ exports[`Storyshots Components/Selects/Single Default 1`] = `
         >
           <div
             className=" css-177do1b-placeholder"
-            id="react-select-12-placeholder"
+            id="react-select-9-placeholder"
           >
             Select...
           </div>
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-12-placeholder"
+            aria-describedby="react-select-9-placeholder"
             aria-expanded={false}
             aria-haspopup={true}
             aria-readonly={true}
@@ -11333,7 +10799,7 @@ exports[`Storyshots Components/Selects/Single Grouped Options 1`] = `
     >
       <span
         className="css-1f43avz-a11yText-A11yText"
-        id="react-select-13-live-region"
+        id="react-select-10-live-region"
       />
       <span
         aria-atomic="false"
@@ -11351,13 +10817,13 @@ exports[`Storyshots Components/Selects/Single Grouped Options 1`] = `
         >
           <div
             className=" css-177do1b-placeholder"
-            id="react-select-13-placeholder"
+            id="react-select-10-placeholder"
           >
             Select...
           </div>
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-13-placeholder"
+            aria-describedby="react-select-10-placeholder"
             aria-expanded={false}
             aria-haspopup={true}
             aria-readonly={true}
@@ -11413,168 +10879,14 @@ exports[`Storyshots Components/Selects/Single In Modal 1`] = `
     }
   }
 >
-  <div
-    className="ReactModal__Overlay"
+  <button
+    className="Button btn btn-primary"
+    disabled={false}
     onClick={[Function]}
-    onMouseDown={[Function]}
-    style={
-      Object {
-        "backgroundColor": "rgba(255, 255, 255, 0.75)",
-        "bottom": 0,
-        "left": 0,
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
+    type="button"
   >
-    <div
-      aria-label="Select in Modal"
-      aria-modal={true}
-      className="ReactModal__Content SelectInModal"
-      onClick={[Function]}
-      onKeyDown={[Function]}
-      onMouseDown={[Function]}
-      onMouseUp={[Function]}
-      role="dialog"
-      style={Object {}}
-      tabIndex="-1"
-    >
-      <header
-        className="ModalHeader"
-      >
-        <div
-          className="ModalHeader__heading"
-        >
-          <h1
-            className="ModalHeader__title"
-            id="select-in-modal"
-          >
-            Select in modal
-          </h1>
-        </div>
-        <button
-          aria-label="Close"
-          className="btn btn-sm btn-close"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-        />
-      </header>
-      <div
-        className="ModalBody"
-      >
-        <div
-          className="FormGroup"
-        >
-          <label
-            className="InputLabel"
-            htmlFor="in-modal-select"
-          >
-            In Modal select
-          </label>
-          <div
-            className="SingleSelect css-b62m3t-container"
-            onKeyDown={[Function]}
-          >
-            <span
-              className="css-1f43avz-a11yText-A11yText"
-              id="react-select-14-live-region"
-            />
-            <span
-              aria-atomic="false"
-              aria-live="polite"
-              aria-relevant="additions text"
-              className="css-1f43avz-a11yText-A11yText"
-            />
-            <div
-              className=" css-9435u6-control"
-              onMouseDown={[Function]}
-              onTouchEnd={[Function]}
-            >
-              <div
-                className=" css-1fdsijx-ValueContainer"
-              >
-                <div
-                  className=" css-177do1b-placeholder"
-                  id="react-select-14-placeholder"
-                >
-                  Select...
-                </div>
-                <input
-                  aria-autocomplete="list"
-                  aria-describedby="react-select-14-placeholder"
-                  aria-expanded={false}
-                  aria-haspopup={true}
-                  aria-readonly={true}
-                  className="css-mohuvp-dummyInput-DummyInput"
-                  disabled={false}
-                  id="in-modal-select"
-                  inputMode="none"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  role="combobox"
-                  tabIndex={0}
-                  value=""
-                />
-              </div>
-              <div
-                className=" css-1hb7zxy-IndicatorsContainer"
-              >
-                <span
-                  className=" css-1uei4ir-indicatorSeparator"
-                />
-                <div
-                  aria-hidden="true"
-                  className=" css-1r0gan2-indicatorContainer"
-                  onMouseDown={[Function]}
-                  onTouchEnd={[Function]}
-                >
-                  <svg
-                    aria-hidden="true"
-                    className="css-tj5bde-Svg"
-                    focusable="false"
-                    height={20}
-                    viewBox="0 0 20 20"
-                    width={20}
-                  >
-                    <path
-                      d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                    />
-                  </svg>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="FormGroup__helper-text"
-          >
-            Select menu is able to overflow the Modal container
-          </div>
-        </div>
-      </div>
-      <div
-        className="ModalFooter"
-      >
-        <button
-          className="Button btn btn-transparent"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-        >
-          Cancel
-        </button>
-        <button
-          className="Button btn btn-primary"
-          disabled={false}
-          type="submit"
-        >
-          Confirm
-        </button>
-      </div>
-    </div>
-  </div>
+    Click to open modal
+  </button>
 </div>
 `;
 
@@ -11601,7 +10913,7 @@ exports[`Storyshots Components/Selects/Single Loading 1`] = `
     >
       <span
         className="css-1f43avz-a11yText-A11yText"
-        id="react-select-15-live-region"
+        id="react-select-11-live-region"
       />
       <span
         aria-atomic="false"
@@ -11619,13 +10931,13 @@ exports[`Storyshots Components/Selects/Single Loading 1`] = `
         >
           <div
             className=" css-177do1b-placeholder"
-            id="react-select-15-placeholder"
+            id="react-select-11-placeholder"
           >
             Select...
           </div>
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-15-placeholder"
+            aria-describedby="react-select-11-placeholder"
             aria-expanded={false}
             aria-haspopup={true}
             aria-readonly={true}
@@ -11696,7 +11008,7 @@ exports[`Storyshots Components/Selects/Single Multiple Select 1`] = `
     >
       <span
         className="css-1f43avz-a11yText-A11yText"
-        id="react-select-16-live-region"
+        id="react-select-12-live-region"
       />
       <span
         aria-atomic="false"
@@ -11714,13 +11026,13 @@ exports[`Storyshots Components/Selects/Single Multiple Select 1`] = `
         >
           <div
             className=" css-177do1b-placeholder"
-            id="react-select-16-placeholder"
+            id="react-select-12-placeholder"
           >
             Select...
           </div>
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-16-placeholder"
+            aria-describedby="react-select-12-placeholder"
             aria-expanded={false}
             aria-haspopup={true}
             aria-readonly={true}
@@ -11791,7 +11103,7 @@ exports[`Storyshots Components/Selects/Single Searchable 1`] = `
     >
       <span
         className="css-1f43avz-a11yText-A11yText"
-        id="react-select-17-live-region"
+        id="react-select-13-live-region"
       />
       <span
         aria-atomic="false"
@@ -11809,7 +11121,7 @@ exports[`Storyshots Components/Selects/Single Searchable 1`] = `
         >
           <div
             className=" css-177do1b-placeholder"
-            id="react-select-17-placeholder"
+            id="react-select-13-placeholder"
           >
             Select...
           </div>
@@ -11819,7 +11131,7 @@ exports[`Storyshots Components/Selects/Single Searchable 1`] = `
           >
             <input
               aria-autocomplete="list"
-              aria-describedby="react-select-17-placeholder"
+              aria-describedby="react-select-13-placeholder"
               aria-expanded={false}
               aria-haspopup={true}
               autoCapitalize="none"

--- a/src/Select/AsyncCreatableSelect.stories.jsx
+++ b/src/Select/AsyncCreatableSelect.stories.jsx
@@ -1,89 +1,100 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 
 import AsyncCreatableSelect from 'src/Select/AsyncCreatableSelect';
 import Button from 'src/Button';
 import FormGroup from 'src/FormGroup';
 import {
-  Modal, ModalHeader, ModalBody, ModalFooter,
- } from 'src/Modal';
+    Modal, ModalHeader, ModalBody, ModalFooter,
+} from 'src/Modal';
 
 export default {
-  title: 'Components/Selects/AsyncCreatable',
-  component: AsyncCreatableSelect,
+    title: 'Components/Selects/AsyncCreatable',
+    component: AsyncCreatableSelect,
 };
 
 const options = [
-  { label: 'Red', value: 1 },
-  { label: 'Green', value: 2 },
-  { label: 'Blue', value: 3 },
+    { label: 'Red', value: 1 },
+    { label: 'Green', value: 2 },
+    { label: 'Blue', value: 3 },
 ];
 
-const handleRequestClose = () => action('Close');
-
 async function loadOptions(search) {
-  await new Promise((resolve) => setTimeout(resolve, 2000));
+    await new Promise((resolve) => setTimeout(resolve, 2000));
 
-  if (!search || !search.length) { return options; }
+    if (!search || !search.length) {
+        return options;
+    }
 
-  return options.filter(({ label }) => label.toLowerCase().includes(search.toLowerCase()));
+    return options.filter(({ label }) => label.toLowerCase().includes(search.toLowerCase()));
 }
 
 export const Default = () => {
-  const handleChange = () => {};
-  const handleInputChange = () => {};
+    const handleChange = () => {
+    };
+    const handleInputChange = () => {
+    };
 
-  return (
-    <FormGroup
-      label="Default async creatable select"
-      labelHtmlFor="default-async-creatable-select"
-    >
-      <AsyncCreatableSelect
-        getOptionLabel={({ label }) => label}
-        getOptionValue={({ value }) => value}
-        inputId="default-async-creatable-select"
-        isClearable
-        loadOptions={loadOptions}
-        onChange={handleChange}
-        onInputChange={handleInputChange}
-      />
-    </FormGroup>
-  );
-};
-
-export const InModal = () => (
-  <Modal
-    ariaHideApp={false}
-    className="AsyncCreatableSelectInModal"
-    contentLabel="AsyncCreatableSelect in Modal"
-    isOpen
-  >
-    <ModalHeader
-      title="In Modal AsyncCreatable select"
-      titleId="in-modal-async-creatable-select"
-      onRequestClose={handleRequestClose}
-    />
-    <ModalBody>
+    return (
       <FormGroup
-        helperText="Select menu is able to overflow the Modal container"
-        label="In Modal AsyncCreatable select"
-        labelHtmlFor="in-modal-creatable-select"
+        label="Default async creatable select"
+        labelHtmlFor="default-async-creatable-select"
       >
         <AsyncCreatableSelect
           getOptionLabel={({ label }) => label}
           getOptionValue={({ value }) => value}
-          inputId="in-modal-creatable-select"
+          inputId="default-async-creatable-select"
+          isClearable
           loadOptions={loadOptions}
-          modal
-          noOptionsMessage={({ inputValue }) => inputValue.length ? 'No results!' : 'Type to search...'}
+          onChange={handleChange}
+          onInputChange={handleInputChange}
         />
       </FormGroup>
-    </ModalBody>
-    <ModalFooter
-      dismissButtonText="Cancel"
-      onRequestClose={handleRequestClose}
-    >
-      <Button type="submit" variant="primary">Confirm</Button>
-    </ModalFooter>
-  </Modal>
-  );
+    );
+};
+
+export const InModal = () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const handleRequestClose = () => setIsOpen(false);
+
+    return (
+      <>
+        <Button onClick={() => setIsOpen(true)}>Click to open modal</Button>
+        <Modal
+          ariaHideApp={false}
+          className="AsyncCreatableSelectInModal"
+          contentLabel="AsyncCreatableSelect in Modal"
+          isOpen={isOpen}
+        >
+          <ModalHeader
+            title="In Modal AsyncCreatable select"
+            titleId="in-modal-async-creatable-select"
+            onRequestClose={handleRequestClose}
+          />
+          <ModalBody>
+            <FormGroup
+              helperText="Select menu is able to overflow the Modal container"
+              label="In Modal AsyncCreatable select"
+              labelHtmlFor="in-modal-creatable-select"
+            >
+              <AsyncCreatableSelect
+                getOptionLabel={({ label }) => label}
+                getOptionValue={({ value }) => value}
+                inputId="in-modal-creatable-select"
+                loadOptions={loadOptions}
+                modal
+                noOptionsMessage={({ inputValue }) => inputValue.length ? 'No results!' : 'Type to search...'}
+              />
+            </FormGroup>
+          </ModalBody>
+          <ModalFooter
+            dismissButtonText="Cancel"
+            onRequestClose={handleRequestClose}
+          >
+            <Button type="submit" variant="primary">Confirm</Button>
+          </ModalFooter>
+        </Modal>
+      </>
+    );
+};

--- a/src/Select/AsyncCreatableSelect.stories.jsx
+++ b/src/Select/AsyncCreatableSelect.stories.jsx
@@ -5,96 +5,96 @@ import AsyncCreatableSelect from 'src/Select/AsyncCreatableSelect';
 import Button from 'src/Button';
 import FormGroup from 'src/FormGroup';
 import {
-    Modal, ModalHeader, ModalBody, ModalFooter,
+  Modal, ModalHeader, ModalBody, ModalFooter,
 } from 'src/Modal';
 
 export default {
-    title: 'Components/Selects/AsyncCreatable',
-    component: AsyncCreatableSelect,
+  title: 'Components/Selects/AsyncCreatable',
+  component: AsyncCreatableSelect,
 };
 
 const options = [
-    { label: 'Red', value: 1 },
-    { label: 'Green', value: 2 },
-    { label: 'Blue', value: 3 },
+  { label: 'Red', value: 1 },
+  { label: 'Green', value: 2 },
+  { label: 'Blue', value: 3 },
 ];
 
 async function loadOptions(search) {
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+  await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    if (!search || !search.length) {
-        return options;
-    }
+  if (!search || !search.length) {
+    return options;
+  }
 
-    return options.filter(({ label }) => label.toLowerCase().includes(search.toLowerCase()));
+  return options.filter(({ label }) => label.toLowerCase().includes(search.toLowerCase()));
 }
 
 export const Default = () => {
-    const handleChange = () => {
-    };
-    const handleInputChange = () => {
-    };
+  const handleChange = () => {
+  };
+  const handleInputChange = () => {
+  };
 
-    return (
-      <FormGroup
-        label="Default async creatable select"
-        labelHtmlFor="default-async-creatable-select"
-      >
-        <AsyncCreatableSelect
-          getOptionLabel={({ label }) => label}
-          getOptionValue={({ value }) => value}
-          inputId="default-async-creatable-select"
-          isClearable
-          loadOptions={loadOptions}
-          onChange={handleChange}
-          onInputChange={handleInputChange}
-        />
-      </FormGroup>
-    );
+  return (
+    <FormGroup
+      label="Default async creatable select"
+      labelHtmlFor="default-async-creatable-select"
+    >
+      <AsyncCreatableSelect
+        getOptionLabel={({ label }) => label}
+        getOptionValue={({ value }) => value}
+        inputId="default-async-creatable-select"
+        isClearable
+        loadOptions={loadOptions}
+        onChange={handleChange}
+        onInputChange={handleInputChange}
+      />
+    </FormGroup>
+  );
 };
 
 export const InModal = () => {
-    const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
 
-    const handleRequestClose = () => setIsOpen(false);
+  const handleRequestClose = () => setIsOpen(false);
 
-    return (
-      <>
-        <Button onClick={() => setIsOpen(true)}>Click to open modal</Button>
-        <Modal
-          ariaHideApp={false}
-          className="AsyncCreatableSelectInModal"
-          contentLabel="AsyncCreatableSelect in Modal"
-          isOpen={isOpen}
-        >
-          <ModalHeader
-            title="In Modal AsyncCreatable select"
-            titleId="in-modal-async-creatable-select"
-            onRequestClose={handleRequestClose}
-          />
-          <ModalBody>
-            <FormGroup
-              helperText="Select menu is able to overflow the Modal container"
-              label="In Modal AsyncCreatable select"
-              labelHtmlFor="in-modal-creatable-select"
-            >
-              <AsyncCreatableSelect
-                getOptionLabel={({ label }) => label}
-                getOptionValue={({ value }) => value}
-                inputId="in-modal-creatable-select"
-                loadOptions={loadOptions}
-                modal
-                noOptionsMessage={({ inputValue }) => inputValue.length ? 'No results!' : 'Type to search...'}
-              />
-            </FormGroup>
-          </ModalBody>
-          <ModalFooter
-            dismissButtonText="Cancel"
-            onRequestClose={handleRequestClose}
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Click to open modal</Button>
+      <Modal
+        ariaHideApp={false}
+        className="AsyncCreatableSelectInModal"
+        contentLabel="AsyncCreatableSelect in Modal"
+        isOpen={isOpen}
+      >
+        <ModalHeader
+          title="In Modal AsyncCreatable select"
+          titleId="in-modal-async-creatable-select"
+          onRequestClose={handleRequestClose}
+        />
+        <ModalBody>
+          <FormGroup
+            helperText="Select menu is able to overflow the Modal container"
+            label="In Modal AsyncCreatable select"
+            labelHtmlFor="in-modal-creatable-select"
           >
-            <Button type="submit" variant="primary">Confirm</Button>
-          </ModalFooter>
-        </Modal>
-      </>
-    );
+            <AsyncCreatableSelect
+              getOptionLabel={({ label }) => label}
+              getOptionValue={({ value }) => value}
+              inputId="in-modal-creatable-select"
+              loadOptions={loadOptions}
+              modal
+              noOptionsMessage={({ inputValue }) => inputValue.length ? 'No results!' : 'Type to search...'}
+            />
+          </FormGroup>
+        </ModalBody>
+        <ModalFooter
+          dismissButtonText="Cancel"
+          onRequestClose={handleRequestClose}
+        >
+          <Button type="submit" variant="primary">Confirm</Button>
+        </ModalFooter>
+      </Modal>
+    </>
+  );
 };

--- a/src/Select/AsyncCreatableSelect.stories.jsx
+++ b/src/Select/AsyncCreatableSelect.stories.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { action } from '@storybook/addon-actions';
 
 import AsyncCreatableSelect from 'src/Select/AsyncCreatableSelect';
 import Button from 'src/Button';

--- a/src/Select/AsyncSelect.stories.jsx
+++ b/src/Select/AsyncSelect.stories.jsx
@@ -1,35 +1,34 @@
-import React from 'react';
-import { action } from '@storybook/addon-actions';
+import React, { useState } from 'react';
 
 import AsyncSelect from 'src/Select/AsyncSelect';
 import Button from 'src/Button';
 import FormGroup from 'src/FormGroup';
 import {
-  Modal, ModalHeader, ModalBody, ModalFooter,
- } from 'src/Modal';
+    Modal, ModalHeader, ModalBody, ModalFooter,
+} from 'src/Modal';
 
 export default {
-  title: 'Components/Selects/Async',
-  component: AsyncSelect,
+    title: 'Components/Selects/Async',
+    component: AsyncSelect,
 };
 
 const options = [
-  { label: 'Bob', value: 1 },
-  { label: 'Dave', value: 2 },
-  { label: 'Jeff', value: 3 },
-  { label: 'Dennis', value: 4 },
-  { label: 'Basel', value: 5 },
+    { label: 'Bob', value: 1 },
+    { label: 'Dave', value: 2 },
+    { label: 'Jeff', value: 3 },
+    { label: 'Dennis', value: 4 },
+    { label: 'Basel', value: 5 },
 ];
 
 async function loadOptions(search) {
-  await new Promise((resolve) => setTimeout(resolve, 2000));
+    await new Promise((resolve) => setTimeout(resolve, 2000));
 
-  if (!search || !search.length) { return options; }
+    if (!search || !search.length) {
+        return options;
+    }
 
-  return options.filter(({ label }) => label.toLowerCase().includes(search.toLowerCase()));
+    return options.filter(({ label }) => label.toLowerCase().includes(search.toLowerCase()));
 }
-
-const handleRequestClose = () => action('Close');
 
 export const Default = () => (
   <FormGroup
@@ -46,39 +45,48 @@ export const Default = () => (
   </FormGroup>
 );
 
-export const InModal = () => (
-  <Modal
-    ariaHideApp={false}
-    className="AsyncSelectInModal"
-    contentLabel="AsyncSelect in Modal"
-    isOpen
-  >
-    <ModalHeader
-      title="In Modal AsyncSelect"
-      titleId="in-modal-async-select"
-      onRequestClose={handleRequestClose}
-    />
-    <ModalBody>
-      <FormGroup
-        helperText="Select menu is able to overflow the Modal container"
-        label="In Modal async select"
-        labelHtmlFor="in-modal-async-select"
-      >
-        <AsyncSelect
-          getOptionLabel={({ label }) => label}
-          getOptionValue={({ value }) => value}
-          inputId="in-modal-async-select"
-          loadOptions={loadOptions}
-          modal
-          noOptionsMessage={({ inputValue }) => inputValue.length ? 'No results!' : 'Type to search...'}
-        />
-      </FormGroup>
-    </ModalBody>
-    <ModalFooter
-      dismissButtonText="Cancel"
-      onRequestClose={handleRequestClose}
-    >
-      <Button type="submit" variant="primary">Confirm</Button>
-    </ModalFooter>
-  </Modal>
-  );
+export const InModal = () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const handleRequestClose = () => setIsOpen(false);
+
+    return (
+      <>
+        <Button onClick={() => setIsOpen(true)}>Click to open modal</Button>
+        <Modal
+          ariaHideApp={false}
+          className="AsyncSelectInModal"
+          contentLabel="AsyncSelect in Modal"
+          isOpen={isOpen}
+        >
+          <ModalHeader
+            title="In Modal AsyncSelect"
+            titleId="in-modal-async-select"
+            onRequestClose={handleRequestClose}
+          />
+          <ModalBody>
+            <FormGroup
+              helperText="Select menu is able to overflow the Modal container"
+              label="In Modal async select"
+              labelHtmlFor="in-modal-async-select"
+            >
+              <AsyncSelect
+                getOptionLabel={({ label }) => label}
+                getOptionValue={({ value }) => value}
+                inputId="in-modal-async-select"
+                loadOptions={loadOptions}
+                modal
+                noOptionsMessage={({ inputValue }) => inputValue.length ? 'No results!' : 'Type to search...'}
+              />
+            </FormGroup>
+          </ModalBody>
+          <ModalFooter
+            dismissButtonText="Cancel"
+            onRequestClose={handleRequestClose}
+          >
+            <Button type="submit" variant="primary">Confirm</Button>
+          </ModalFooter>
+        </Modal>
+      </>
+    );
+};

--- a/src/Select/AsyncSelect.stories.jsx
+++ b/src/Select/AsyncSelect.stories.jsx
@@ -4,30 +4,30 @@ import AsyncSelect from 'src/Select/AsyncSelect';
 import Button from 'src/Button';
 import FormGroup from 'src/FormGroup';
 import {
-    Modal, ModalHeader, ModalBody, ModalFooter,
+  Modal, ModalHeader, ModalBody, ModalFooter,
 } from 'src/Modal';
 
 export default {
-    title: 'Components/Selects/Async',
-    component: AsyncSelect,
+  title: 'Components/Selects/Async',
+  component: AsyncSelect,
 };
 
 const options = [
-    { label: 'Bob', value: 1 },
-    { label: 'Dave', value: 2 },
-    { label: 'Jeff', value: 3 },
-    { label: 'Dennis', value: 4 },
-    { label: 'Basel', value: 5 },
+  { label: 'Bob', value: 1 },
+  { label: 'Dave', value: 2 },
+  { label: 'Jeff', value: 3 },
+  { label: 'Dennis', value: 4 },
+  { label: 'Basel', value: 5 },
 ];
 
 async function loadOptions(search) {
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+  await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    if (!search || !search.length) {
-        return options;
-    }
+  if (!search || !search.length) {
+    return options;
+  }
 
-    return options.filter(({ label }) => label.toLowerCase().includes(search.toLowerCase()));
+  return options.filter(({ label }) => label.toLowerCase().includes(search.toLowerCase()));
 }
 
 export const Default = () => (
@@ -46,47 +46,47 @@ export const Default = () => (
 );
 
 export const InModal = () => {
-    const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
 
-    const handleRequestClose = () => setIsOpen(false);
+  const handleRequestClose = () => setIsOpen(false);
 
-    return (
-      <>
-        <Button onClick={() => setIsOpen(true)}>Click to open modal</Button>
-        <Modal
-          ariaHideApp={false}
-          className="AsyncSelectInModal"
-          contentLabel="AsyncSelect in Modal"
-          isOpen={isOpen}
-        >
-          <ModalHeader
-            title="In Modal AsyncSelect"
-            titleId="in-modal-async-select"
-            onRequestClose={handleRequestClose}
-          />
-          <ModalBody>
-            <FormGroup
-              helperText="Select menu is able to overflow the Modal container"
-              label="In Modal async select"
-              labelHtmlFor="in-modal-async-select"
-            >
-              <AsyncSelect
-                getOptionLabel={({ label }) => label}
-                getOptionValue={({ value }) => value}
-                inputId="in-modal-async-select"
-                loadOptions={loadOptions}
-                modal
-                noOptionsMessage={({ inputValue }) => inputValue.length ? 'No results!' : 'Type to search...'}
-              />
-            </FormGroup>
-          </ModalBody>
-          <ModalFooter
-            dismissButtonText="Cancel"
-            onRequestClose={handleRequestClose}
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Click to open modal</Button>
+      <Modal
+        ariaHideApp={false}
+        className="AsyncSelectInModal"
+        contentLabel="AsyncSelect in Modal"
+        isOpen={isOpen}
+      >
+        <ModalHeader
+          title="In Modal AsyncSelect"
+          titleId="in-modal-async-select"
+          onRequestClose={handleRequestClose}
+        />
+        <ModalBody>
+          <FormGroup
+            helperText="Select menu is able to overflow the Modal container"
+            label="In Modal async select"
+            labelHtmlFor="in-modal-async-select"
           >
-            <Button type="submit" variant="primary">Confirm</Button>
-          </ModalFooter>
-        </Modal>
-      </>
-    );
+            <AsyncSelect
+              getOptionLabel={({ label }) => label}
+              getOptionValue={({ value }) => value}
+              inputId="in-modal-async-select"
+              loadOptions={loadOptions}
+              modal
+              noOptionsMessage={({ inputValue }) => inputValue.length ? 'No results!' : 'Type to search...'}
+            />
+          </FormGroup>
+        </ModalBody>
+        <ModalFooter
+          dismissButtonText="Cancel"
+          onRequestClose={handleRequestClose}
+        >
+          <Button type="submit" variant="primary">Confirm</Button>
+        </ModalFooter>
+      </Modal>
+    </>
+  );
 };

--- a/src/Select/CreatableSelect.stories.jsx
+++ b/src/Select/CreatableSelect.stories.jsx
@@ -1,83 +1,93 @@
-import React from 'react';
-import { action } from '@storybook/addon-actions';
+import React, { useState } from 'react';
 
 import Button from 'src/Button';
 import CreatableSelect from 'src/Select/CreatableSelect';
 import FormGroup from 'src/FormGroup';
 import {
-  Modal, ModalHeader, ModalBody, ModalFooter,
- } from 'src/Modal';
+    Modal, ModalHeader, ModalBody, ModalFooter,
+} from 'src/Modal';
 
 export default {
-  title: 'Components/Selects/Creatable',
-  component: CreatableSelect,
+    title: 'Components/Selects/Creatable',
+    component: CreatableSelect,
 };
 
 const options = [
-  { label: 'Red', value: 1 },
-  { label: 'Green', value: 2 },
-  { label: 'Blue', value: 3 },
+    { label: 'Red', value: 1 },
+    { label: 'Green', value: 2 },
+    { label: 'Blue', value: 3 },
 ];
 
 export const Default = () => {
-  const handleChange = () => {};
-  const handleInputChange = () => {};
+    const handleChange = () => {
+    };
+    const handleInputChange = () => {
+    };
 
-  return (
-    <FormGroup
-      label="Default creatable select"
-      labelHtmlFor="default-creatable-select"
-    >
-      <CreatableSelect
-        inputId="default-creatable-select"
-        isClearable
-        options={options}
-        onChange={handleChange}
-        onInputChange={handleInputChange}
-      />
-    </FormGroup>
-  );
+    return (
+      <FormGroup
+        label="Default creatable select"
+        labelHtmlFor="default-creatable-select"
+      >
+        <CreatableSelect
+          inputId="default-creatable-select"
+          isClearable
+          options={options}
+          onChange={handleChange}
+          onInputChange={handleInputChange}
+        />
+      </FormGroup>
+    );
 };
 
 export const InModal = () => {
-  const handleChange = () => {};
-  const handleInputChange = () => {};
-  const handleRequestClose = () => action('Close');
+    const [isOpen, setIsOpen] = useState(false);
 
-  return (
-    <Modal
-      ariaHideApp={false}
-      className="CreatableSelectInModal"
-      contentLabel="CreatableSelect in Modal"
-      isOpen
-    >
-      <ModalHeader
-        title="In Modal creatable select"
-        titleId="in-modal-creatable-select"
-        onRequestClose={handleRequestClose}
-      />
-      <ModalBody>
-        <FormGroup
-          helperText="Select menu is able to overflow the Modal container"
-          label="In Modal creatable select"
-          labelHtmlFor="in-modal-creatable-select"
+    const handleChange = () => {
+    };
+    const handleInputChange = () => {
+    };
+    const handleRequestClose = () => setIsOpen(false);
+
+    return (
+      <>
+        <Button onClick={() => setIsOpen(true)}>Click to open modal</Button>
+        <Modal
+          ariaHideApp={false}
+          className="CreatableSelectInModal"
+          contentLabel="CreatableSelect in Modal"
+          isOpen={isOpen}
         >
-          <CreatableSelect
-            inputId="in-modal-creatable-select"
-            isClearable
-            modal
-            options={options}
-            onChange={handleChange}
-            onInputChange={handleInputChange}
+          <ModalHeader
+            git
+            stat
+            title="In Modal creatable select"
+            titleId="in-modal-creatable-select"
+            onRequestClose={handleRequestClose}
           />
-        </FormGroup>
-      </ModalBody>
-      <ModalFooter
-        dismissButtonText="Cancel"
-        onRequestClose={handleRequestClose}
-      >
-        <Button type="submit" variant="primary">Confirm</Button>
-      </ModalFooter>
-    </Modal>
-  );
+          <ModalBody>
+            <FormGroup
+              helperText="Select menu is able to overflow the Modal container"
+              label="In Modal creatable select"
+              labelHtmlFor="in-modal-creatable-select"
+            >
+              <CreatableSelect
+                inputId="in-modal-creatable-select"
+                isClearable
+                modal
+                options={options}
+                onChange={handleChange}
+                onInputChange={handleInputChange}
+              />
+            </FormGroup>
+          </ModalBody>
+          <ModalFooter
+            dismissButtonText="Cancel"
+            onRequestClose={handleRequestClose}
+          >
+            <Button type="submit" variant="primary">Confirm</Button>
+          </ModalFooter>
+        </Modal>
+      </>
+    );
 };

--- a/src/Select/CreatableSelect.stories.jsx
+++ b/src/Select/CreatableSelect.stories.jsx
@@ -4,90 +4,90 @@ import Button from 'src/Button';
 import CreatableSelect from 'src/Select/CreatableSelect';
 import FormGroup from 'src/FormGroup';
 import {
-    Modal, ModalHeader, ModalBody, ModalFooter,
+  Modal, ModalHeader, ModalBody, ModalFooter,
 } from 'src/Modal';
 
 export default {
-    title: 'Components/Selects/Creatable',
-    component: CreatableSelect,
+  title: 'Components/Selects/Creatable',
+  component: CreatableSelect,
 };
 
 const options = [
-    { label: 'Red', value: 1 },
-    { label: 'Green', value: 2 },
-    { label: 'Blue', value: 3 },
+  { label: 'Red', value: 1 },
+  { label: 'Green', value: 2 },
+  { label: 'Blue', value: 3 },
 ];
 
 export const Default = () => {
-    const handleChange = () => {
-    };
-    const handleInputChange = () => {
-    };
+  const handleChange = () => {
+  };
+  const handleInputChange = () => {
+  };
 
-    return (
-      <FormGroup
-        label="Default creatable select"
-        labelHtmlFor="default-creatable-select"
-      >
-        <CreatableSelect
-          inputId="default-creatable-select"
-          isClearable
-          options={options}
-          onChange={handleChange}
-          onInputChange={handleInputChange}
-        />
-      </FormGroup>
-    );
+  return (
+    <FormGroup
+      label="Default creatable select"
+      labelHtmlFor="default-creatable-select"
+    >
+      <CreatableSelect
+        inputId="default-creatable-select"
+        isClearable
+        options={options}
+        onChange={handleChange}
+        onInputChange={handleInputChange}
+      />
+    </FormGroup>
+  );
 };
 
 export const InModal = () => {
-    const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
 
-    const handleChange = () => {
-    };
-    const handleInputChange = () => {
-    };
-    const handleRequestClose = () => setIsOpen(false);
+  const handleChange = () => {
+  };
+  const handleInputChange = () => {
+  };
+  const handleRequestClose = () => setIsOpen(false);
 
-    return (
-      <>
-        <Button onClick={() => setIsOpen(true)}>Click to open modal</Button>
-        <Modal
-          ariaHideApp={false}
-          className="CreatableSelectInModal"
-          contentLabel="CreatableSelect in Modal"
-          isOpen={isOpen}
-        >
-          <ModalHeader
-            git
-            stat
-            title="In Modal creatable select"
-            titleId="in-modal-creatable-select"
-            onRequestClose={handleRequestClose}
-          />
-          <ModalBody>
-            <FormGroup
-              helperText="Select menu is able to overflow the Modal container"
-              label="In Modal creatable select"
-              labelHtmlFor="in-modal-creatable-select"
-            >
-              <CreatableSelect
-                inputId="in-modal-creatable-select"
-                isClearable
-                modal
-                options={options}
-                onChange={handleChange}
-                onInputChange={handleInputChange}
-              />
-            </FormGroup>
-          </ModalBody>
-          <ModalFooter
-            dismissButtonText="Cancel"
-            onRequestClose={handleRequestClose}
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Click to open modal</Button>
+      <Modal
+        ariaHideApp={false}
+        className="CreatableSelectInModal"
+        contentLabel="CreatableSelect in Modal"
+        isOpen={isOpen}
+      >
+        <ModalHeader
+          git
+          stat
+          title="In Modal creatable select"
+          titleId="in-modal-creatable-select"
+          onRequestClose={handleRequestClose}
+        />
+        <ModalBody>
+          <FormGroup
+            helperText="Select menu is able to overflow the Modal container"
+            label="In Modal creatable select"
+            labelHtmlFor="in-modal-creatable-select"
           >
-            <Button type="submit" variant="primary">Confirm</Button>
-          </ModalFooter>
-        </Modal>
-      </>
-    );
+            <CreatableSelect
+              inputId="in-modal-creatable-select"
+              isClearable
+              modal
+              options={options}
+              onChange={handleChange}
+              onInputChange={handleInputChange}
+            />
+          </FormGroup>
+        </ModalBody>
+        <ModalFooter
+          dismissButtonText="Cancel"
+          onRequestClose={handleRequestClose}
+        >
+          <Button type="submit" variant="primary">Confirm</Button>
+        </ModalFooter>
+      </Modal>
+    </>
+  );
 };

--- a/src/Select/CreatableSelect.stories.jsx
+++ b/src/Select/CreatableSelect.stories.jsx
@@ -59,8 +59,6 @@ export const InModal = () => {
         isOpen={isOpen}
       >
         <ModalHeader
-          git
-          stat
           title="In Modal creatable select"
           titleId="in-modal-creatable-select"
           onRequestClose={handleRequestClose}

--- a/src/Select/SingleSelect.mdx
+++ b/src/Select/SingleSelect.mdx
@@ -35,16 +35,10 @@ A base select input. Flexible and comes with multiselect, clearable, searchable,
   <Story id="components-selects-single--loading" />
 </Preview>
 
-### Labeled
-
-<Preview>
-  <Story id="components-selects-single--labeled" />
-</Preview>
-
 ### Multi Select
 
 <Preview>
-  <Story id="components-selects-single--multi-select" />
+  <Story id="components-selects-single--multiple-select" />
 </Preview>
 
 ### Custom Option With Checkbox

--- a/src/Select/SingleSelect.stories.jsx
+++ b/src/Select/SingleSelect.stories.jsx
@@ -1,10 +1,10 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import { action } from '@storybook/addon-actions';
 
 import Button from 'src/Button';
 import FormGroup from 'src/FormGroup';
 import {
- Modal, ModalHeader, ModalBody, ModalFooter,
+    Modal, ModalHeader, ModalBody, ModalFooter,
 } from 'src/Modal';
 import SingleSelect from 'src/Select/SingleSelect';
 
@@ -15,23 +15,22 @@ import ValueContainer from './ValueContainer';
 import mdx from './SingleSelect.mdx';
 
 const onChange = () => action('Change');
-const handleRequestClose = () => action('Close');
 
 export default {
-  title: 'Components/Selects/Single',
-  component: SingleSelect,
-  parameters: {
-    docs: {
-      page: mdx,
+    title: 'Components/Selects/Single',
+    component: SingleSelect,
+    parameters: {
+        docs: {
+            page: mdx,
+        },
     },
-  },
 };
 
 const options = [
-  { label: '1-on-1 interview', value: 1 },
-  { label: 'Focus group', value: 2 },
-  { label: 'Multi-day study', value: 3 },
-  { label: 'Unmoderated task', value: 4 },
+    { label: '1-on-1 interview', value: 1 },
+    { label: 'Focus group', value: 2 },
+    { label: 'Multi-day study', value: 3 },
+    { label: 'Unmoderated task', value: 4 },
 ];
 
 export const Default = () => (
@@ -75,104 +74,124 @@ export const MultipleSelect = () => (
   </FormGroup>
 );
 
-export const InModal = () => (
-  <Modal
-    ariaHideApp={false}
-    className="SelectInModal"
-    contentLabel="Select in Modal"
-    isOpen
-  >
-    <ModalHeader
-      title="Select in modal"
-      titleId="select-in-modal"
-      onRequestClose={handleRequestClose}
-    />
-    <ModalBody>
+export const InModal = () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const handleRequestClose = () => setIsOpen(false);
+
+    return (
+      <>
+        <Button onClick={() => setIsOpen(true)}>Click to open modal</Button>
+        <Modal
+          ariaHideApp={false}
+          className="SelectInModal"
+          contentLabel="Select in Modal"
+          isOpen={isOpen}
+        >
+          <ModalHeader
+            title="Select in modal"
+            titleId="select-in-modal"
+            onRequestClose={handleRequestClose}
+          />
+          <ModalBody>
+            <FormGroup
+              helperText="Select menu is able to overflow the Modal container"
+              label="In Modal select"
+              labelHtmlFor="in-modal-select"
+            >
+              <SingleSelect
+                inputId="in-modal-select"
+                modal
+                options={options}
+                onChange={onChange}
+              />
+            </FormGroup>
+          </ModalBody>
+          <ModalFooter
+            dismissButtonText="Cancel"
+            onRequestClose={handleRequestClose}
+          >
+            <Button type="submit" variant="primary">Confirm</Button>
+          </ModalFooter>
+        </Modal>
+      </>
+    );
+};
+export const GroupedOptions = () => {
+    const groupedOptions = [
+        {
+            label: 'Study type',
+            options,
+        },
+        {
+            label: 'Audience type',
+            options: [
+                { label: 'Consumers', value: 5 },
+                { label: 'Professionals', value: 6 },
+            ],
+        },
+    ];
+    return (
       <FormGroup
-        helperText="Select menu is able to overflow the Modal container"
-        label="In Modal select"
-        labelHtmlFor="in-modal-select"
+        label="Grouped options"
+        labelHtmlFor="grouped-options-select"
       >
         <SingleSelect
-          inputId="in-modal-select"
-          modal
-          options={options}
+          inputId="grouped-options-select"
+          options={groupedOptions}
           onChange={onChange}
         />
       </FormGroup>
-    </ModalBody>
-    <ModalFooter
-      dismissButtonText="Cancel"
-      onRequestClose={handleRequestClose}
-    >
-      <Button type="submit" variant="primary">Confirm</Button>
-    </ModalFooter>
-  </Modal>
-  );
-
-export const GroupedOptions = () => {
-  const groupedOptions = [
-    {
-      label: 'Study type',
-      options,
-    },
-    {
-      label: 'Audience type',
-      options: [
-        { label: 'Consumers', value: 5 },
-        { label: 'Professionals', value: 6 },
-      ],
-    },
-  ];
-  return (
-    <FormGroup
-      label="Grouped options"
-      labelHtmlFor="grouped-options-select"
-    >
-      <SingleSelect
-        inputId="grouped-options-select"
-        options={groupedOptions}
-        onChange={onChange}
-      />
-    </FormGroup>
-  );
+    );
 };
 
 export const CustomOptionWithDescription = () => {
-  const optionsWithDescriptions = [
-    {
- label: 'Org Admin', value: 1, description: 'Short description of role capabilities', labelDescription: '(Full access)',
-},
-    {
- label: 'Administrator', value: 2, description: 'Short description of role capabilities', labelDescription: '(Full access)',
-},
-    {
- label: 'Researcher', value: 3, description: 'Short description of role capabilities', labelDescription: '(Standard access)',
-},
-    {
- label: 'Teammate', value: 4, description: 'Short description of role capabilities', labelDescription: '(Limited access)',
-},
-  ];
+    const optionsWithDescriptions = [
+        {
+            label: 'Org Admin',
+            value: 1,
+            description: 'Short description of role capabilities',
+            labelDescription: '(Full access)',
+        },
+        {
+            label: 'Administrator',
+            value: 2,
+            description: 'Short description of role capabilities',
+            labelDescription: '(Full access)',
+        },
+        {
+            label: 'Researcher',
+            value: 3,
+            description: 'Short description of role capabilities',
+            labelDescription: '(Standard access)',
+        },
+        {
+            label: 'Teammate',
+            value: 4,
+            description: 'Short description of role capabilities',
+            labelDescription: '(Limited access)',
+        },
+    ];
 
-  return (
-    <FormGroup
-      label="Custom Option with Description"
-      labelHtmlFor="custom-option-with-description-select"
-    >
-      <SingleSelect
-        components={{
-          Option: (props) => (
-            <OptionWithDescription
-              {...props}
-            />
-          ),
-        }}
-        inputId="custom-option-with-description-select"
-        options={optionsWithDescriptions}
-        onChange={onChange}
-      />
-    </FormGroup>
-  );
+    return (
+      <FormGroup
+        label="Custom Option with Description"
+        labelHtmlFor="custom-option-with-description-select"
+      >
+        <SingleSelect
+          components={{
+                    Option: (props) => (
+                      <OptionWithDescription
+                        {...props}
+                      />
+                    ),
+                }}
+          inputId="custom-option-with-description-select"
+          options={optionsWithDescriptions}
+          onChange={onChange}
+        />
+      </FormGroup>
+    );
 };
 
 export const CustomOptionWithCheckbox = () => (
@@ -183,8 +202,8 @@ export const CustomOptionWithCheckbox = () => (
     <SingleSelect
       closeMenuOnSelect={false}
       components={{
-        Option,
-      }}
+                Option,
+            }}
       hideSelectedOptions={false}
       inputId="custom-option-with-checkbox-select"
       isMulti
@@ -195,46 +214,46 @@ export const CustomOptionWithCheckbox = () => (
 );
 
 export const CustomOptionWithIndeterminateCheckbox = () => {
-  const optionsArr = [
-    { label: 'Riley Researcher', value: 1 },
-    { label: 'Patty Participant', value: 2 },
-    { label: 'Patrick Participant (indeterminate)', value: 3 },
-    { label: 'Polly Participant (indeterminate)', value: 4 },
-  ];
+    const optionsArr = [
+        { label: 'Riley Researcher', value: 1 },
+        { label: 'Patty Participant', value: 2 },
+        { label: 'Patrick Participant (indeterminate)', value: 3 },
+        { label: 'Polly Participant (indeterminate)', value: 4 },
+    ];
 
-  let inputRef;
+    let inputRef;
 
-  const createInputRef = () => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    inputRef = useRef();
-    return inputRef;
-  };
+    const createInputRef = () => {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        inputRef = useRef();
+        return inputRef;
+    };
 
-  return (
-    <FormGroup
-      label="Custom Option with Indeterminate Checkbox"
-      labelHtmlFor="custom-option-with-indeterminate-checkbox"
-    >
-      <SingleSelect
-        closeMenuOnSelect={false}
-        components={{
-          Option: (props) => (
-            <Option
-              {...props}
-              // eslint-disable-next-line react/prop-types
-              indeterminate={props.value > 2}
-              ref={createInputRef()}
-            />
-          ),
-        }}
-        hideSelectedOptions={false}
-        inputId="custom-option-with-indeterminate-checkbox"
-        isMulti
-        options={optionsArr}
-        onChange={onChange}
-      />
-    </FormGroup>
-  );
+    return (
+      <FormGroup
+        label="Custom Option with Indeterminate Checkbox"
+        labelHtmlFor="custom-option-with-indeterminate-checkbox"
+      >
+        <SingleSelect
+          closeMenuOnSelect={false}
+          components={{
+                    Option: (props) => (
+                      <Option
+                        {...props}
+                            // eslint-disable-next-line react/prop-types
+                        indeterminate={props.value > 2}
+                        ref={createInputRef()}
+                      />
+                    ),
+                }}
+          hideSelectedOptions={false}
+          inputId="custom-option-with-indeterminate-checkbox"
+          isMulti
+          options={optionsArr}
+          onChange={onChange}
+        />
+      </FormGroup>
+    );
 };
 
 export const CustomValueContainer = () => (
@@ -245,16 +264,15 @@ export const CustomValueContainer = () => (
     <SingleSelect
       closeMenuOnSelect={false}
       components={{
-        Option,
-        ValueContainer: (props) => (
-          <ValueContainer
-            {...props}
-            /* eslint-disable react/prop-types */
-            valueText={`participant${props.getValue().length > 1 ? 's' : ''} selected`}
-            /* eslint-enable react/prop-types */
-          />
-        ),
-      }}
+                Option,
+                ValueContainer: (props) => (
+                  <ValueContainer
+                    {...props}
+                        /* eslint-disable react/prop-types */
+                    valueText={`participant${props.getValue().length > 1 ? 's' : ''} selected`}
+                  />
+                ),
+            }}
       hideSelectedOptions={false}
       inputId="custom-value-container-select"
       isMulti

--- a/src/Select/SingleSelect.stories.jsx
+++ b/src/Select/SingleSelect.stories.jsx
@@ -180,12 +180,12 @@ export const CustomOptionWithDescription = () => {
     >
       <SingleSelect
         components={{
-              Option: (props) => (
-                <OptionWithDescription
-                  {...props}
-                />
-              ),
-            }}
+          Option: (props) => (
+            <OptionWithDescription
+              {...props}
+            />
+          ),
+        }}
         inputId="custom-option-with-description-select"
         options={optionsWithDescriptions}
         onChange={onChange}
@@ -201,9 +201,7 @@ export const CustomOptionWithCheckbox = () => (
   >
     <SingleSelect
       closeMenuOnSelect={false}
-      components={{
-            Option,
-          }}
+      components={{ Option }}
       hideSelectedOptions={false}
       inputId="custom-option-with-checkbox-select"
       isMulti
@@ -237,15 +235,15 @@ export const CustomOptionWithIndeterminateCheckbox = () => {
       <SingleSelect
         closeMenuOnSelect={false}
         components={{
-              Option: (props) => (
-                <Option
-                  {...props}
-                      // eslint-disable-next-line react/prop-types
-                  indeterminate={props.value > 2}
-                  ref={createInputRef()}
-                />
-              ),
-            }}
+          Option: (props) => (
+            <Option
+              {...props}
+                  // eslint-disable-next-line react/prop-types
+              indeterminate={props.value > 2}
+              ref={createInputRef()}
+            />
+          ),
+        }}
         hideSelectedOptions={false}
         inputId="custom-option-with-indeterminate-checkbox"
         isMulti
@@ -264,15 +262,15 @@ export const CustomValueContainer = () => (
     <SingleSelect
       closeMenuOnSelect={false}
       components={{
-            Option,
-            ValueContainer: (props) => (
-              <ValueContainer
-                {...props}
-                    /* eslint-disable react/prop-types */
-                valueText={`participant${props.getValue().length > 1 ? 's' : ''} selected`}
-              />
-            ),
-          }}
+        Option,
+        ValueContainer: (props) => (
+          <ValueContainer
+            {...props}
+                /* eslint-disable react/prop-types */
+            valueText={`participant${props.getValue().length > 1 ? 's' : ''} selected`}
+          />
+        ),
+      }}
       hideSelectedOptions={false}
       inputId="custom-value-container-select"
       isMulti

--- a/src/Select/SingleSelect.stories.jsx
+++ b/src/Select/SingleSelect.stories.jsx
@@ -4,7 +4,7 @@ import { action } from '@storybook/addon-actions';
 import Button from 'src/Button';
 import FormGroup from 'src/FormGroup';
 import {
-    Modal, ModalHeader, ModalBody, ModalFooter,
+  Modal, ModalHeader, ModalBody, ModalFooter,
 } from 'src/Modal';
 import SingleSelect from 'src/Select/SingleSelect';
 
@@ -17,20 +17,20 @@ import mdx from './SingleSelect.mdx';
 const onChange = () => action('Change');
 
 export default {
-    title: 'Components/Selects/Single',
-    component: SingleSelect,
-    parameters: {
-        docs: {
-            page: mdx,
-        },
+  title: 'Components/Selects/Single',
+  component: SingleSelect,
+  parameters: {
+    docs: {
+      page: mdx,
     },
+  },
 };
 
 const options = [
-    { label: '1-on-1 interview', value: 1 },
-    { label: 'Focus group', value: 2 },
-    { label: 'Multi-day study', value: 3 },
-    { label: 'Unmoderated task', value: 4 },
+  { label: '1-on-1 interview', value: 1 },
+  { label: 'Focus group', value: 2 },
+  { label: 'Multi-day study', value: 3 },
+  { label: 'Unmoderated task', value: 4 },
 ];
 
 export const Default = () => (
@@ -75,123 +75,123 @@ export const MultipleSelect = () => (
 );
 
 export const InModal = () => {
-    const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
 
-    const handleRequestClose = () => setIsOpen(false);
+  const handleRequestClose = () => setIsOpen(false);
 
-    return (
-      <>
-        <Button onClick={() => setIsOpen(true)}>Click to open modal</Button>
-        <Modal
-          ariaHideApp={false}
-          className="SelectInModal"
-          contentLabel="Select in Modal"
-          isOpen={isOpen}
-        >
-          <ModalHeader
-            title="Select in modal"
-            titleId="select-in-modal"
-            onRequestClose={handleRequestClose}
-          />
-          <ModalBody>
-            <FormGroup
-              helperText="Select menu is able to overflow the Modal container"
-              label="In Modal select"
-              labelHtmlFor="in-modal-select"
-            >
-              <SingleSelect
-                inputId="in-modal-select"
-                modal
-                options={options}
-                onChange={onChange}
-              />
-            </FormGroup>
-          </ModalBody>
-          <ModalFooter
-            dismissButtonText="Cancel"
-            onRequestClose={handleRequestClose}
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Click to open modal</Button>
+      <Modal
+        ariaHideApp={false}
+        className="SelectInModal"
+        contentLabel="Select in Modal"
+        isOpen={isOpen}
+      >
+        <ModalHeader
+          title="Select in modal"
+          titleId="select-in-modal"
+          onRequestClose={handleRequestClose}
+        />
+        <ModalBody>
+          <FormGroup
+            helperText="Select menu is able to overflow the Modal container"
+            label="In Modal select"
+            labelHtmlFor="in-modal-select"
           >
-            <Button type="submit" variant="primary">Confirm</Button>
-          </ModalFooter>
-        </Modal>
-      </>
-    );
+            <SingleSelect
+              inputId="in-modal-select"
+              modal
+              options={options}
+              onChange={onChange}
+            />
+          </FormGroup>
+        </ModalBody>
+        <ModalFooter
+          dismissButtonText="Cancel"
+          onRequestClose={handleRequestClose}
+        >
+          <Button type="submit" variant="primary">Confirm</Button>
+        </ModalFooter>
+      </Modal>
+    </>
+  );
 };
 export const GroupedOptions = () => {
-    const groupedOptions = [
-        {
-            label: 'Study type',
-            options,
-        },
-        {
-            label: 'Audience type',
-            options: [
-                { label: 'Consumers', value: 5 },
-                { label: 'Professionals', value: 6 },
-            ],
-        },
-    ];
-    return (
-      <FormGroup
-        label="Grouped options"
-        labelHtmlFor="grouped-options-select"
-      >
-        <SingleSelect
-          inputId="grouped-options-select"
-          options={groupedOptions}
-          onChange={onChange}
-        />
-      </FormGroup>
-    );
+  const groupedOptions = [
+    {
+      label: 'Study type',
+      options,
+    },
+    {
+      label: 'Audience type',
+      options: [
+        { label: 'Consumers', value: 5 },
+        { label: 'Professionals', value: 6 },
+      ],
+    },
+  ];
+  return (
+    <FormGroup
+      label="Grouped options"
+      labelHtmlFor="grouped-options-select"
+    >
+      <SingleSelect
+        inputId="grouped-options-select"
+        options={groupedOptions}
+        onChange={onChange}
+      />
+    </FormGroup>
+  );
 };
 
 export const CustomOptionWithDescription = () => {
-    const optionsWithDescriptions = [
-        {
-            label: 'Org Admin',
-            value: 1,
-            description: 'Short description of role capabilities',
-            labelDescription: '(Full access)',
-        },
-        {
-            label: 'Administrator',
-            value: 2,
-            description: 'Short description of role capabilities',
-            labelDescription: '(Full access)',
-        },
-        {
-            label: 'Researcher',
-            value: 3,
-            description: 'Short description of role capabilities',
-            labelDescription: '(Standard access)',
-        },
-        {
-            label: 'Teammate',
-            value: 4,
-            description: 'Short description of role capabilities',
-            labelDescription: '(Limited access)',
-        },
-    ];
+  const optionsWithDescriptions = [
+    {
+      label: 'Org Admin',
+      value: 1,
+      description: 'Short description of role capabilities',
+      labelDescription: '(Full access)',
+    },
+    {
+      label: 'Administrator',
+      value: 2,
+      description: 'Short description of role capabilities',
+      labelDescription: '(Full access)',
+    },
+    {
+      label: 'Researcher',
+      value: 3,
+      description: 'Short description of role capabilities',
+      labelDescription: '(Standard access)',
+    },
+    {
+      label: 'Teammate',
+      value: 4,
+      description: 'Short description of role capabilities',
+      labelDescription: '(Limited access)',
+    },
+  ];
 
-    return (
-      <FormGroup
-        label="Custom Option with Description"
-        labelHtmlFor="custom-option-with-description-select"
-      >
-        <SingleSelect
-          components={{
-                    Option: (props) => (
-                      <OptionWithDescription
-                        {...props}
-                      />
-                    ),
-                }}
-          inputId="custom-option-with-description-select"
-          options={optionsWithDescriptions}
-          onChange={onChange}
-        />
-      </FormGroup>
-    );
+  return (
+    <FormGroup
+      label="Custom Option with Description"
+      labelHtmlFor="custom-option-with-description-select"
+    >
+      <SingleSelect
+        components={{
+              Option: (props) => (
+                <OptionWithDescription
+                  {...props}
+                />
+              ),
+            }}
+        inputId="custom-option-with-description-select"
+        options={optionsWithDescriptions}
+        onChange={onChange}
+      />
+    </FormGroup>
+  );
 };
 
 export const CustomOptionWithCheckbox = () => (
@@ -202,8 +202,8 @@ export const CustomOptionWithCheckbox = () => (
     <SingleSelect
       closeMenuOnSelect={false}
       components={{
-                Option,
-            }}
+            Option,
+          }}
       hideSelectedOptions={false}
       inputId="custom-option-with-checkbox-select"
       isMulti
@@ -214,46 +214,46 @@ export const CustomOptionWithCheckbox = () => (
 );
 
 export const CustomOptionWithIndeterminateCheckbox = () => {
-    const optionsArr = [
-        { label: 'Riley Researcher', value: 1 },
-        { label: 'Patty Participant', value: 2 },
-        { label: 'Patrick Participant (indeterminate)', value: 3 },
-        { label: 'Polly Participant (indeterminate)', value: 4 },
-    ];
+  const optionsArr = [
+    { label: 'Riley Researcher', value: 1 },
+    { label: 'Patty Participant', value: 2 },
+    { label: 'Patrick Participant (indeterminate)', value: 3 },
+    { label: 'Polly Participant (indeterminate)', value: 4 },
+  ];
 
-    let inputRef;
+  let inputRef;
 
-    const createInputRef = () => {
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        inputRef = useRef();
-        return inputRef;
-    };
+  const createInputRef = () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    inputRef = useRef();
+    return inputRef;
+  };
 
-    return (
-      <FormGroup
-        label="Custom Option with Indeterminate Checkbox"
-        labelHtmlFor="custom-option-with-indeterminate-checkbox"
-      >
-        <SingleSelect
-          closeMenuOnSelect={false}
-          components={{
-                    Option: (props) => (
-                      <Option
-                        {...props}
-                            // eslint-disable-next-line react/prop-types
-                        indeterminate={props.value > 2}
-                        ref={createInputRef()}
-                      />
-                    ),
-                }}
-          hideSelectedOptions={false}
-          inputId="custom-option-with-indeterminate-checkbox"
-          isMulti
-          options={optionsArr}
-          onChange={onChange}
-        />
-      </FormGroup>
-    );
+  return (
+    <FormGroup
+      label="Custom Option with Indeterminate Checkbox"
+      labelHtmlFor="custom-option-with-indeterminate-checkbox"
+    >
+      <SingleSelect
+        closeMenuOnSelect={false}
+        components={{
+              Option: (props) => (
+                <Option
+                  {...props}
+                      // eslint-disable-next-line react/prop-types
+                  indeterminate={props.value > 2}
+                  ref={createInputRef()}
+                />
+              ),
+            }}
+        hideSelectedOptions={false}
+        inputId="custom-option-with-indeterminate-checkbox"
+        isMulti
+        options={optionsArr}
+        onChange={onChange}
+      />
+    </FormGroup>
+  );
 };
 
 export const CustomValueContainer = () => (
@@ -264,15 +264,15 @@ export const CustomValueContainer = () => (
     <SingleSelect
       closeMenuOnSelect={false}
       components={{
-                Option,
-                ValueContainer: (props) => (
-                  <ValueContainer
-                    {...props}
-                        /* eslint-disable react/prop-types */
-                    valueText={`participant${props.getValue().length > 1 ? 's' : ''} selected`}
-                  />
-                ),
-            }}
+            Option,
+            ValueContainer: (props) => (
+              <ValueContainer
+                {...props}
+                    /* eslint-disable react/prop-types */
+                valueText={`participant${props.getValue().length > 1 ? 's' : ''} selected`}
+              />
+            ),
+          }}
       hideSelectedOptions={false}
       inputId="custom-value-container-select"
       isMulti


### PR DESCRIPTION
Resolves this bug #746 

Updates the stories under `Selects` for 
- Async Creatable > In Modal
- Single > In Modal
- Async > In Modal
- Creatable > In Modal

The underlying code isn't touched, just the story functions. 

**Note**: I ran the project eslint config on the files I touched and it seem to have changed some stuff, some of which seem weird to me like in some places like forcing empty functions onto two lines 
```
  const handleChange = () => {
  };
```
Not sure if this is intended/matters?

### **Screenshots**

After this fix, we have a button to open the modal manually, and can close the modal as well using the expected cancel/X buttons:
![Screenshot 2023-04-07 at 2 40 55 PM](https://user-images.githubusercontent.com/25135946/230661515-d6846bc9-c9ef-4ec8-a362-570f0571b7b6.png)
![Screenshot 2023-04-07 at 2 41 00 PM](https://user-images.githubusercontent.com/25135946/230661514-bcb705dc-f7c5-4d02-a0f5-2e2f93432d79.png)

