### PR TITLE
Improve Drawer breakpoints on tablets

### DIFF
--- a/src/Drawer/Drawer.scss
+++ b/src/Drawer/Drawer.scss
@@ -19,15 +19,19 @@
 }
 
 .Drawer {
-  @include media-breakpoint-up(sm) {
+  @media (min-width: $drawer-width-small) {
     &--sm {
       width: $drawer-width-small
     }
+  }
 
+  @media (min-width: $drawer-width-medium) {
     &--md {
       width: $drawer-width-medium;
     }
+  }
 
+  @media (min-width: $drawer-width-large) {
     &--lg {
       width: $drawer-width-large;
     }


### PR DESCRIPTION
Closes #920

* The breakpoints weren't working as intended on tablet sized screens. Improved the media queries so when the screen size hits the width of the drawer the drawer becomes 100% width, for all size variants.
* Switched to standard media queries instead of Bootstrap's mixin since we don't use it elsewhere

## Before

https://github.com/user-interviews/ui-design-system/assets/20173797/71a24214-7a40-4572-92f6-3fb8819b9984

## After


https://github.com/user-interviews/ui-design-system/assets/20173797/5222a46c-aa05-40e9-b7fd-aa06a820c453

