### PR TITLE
change Chromatic build deploy on main branch

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,13 +1,13 @@
 # .github/workflows/chromatic.yml
 
 # Workflow name
-name: 'Chromatic build on develop'
+name: 'Chromatic build on main'
 
 # Event for the workflow
 on:
   push:
     branches:
-      - develop
+      - main
 
 # List of jobs
 jobs:


### PR DESCRIPTION
closes #943 

We have about a 5,000 snapshot limit on Chromatic every month and I find myself getting closer to the limit more often / I have to think about hitting the limit. 

Changing the deploy step on `main` makes a little more sense at this point since we really just need to inspect the visual diffs before a release anyways. Also just reduces the noise on the Chromatic dashboard with all the pushes to `develop`

![Screenshot 2023-05-22 at 12 59 54 PM](https://github.com/user-interviews/ui-design-system/assets/37383785/2063b0f3-f53c-4b9e-989e-7308e4ef0afb)

![Screenshot 2023-05-22 at 12 59 39 PM](https://github.com/user-interviews/ui-design-system/assets/37383785/076b4770-43b3-443f-a23a-ef1d71a20552)
