### PR TITLE
bump node version max to 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "scss"
   ],
   "engines": {
-    "node": ">= 16 < 17",
+    "node": ">= 16 < 19",
     "yarn": "^ 1.22"
   },
   "main": "lib/index.js",


### PR DESCRIPTION
closes #925 

Bumping the `node` version max to 19. We're aiming for `18.16.0` on RS, since 16 is EOL in September.  

![Screenshot 2023-05-17 at 10 04 39 AM](https://github.com/user-interviews/ui-design-system/assets/37383785/3ede42a0-bd6c-4c25-a8bb-eaa9c27ce164)
