### PR TITLE
add MoneyInput component

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "dependencies": {
     "react-bootstrap": "^2.5.0",
+    "react-currency-input-field": "^3.6.10",
     "react-loading-skeleton": "^3.1.0",
     "react-router-dom": "^5.2.0",
     "react-select": "^5.0.0",

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -9403,6 +9403,86 @@ exports[`Storyshots Components/Modal With Subtitle Modal 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/MoneyInput Default 1`] = `
+<div
+  className="FormGroup"
+>
+  <label
+    className="InputLabel"
+    htmlFor="money-input-1"
+  >
+    Incentive amount
+  </label>
+  <input
+    className="MoneyInput form-control"
+    disabled={false}
+    id="money-input-1"
+    inputMode="decimal"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    placeholder="Please enter a number"
+    type="text"
+    value="1,250.99"
+  />
+  <br />
+  <h2
+    className="Heading Heading--xxl Heading--bold"
+    style={
+      Object {
+        "textAlign": undefined,
+      }
+    }
+  >
+    Value: 
+    1250.99
+  </h2>
+</div>
+`;
+
+exports[`Storyshots Components/MoneyInput Prefix 1`] = `
+Array [
+  <div
+    className="FormGroup"
+  >
+    <label
+      className="InputLabel"
+      htmlFor="money-input-2"
+    >
+      Incentive amount
+    </label>
+    <input
+      className="MoneyInput form-control"
+      disabled={false}
+      id="money-input-2"
+      inputMode="decimal"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      placeholder="Please enter incentive amount"
+      type="text"
+      value="$2,500.55"
+    />
+  </div>,
+  <br />,
+  <h2
+    className="Heading Heading--xxl Heading--bold"
+    style={
+      Object {
+        "textAlign": undefined,
+      }
+    }
+  >
+    Value: 
+    2500.55
+  </h2>,
+]
+`;
+
 exports[`Storyshots Components/Pill Default 1`] = `
 <div>
   <h4

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -9425,7 +9425,7 @@ exports[`Storyshots Components/MoneyInput Default 1`] = `
     onKeyUp={[Function]}
     placeholder="Please enter a number"
     type="text"
-    value="1,250.99"
+    value="$1,250.99"
   />
   <br />
   <h2
@@ -9440,47 +9440,6 @@ exports[`Storyshots Components/MoneyInput Default 1`] = `
     1250.99
   </h2>
 </div>
-`;
-
-exports[`Storyshots Components/MoneyInput Prefix 1`] = `
-Array [
-  <div
-    className="FormGroup"
-  >
-    <label
-      className="InputLabel"
-      htmlFor="money-input-2"
-    >
-      Incentive amount
-    </label>
-    <input
-      className="MoneyInput form-control"
-      disabled={false}
-      id="money-input-2"
-      inputMode="decimal"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      placeholder="Please enter incentive amount"
-      type="text"
-      value="$2,500.55"
-    />
-  </div>,
-  <br />,
-  <h2
-    className="Heading Heading--xxl Heading--bold"
-    style={
-      Object {
-        "textAlign": undefined,
-      }
-    }
-  >
-    Value: 
-    2500.55
-  </h2>,
-]
 `;
 
 exports[`Storyshots Components/Pill Default 1`] = `

--- a/src/MoneyInput/MoneyInput.jsx
+++ b/src/MoneyInput/MoneyInput.jsx
@@ -20,36 +20,8 @@ MoneyInput.propTypes = {
   */
   allowNegativeValue: PropTypes.bool,
   className: PropTypes.string,
-  /**
-    Specify decimal scale for padding/trimming eg. 1.5 -> 1.50 or 1.234 -> 1.23 if decimal scale 2
-  */
-  decimalScale: PropTypes.number,
-  /**
-    Separator between integer part and fractional part of value
-  */
-  decimalSeparator: PropTypes.string,
-  /**
-    Limit length of decimals allowed
-  */
-  decimalsLimit: PropTypes.number,
   defaultValue: PropTypes.number,
-  /**
-    Disable abbreviations eg. 1k -> 1,000, 2m -> 2,000,000
-  */
-  disableAbbreviations: PropTypes.bool,
   disabled: PropTypes.bool,
-  /**
-    Disable auto adding the group separator between values, eg. 1000 -> 1,000
-  */
-  disableGroupSeparators: PropTypes.bool,
-  /**
-    Value will always have the specified length of decimals
-  */
-  fixedDecimalLength: PropTypes.number,
-  /**
-    Separator between thousand, million and billion
-  */
-  groupSeparator: PropTypes.string,
   /**
     International locale config
   */
@@ -63,18 +35,6 @@ MoneyInput.propTypes = {
   */
   placeholder: PropTypes.string,
   /**
-    Include a prefix eg. £ or $
-  */
-  prefix: PropTypes.string,
-  /**
-    Incremental value change on arrow down and arrow up key press
-  */
-  step: PropTypes.number,
-  /**
-    Include a suffix eg. € or %
-  */
-  suffix: PropTypes.string,
-  /**
     Transform the raw value from the input before parsing. Needs to return string.
   */
   transformRawValue: PropTypes.func,
@@ -87,23 +47,13 @@ MoneyInput.defaultProps = {
   allowNegativeValue: true,
   className: undefined,
   defaultValue: undefined,
+  disabled: false,
+  intlConfig: { locale: 'en-US', currency: 'USD' },
+  maxLength: undefined,
+  placeholder: undefined,
+  transformRawValue: undefined,
   value: undefined,
   onValueChange: undefined,
-  placeholder: undefined,
-  decimalsLimit: 2,
-  decimalScale: undefined,
-  fixedDecimalLength: undefined,
-  prefix: '$',
-  suffix: undefined,
-  decimalSeparator: undefined,
-  groupSeparator: undefined,
-  intlConfig: undefined,
-  disabled: false,
-  disableAbbreviations: false,
-  disableGroupSeparators: false,
-  maxLength: undefined,
-  step: undefined,
-  transformRawValue: undefined,
 };
 
 export default MoneyInput;

--- a/src/MoneyInput/MoneyInput.jsx
+++ b/src/MoneyInput/MoneyInput.jsx
@@ -93,7 +93,7 @@ MoneyInput.defaultProps = {
   decimalsLimit: 2,
   decimalScale: undefined,
   fixedDecimalLength: undefined,
-  prefix: undefined,
+  prefix: '$',
   suffix: undefined,
   decimalSeparator: undefined,
   groupSeparator: undefined,

--- a/src/MoneyInput/MoneyInput.jsx
+++ b/src/MoneyInput/MoneyInput.jsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import CurrencyInput from 'react-currency-input-field';
+
+import './MoneyInput.scss';
+
+const MoneyInput = ({ className, ...props }) => (
+  <CurrencyInput className={classNames(className, 'MoneyInput', 'form-control')} {...props} />
+);
+
+MoneyInput.propTypes = {
+  /**
+    Allow decimals in input
+  */
+  allowDecimals: PropTypes.bool,
+  /**
+    Allow user to enter negative value
+  */
+  allowNegativeValue: PropTypes.bool,
+  className: PropTypes.string,
+  /**
+    Specify decimal scale for padding/trimming eg. 1.5 -> 1.50 or 1.234 -> 1.23 if decimal scale 2
+  */
+  decimalScale: PropTypes.number,
+  /**
+    Separator between integer part and fractional part of value
+  */
+  decimalSeparator: PropTypes.string,
+  /**
+    Limit length of decimals allowed
+  */
+  decimalsLimit: PropTypes.number,
+  defaultValue: PropTypes.number,
+  /**
+    Disable abbreviations eg. 1k -> 1,000, 2m -> 2,000,000
+  */
+  disableAbbreviations: PropTypes.bool,
+  disabled: PropTypes.bool,
+  /**
+    Disable auto adding the group separator between values, eg. 1000 -> 1,000
+  */
+  disableGroupSeparators: PropTypes.bool,
+  /**
+    Value will always have the specified length of decimals
+  */
+  fixedDecimalLength: PropTypes.number,
+  /**
+    Separator between thousand, million and billion
+  */
+  groupSeparator: PropTypes.string,
+  /**
+    International locale config
+  */
+  intlConfig: PropTypes.object,
+  /**
+    Maximum characters the user can enter
+  */
+  maxLength: PropTypes.number,
+  /**
+    Placeholder if no value
+  */
+  placeholder: PropTypes.string,
+  /**
+    Include a prefix eg. £ or $
+  */
+  prefix: PropTypes.string,
+  /**
+    Incremental value change on arrow down and arrow up key press
+  */
+  step: PropTypes.number,
+  /**
+    Include a suffix eg. € or %
+  */
+  suffix: PropTypes.string,
+  /**
+    Transform the raw value from the input before parsing. Needs to return string.
+  */
+  transformRawValue: PropTypes.func,
+  value: PropTypes.number,
+  onValueChange: PropTypes.func,
+};
+
+MoneyInput.defaultProps = {
+  allowDecimals: true,
+  allowNegativeValue: true,
+  className: undefined,
+  defaultValue: undefined,
+  value: undefined,
+  onValueChange: undefined,
+  placeholder: undefined,
+  decimalsLimit: 2,
+  decimalScale: undefined,
+  fixedDecimalLength: undefined,
+  prefix: undefined,
+  suffix: undefined,
+  decimalSeparator: undefined,
+  groupSeparator: undefined,
+  intlConfig: undefined,
+  disabled: false,
+  disableAbbreviations: false,
+  disableGroupSeparators: false,
+  maxLength: undefined,
+  step: undefined,
+  transformRawValue: undefined,
+};
+
+export default MoneyInput;

--- a/src/MoneyInput/MoneyInput.mdx
+++ b/src/MoneyInput/MoneyInput.mdx
@@ -20,9 +20,3 @@ import * as ComponentStories from './MoneyInput.stories';
 ### Default
 
 <Canvas of={ComponentStories.Default} />
-
-### Prefix
-
-<Canvas of={ComponentStories.Prefix} />
-
-

--- a/src/MoneyInput/MoneyInput.mdx
+++ b/src/MoneyInput/MoneyInput.mdx
@@ -1,0 +1,28 @@
+import { ArgTypes, Canvas } from '@storybook/blocks';
+import MoneyInput from './MoneyInput';
+import * as ComponentStories from './MoneyInput.stories';
+
+# MoneyInput
+
+##
+
+<h4>
+  A user-friendly input field that allows for easy and accurate entry of monetary values.
+</h4>
+
+<Canvas of={ComponentStories.Default} />
+
+<ArgTypes of={MoneyInput} />
+
+
+## Stories
+
+### Default
+
+<Canvas of={ComponentStories.Default} />
+
+### Prefix
+
+<Canvas of={ComponentStories.Prefix} />
+
+

--- a/src/MoneyInput/MoneyInput.scss
+++ b/src/MoneyInput/MoneyInput.scss
@@ -1,0 +1,13 @@
+@import '../../scss/theme';
+
+.MoneyInput {
+  @include font-type-30;
+  box-shadow: $input-box-shadow;
+
+  &:focus {
+    border: 0.06rem solid $ux-blue-500;
+    box-shadow: $input-focus-box-shadow;
+    color: $input-focus-color;
+    filter: drop-shadow(0px 0px 3px rgba(102, 175, 233, 0.7));
+  }
+}

--- a/src/MoneyInput/MoneyInput.stories.jsx
+++ b/src/MoneyInput/MoneyInput.stories.jsx
@@ -47,36 +47,3 @@ Default.args = {
   placeholder: 'Please enter a number',
   decimalsLimit: 2,
 };
-
-export const Prefix = (args) => {
-  const [value, setValue] = useState(2500.55);
-
-  const handleOnValueChange = (val) => {
-    if (!val) {
-      setValue('');
-      return;
-    }
-    setValue(val);
-  };
-
-  return (
-    <>
-      <FormGroup label="Incentive amount" labelHtmlFor="money-input-2">
-        <MoneyInput
-          value={value}
-          onValueChange={handleOnValueChange}
-          {...args}
-        />
-      </FormGroup>
-      <br />
-      <Heading>Value: {value}</Heading>
-    </>
-  );
-};
-
-Prefix.args = {
-  id: 'money-input-2',
-  placeholder: 'Please enter incentive amount',
-  prefix: '$',
-  decimalsLimit: 2,
-};

--- a/src/MoneyInput/MoneyInput.stories.jsx
+++ b/src/MoneyInput/MoneyInput.stories.jsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+
+import FormGroup from 'src/FormGroup';
+import { Heading } from 'src/Heading';
+import MoneyInput from './MoneyInput';
+
+import mdx from './MoneyInput.mdx';
+
+export default {
+  title: 'Components/MoneyInput',
+  component: MoneyInput,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+};
+
+export const Default = (args) => {
+  const [value, setValue] = useState(1250.99);
+
+  const handleOnValueChange = (val) => {
+    if (!val) {
+      setValue('');
+      return;
+    }
+    setValue(val);
+  };
+
+  return (
+    <>
+      <FormGroup label="Incentive amount" labelHtmlFor="money-input-1">
+        <MoneyInput
+          value={value}
+          onValueChange={handleOnValueChange}
+          {...args}
+        />
+        <br />
+        <Heading>Value: {value}</Heading>
+      </FormGroup>
+    </>
+  );
+};
+
+Default.args = {
+  id: 'money-input-1',
+  placeholder: 'Please enter a number',
+  decimalsLimit: 2,
+};
+
+export const Prefix = (args) => {
+  const [value, setValue] = useState(2500.55);
+
+  const handleOnValueChange = (val) => {
+    if (!val) {
+      setValue('');
+      return;
+    }
+    setValue(val);
+  };
+
+  return (
+    <>
+      <FormGroup label="Incentive amount" labelHtmlFor="money-input-2">
+        <MoneyInput
+          value={value}
+          onValueChange={handleOnValueChange}
+          {...args}
+        />
+      </FormGroup>
+      <br />
+      <Heading>Value: {value}</Heading>
+    </>
+  );
+};
+
+Prefix.args = {
+  id: 'money-input-2',
+  placeholder: 'Please enter incentive amount',
+  prefix: '$',
+  decimalsLimit: 2,
+};

--- a/src/MoneyInput/index.js
+++ b/src/MoneyInput/index.js
@@ -1,0 +1,1 @@
+export { default } from './MoneyInput';

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,7 @@ import {
   ModalFooter,
   ModalHeader,
 } from 'src/Modal';
+import MoneyInput from 'src/MoneyInput';
 import { OverlayTrigger, OVERLAY_TRIGGER_PLACEMENT } from 'src/OverlayTrigger';
 import { Pill, Pills, PILL_COLORS } from 'src/Pill';
 import { Popover, PopoverBody, PopoverCard } from 'src/Popover';
@@ -149,6 +150,7 @@ export {
   ModalBody,
   ModalFooter,
   ModalHeader,
+  MoneyInput,
   Option,
   OptionWithDescription,
   OverlayTrigger,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10739,6 +10739,11 @@ react-copy-to-clipboard@^5.0.2:
     copy-to-clipboard "^3.3.1"
     prop-types "^15.8.1"
 
+react-currency-input-field@^3.6.10:
+  version "3.6.10"
+  resolved "https://registry.yarnpkg.com/react-currency-input-field/-/react-currency-input-field-3.6.10.tgz#f04663a2074b894735edb6d9fae95499727596b1"
+  integrity sha512-KRAJJaLujarBTLlEVbznsUxQ56+Qyqwoe5w9DnGxmsGnHv4ycQRpRkuuCDfF9BcXHmegzsOXesfIGpW7Cw9mTQ==
+
 react-docgen-typescript@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz#4611055e569edc071204aadb20e1c93e1ab1659c"


### PR DESCRIPTION
closes #736 

## Context

Chatted with Nat on RX Workflow and decided that it would be helpful to bring in a MoneyInput component which aligns with their current efforts relating to incentive editing (as well as improving the overall validation experience for existing currency inputs)

## Reviewer Expectations
Primary Reviewer: Gabe
Secondary Reviewer(s): Dom, Stephen, Nat

## Testing

You can view a live build in Chromatic here: https://62d040e741710e4f085e0647-ppfritpjca.chromatic.com/?path=/docs/components-moneyinput--docs

One example test from RS in `app/javascript/researcher/project_workspace/details/compensation_fields/index.jsx`

Before:

https://github.com/user-interviews/ui-design-system/assets/37383785/8310a0e9-af02-4e05-9a6a-f185522f14ab

After:

https://github.com/user-interviews/ui-design-system/assets/37383785/c34426af-5bf9-49a5-8e51-3ed8f9ae1a9e

