### PR TITLE
Improve outline transparent button disabled state

### DIFF
--- a/scss/buttons.scss
+++ b/scss/buttons.scss
@@ -319,6 +319,12 @@ $warning: $ux-yellow-400;
     border-color: $btn-outline-transparent-active-border-color;
   }
 
+  &:disabled {
+    background-color: $ux-gray-300;
+    border: $ux-gray-400;
+    color: $ux-gray-800;
+  }
+
   &:focus-visible {
     @include btn-focus-outline;
   }

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -3383,6 +3383,49 @@ exports[`Storyshots Components/Button Danger 1`] = `
       />
     </svg>
   </button>
+  <button
+    aria-disabled={true}
+    className="Button btn btn-outline-danger btn-sm"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Delete
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+   
    
   <button
     className="Button btn btn-danger btn-md"
@@ -3471,6 +3514,49 @@ exports[`Storyshots Components/Button Danger 1`] = `
   <button
     aria-disabled={true}
     className="Button btn btn-danger btn-md"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Delete
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+   
+  <button
+    aria-disabled={true}
+    className="Button btn btn-outline-danger btn-md"
     disabled={true}
     type="button"
   >
@@ -3815,6 +3901,49 @@ exports[`Storyshots Components/Button Primary 1`] = `
   </button>
    
   <button
+    aria-disabled={true}
+    className="Button btn btn-outline-primary btn-sm"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Confirm
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+   
+  <button
     className="Button btn btn-primary btn-md"
     disabled={false}
     type="button"
@@ -3901,6 +4030,49 @@ exports[`Storyshots Components/Button Primary 1`] = `
   <button
     aria-disabled={true}
     className="Button btn btn-primary btn-md"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Confirm
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+   
+  <button
+    aria-disabled={true}
+    className="Button btn btn-outline-primary btn-md"
     disabled={true}
     type="button"
   >
@@ -4079,6 +4251,49 @@ exports[`Storyshots Components/Button Transparent 1`] = `
   </button>
    
   <button
+    aria-disabled={true}
+    className="Button btn btn-outline-transparent btn-sm"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Skip
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+   
+  <button
     className="Button btn btn-transparent btn-md"
     disabled={false}
     type="button"
@@ -4165,6 +4380,49 @@ exports[`Storyshots Components/Button Transparent 1`] = `
   <button
     aria-disabled={true}
     className="Button btn btn-transparent btn-md"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Skip
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+   
+  <button
+    aria-disabled={true}
+    className="Button btn btn-outline-transparent btn-md"
     disabled={true}
     type="button"
   >
@@ -4343,6 +4601,49 @@ exports[`Storyshots Components/Button Warning 1`] = `
   </button>
    
   <button
+    aria-disabled={true}
+    className="Button btn btn-outline-warning btn-sm"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Edit
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+   
+  <button
     className="Button btn btn-warning btn-md"
     disabled={false}
     type="button"
@@ -4429,6 +4730,49 @@ exports[`Storyshots Components/Button Warning 1`] = `
   <button
     aria-disabled={true}
     className="Button btn btn-warning btn-md"
+    disabled={true}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-file-alt icon-left"
+      data-icon="file-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 384 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M288 248v28c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-28c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm-12 72H108c-6.6 0-12 5.4-12 12v28c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-28c0-6.6-5.4-12-12-12zm108-188.1V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V48C0 21.5 21.5 0 48 0h204.1C264.8 0 277 5.1 286 14.1L369.9 98c9 8.9 14.1 21.2 14.1 33.9zm-128-80V128h76.1L256 51.9zM336 464V176H232c-13.3 0-24-10.7-24-24V48H48v416h288z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Edit
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-caret-down icon-right"
+      data-icon="caret-down"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M272 160H48.1c-42.6 0-64.2 51.7-33.9 81.9l111.9 112c18.7 18.7 49.1 18.7 67.9 0l112-112c30-30.1 8.7-81.9-34-81.9zM160 320L48 208h224L160 320z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+   
+  <button
+    aria-disabled={true}
+    className="Button btn btn-outline-warning btn-md"
     disabled={true}
     type="button"
   >

--- a/src/Button/Buttons.stories.jsx
+++ b/src/Button/Buttons.stories.jsx
@@ -51,6 +51,16 @@ export const Primary = () => (
     </Button>
     {' '}
     <Button
+      disabled
+      leadingIcon={faFileAlt}
+      size="sm"
+      trailingIcon={faCaretDown}
+      variant="outline-primary"
+    >
+      Confirm
+    </Button>
+    {' '}
+    <Button
       leadingIcon={faFileAlt}
       size="md"
       trailingIcon={faCaretDown}
@@ -74,6 +84,16 @@ export const Primary = () => (
       size="md"
       trailingIcon={faCaretDown}
       variant="primary"
+    >
+      Confirm
+    </Button>
+    {' '}
+    <Button
+      disabled
+      leadingIcon={faFileAlt}
+      size="md"
+      trailingIcon={faCaretDown}
+      variant="outline-primary"
     >
       Confirm
     </Button>
@@ -109,6 +129,16 @@ export const Danger = () => (
     >
       Delete
     </Button>
+    <Button
+      disabled
+      leadingIcon={faFileAlt}
+      size="sm"
+      trailingIcon={faCaretDown}
+      variant="outline-danger"
+    >
+      Delete
+    </Button>
+    {' '}
     {' '}
     <Button
       leadingIcon={faFileAlt}
@@ -134,6 +164,16 @@ export const Danger = () => (
       size="md"
       trailingIcon={faCaretDown}
       variant="danger"
+    >
+      Delete
+    </Button>
+    {' '}
+    <Button
+      disabled
+      leadingIcon={faFileAlt}
+      size="md"
+      trailingIcon={faCaretDown}
+      variant="outline-danger"
     >
       Delete
     </Button>
@@ -171,6 +211,16 @@ export const Warning = () => (
     </Button>
     {' '}
     <Button
+      disabled
+      leadingIcon={faFileAlt}
+      size="sm"
+      trailingIcon={faCaretDown}
+      variant="outline-warning"
+    >
+      Edit
+    </Button>
+    {' '}
+    <Button
       leadingIcon={faFileAlt}
       size="md"
       trailingIcon={faCaretDown}
@@ -194,6 +244,16 @@ export const Warning = () => (
       size="md"
       trailingIcon={faCaretDown}
       variant="warning"
+    >
+      Edit
+    </Button>
+    {' '}
+    <Button
+      disabled
+      leadingIcon={faFileAlt}
+      size="md"
+      trailingIcon={faCaretDown}
+      variant="outline-warning"
     >
       Edit
     </Button>
@@ -231,6 +291,16 @@ export const Transparent = () => (
     </Button>
     {' '}
     <Button
+      disabled
+      leadingIcon={faFileAlt}
+      size="sm"
+      trailingIcon={faCaretDown}
+      variant="outline-transparent"
+    >
+      Skip
+    </Button>
+    {' '}
+    <Button
       leadingIcon={faFileAlt}
       size="md"
       trailingIcon={faCaretDown}
@@ -254,6 +324,16 @@ export const Transparent = () => (
       size="md"
       trailingIcon={faCaretDown}
       variant="transparent"
+    >
+      Skip
+    </Button>
+    {' '}
+    <Button
+      disabled
+      leadingIcon={faFileAlt}
+      size="md"
+      trailingIcon={faCaretDown}
+      variant="outline-transparent"
     >
       Skip
     </Button>


### PR DESCRIPTION
closes #893

- Make `outline-transparent` disabled more obvious based on Veronica's design
- Add `disabled` Button examples in Storybook

<img width="1108" alt="image" src="https://user-images.githubusercontent.com/20173797/230927160-ccbdf415-0c51-4193-8e1a-0d936d8b0c48.png">