### PR TITLE
move btn-focus-outline--dark-bg to buttons styles

### DIFF
--- a/scss/buttons.scss
+++ b/scss/buttons.scss
@@ -28,6 +28,12 @@ $warning: $ux-yellow-400;
   outline-offset: 0.125rem;
 }
 
+@mixin btn-focus-outline--dark-bg {
+  box-shadow: none !important;
+  outline: 0.125rem solid $ux-white;
+  outline-offset: 0.125rem;
+}
+
 @mixin btn-remove-bootstrap-focus-outline {
   box-shadow: none !important;
 }


### PR DESCRIPTION
closes #912 

Just moving this mixin into our `buttons.scss` file. Related to PR: https://github.com/user-interviews/rails-server/pull/18123