### PR TITLE
add IconButton

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -11,6 +11,7 @@ const config = {
     },
     '@storybook/addon-a11y',
     '@storybook/addon-actions',
+    '@storybook/addon-backgrounds',
     '@storybook/addon-controls',
     '@storybook/addon-links',
     '@storybook/addon-knobs',

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,28 @@
+import colors from '../src/Styles/colors/palette';
+
 const preview = {
   parameters: {
+    backgrounds: {
+      default: '$ux-white',
+      values: [
+        {
+          name: '$ux-white',
+          value: colors.UX_WHITE,
+        },
+        {
+          name: '$ux-cream',
+          value: colors.UX_CREAM,
+        },
+        {
+          name: '$ux-emerald-600',
+          value: colors.UX_EMERALD_600,
+        },
+        {
+          name: '$ux-neutral-800',
+          value: colors.UX_NEUTRAL_800,
+        }
+      ],
+    },
     options: {
       storySort: {
         order: ['Foundations', 'Components'],

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@popperjs/core": "^2.5.3",
     "@storybook/addon-a11y": "7.0.8",
     "@storybook/addon-actions": "7.0.8",
+    "@storybook/addon-backgrounds": "7.0.8",
     "@storybook/addon-controls": "^7.0.8",
     "@storybook/addon-docs": "7.0.8",
     "@storybook/addon-jest": "7.0.8",

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -8551,10 +8551,10 @@ Array [
 ]
 `;
 
-exports[`Storyshots Components/IconButton Default 1`] = `
-<span>
+exports[`Storyshots Components/IconButton Aria Label 1`] = `
+Array [
   <button
-    aria-label="Previous"
+    aria-label="Previous page"
     className="Button IconButton btn btn-transparent btn-sm"
     disabled={false}
     type="button"
@@ -8576,9 +8576,9 @@ exports[`Storyshots Components/IconButton Default 1`] = `
         style={Object {}}
       />
     </svg>
-  </button>
+  </button>,
   <button
-    aria-label="Next"
+    aria-label="Next page"
     className="Button IconButton btn btn-transparent btn-sm"
     disabled={false}
     type="button"
@@ -8600,9 +8600,9 @@ exports[`Storyshots Components/IconButton Default 1`] = `
         style={Object {}}
       />
     </svg>
-  </button>
+  </button>,
   <button
-    aria-label="Delete"
+    aria-label="Delete participant"
     className="Button IconButton btn btn-transparent btn-sm"
     disabled={false}
     type="button"
@@ -8624,7 +8624,84 @@ exports[`Storyshots Components/IconButton Default 1`] = `
         style={Object {}}
       />
     </svg>
-  </button>
+  </button>,
+  <button
+    aria-label="Edit note"
+    className="Button IconButton btn btn-transparent btn-sm"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-pencil fa-fw"
+      data-icon="pencil"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M491.609 73.625l-53.861-53.839c-26.378-26.379-69.076-26.383-95.46-.001L24.91 335.089.329 484.085c-2.675 16.215 11.368 30.261 27.587 27.587l148.995-24.582 315.326-317.378c26.33-26.331 26.581-68.879-.628-96.087zM120.644 302l170.259-169.155 88.251 88.251L210 391.355V350h-48v-48h-41.356zM82.132 458.132l-28.263-28.263 12.14-73.587L84.409 338H126v48h48v41.59l-18.282 18.401-73.586 12.141zm378.985-319.533l-.051.051-.051.051-48.03 48.344-88.03-88.03 48.344-48.03.05-.05.05-.05c9.147-9.146 23.978-9.259 33.236-.001l53.854 53.854c9.878 9.877 9.939 24.549.628 33.861z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>,
+]
+`;
+
+exports[`Storyshots Components/IconButton Common Actions 1`] = `
+Array [
+  <button
+    aria-label="Add"
+    className="Button IconButton btn btn-transparent btn-sm"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-plus-circle fa-fw"
+      data-icon="plus-circle"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M384 240v32c0 6.6-5.4 12-12 12h-88v88c0 6.6-5.4 12-12 12h-32c-6.6 0-12-5.4-12-12v-88h-88c-6.6 0-12-5.4-12-12v-32c0-6.6 5.4-12 12-12h88v-88c0-6.6 5.4-12 12-12h32c6.6 0 12 5.4 12 12v88h88c6.6 0 12 5.4 12 12zm120 16c0 137-111 248-248 248S8 393 8 256 119 8 256 8s248 111 248 248zm-48 0c0-110.5-89.5-200-200-200S56 145.5 56 256s89.5 200 200 200 200-89.5 200-200z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>,
+  <button
+    aria-label="Subtract"
+    className="Button IconButton btn btn-transparent btn-sm"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-minus-circle fa-fw"
+      data-icon="minus-circle"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M140 284c-6.6 0-12-5.4-12-12v-32c0-6.6 5.4-12 12-12h232c6.6 0 12 5.4 12 12v32c0 6.6-5.4 12-12 12H140zm364-28c0 137-111 248-248 248S8 393 8 256 119 8 256 8s248 111 248 248zm-48 0c0-110.5-89.5-200-200-200S56 145.5 56 256s89.5 200 200 200 200-89.5 200-200z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>,
   <button
     aria-label="Edit"
     className="Button IconButton btn btn-transparent btn-sm"
@@ -8648,8 +8725,104 @@ exports[`Storyshots Components/IconButton Default 1`] = `
         style={Object {}}
       />
     </svg>
-  </button>
-</span>
+  </button>,
+  <button
+    aria-label="Delete"
+    className="Button IconButton btn btn-transparent btn-sm"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-trash-alt fa-fw"
+      data-icon="trash-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 448 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>,
+  <button
+    aria-label="Copy"
+    className="Button IconButton btn btn-transparent btn-sm"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-copy fa-fw"
+      data-icon="copy"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 448 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M433.941 65.941l-51.882-51.882A48 48 0 0 0 348.118 0H176c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h224c26.51 0 48-21.49 48-48v-48h80c26.51 0 48-21.49 48-48V99.882a48 48 0 0 0-14.059-33.941zM266 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h74v224c0 26.51 21.49 48 48 48h96v42a6 6 0 0 1-6 6zm128-96H182a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h106v88c0 13.255 10.745 24 24 24h88v202a6 6 0 0 1-6 6zm6-256h-64V48h9.632c1.591 0 3.117.632 4.243 1.757l48.368 48.368a6 6 0 0 1 1.757 4.243V112z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>,
+  <button
+    aria-label="Previous"
+    className="Button IconButton btn btn-transparent btn-sm"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-chevron-left fa-fw"
+      data-icon="chevron-left"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 256 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>,
+  <button
+    aria-label="Next"
+    className="Button IconButton btn btn-transparent btn-sm"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-chevron-right fa-fw"
+      data-icon="chevron-right"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 256 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>,
+]
 `;
 
 exports[`Storyshots Components/IconCell Default 1`] = `

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -8551,6 +8551,107 @@ Array [
 ]
 `;
 
+exports[`Storyshots Components/IconButton Default 1`] = `
+<span>
+  <button
+    aria-label="Previous"
+    className="Button IconButton btn btn-transparent"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-chevron-left "
+      data-icon="chevron-left"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 256 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+  <button
+    aria-label="Next"
+    className="Button IconButton btn btn-transparent"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-chevron-right "
+      data-icon="chevron-right"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 256 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+  <button
+    aria-label="Delete"
+    className="Button IconButton btn btn-transparent"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-trash-alt "
+      data-icon="trash-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 448 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+  <button
+    aria-label="Edit"
+    className="Button IconButton btn btn-transparent"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-pencil "
+      data-icon="pencil"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M491.609 73.625l-53.861-53.839c-26.378-26.379-69.076-26.383-95.46-.001L24.91 335.089.329 484.085c-2.675 16.215 11.368 30.261 27.587 27.587l148.995-24.582 315.326-317.378c26.33-26.331 26.581-68.879-.628-96.087zM120.644 302l170.259-169.155 88.251 88.251L210 391.355V350h-48v-48h-41.356zM82.132 458.132l-28.263-28.263 12.14-73.587L84.409 338H126v48h48v41.59l-18.282 18.401-73.586 12.141zm378.985-319.533l-.051.051-.051.051-48.03 48.344-88.03-88.03 48.344-48.03.05-.05.05-.05c9.147-9.146 23.978-9.259 33.236-.001l53.854 53.854c9.878 9.877 9.939 24.549.628 33.861z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>
+</span>
+`;
+
 exports[`Storyshots Components/IconCell Default 1`] = `
 <div>
   <div

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -8555,13 +8555,13 @@ exports[`Storyshots Components/IconButton Default 1`] = `
 <span>
   <button
     aria-label="Previous"
-    className="Button IconButton btn btn-transparent"
+    className="Button IconButton btn btn-transparent btn-sm"
     disabled={false}
     type="button"
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-chevron-left "
+      className="svg-inline--fa fa-chevron-left fa-fw"
       data-icon="chevron-left"
       data-prefix="far"
       focusable="false"
@@ -8579,13 +8579,13 @@ exports[`Storyshots Components/IconButton Default 1`] = `
   </button>
   <button
     aria-label="Next"
-    className="Button IconButton btn btn-transparent"
+    className="Button IconButton btn btn-transparent btn-sm"
     disabled={false}
     type="button"
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-chevron-right "
+      className="svg-inline--fa fa-chevron-right fa-fw"
       data-icon="chevron-right"
       data-prefix="far"
       focusable="false"
@@ -8603,13 +8603,13 @@ exports[`Storyshots Components/IconButton Default 1`] = `
   </button>
   <button
     aria-label="Delete"
-    className="Button IconButton btn btn-transparent"
+    className="Button IconButton btn btn-transparent btn-sm"
     disabled={false}
     type="button"
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-trash-alt "
+      className="svg-inline--fa fa-trash-alt fa-fw"
       data-icon="trash-alt"
       data-prefix="far"
       focusable="false"
@@ -8627,13 +8627,13 @@ exports[`Storyshots Components/IconButton Default 1`] = `
   </button>
   <button
     aria-label="Edit"
-    className="Button IconButton btn btn-transparent"
+    className="Button IconButton btn btn-transparent btn-sm"
     disabled={false}
     type="button"
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-pencil "
+      className="svg-inline--fa fa-pencil fa-fw"
       data-icon="pencil"
       data-prefix="far"
       focusable="false"

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -8822,6 +8822,54 @@ Array [
       />
     </svg>
   </button>,
+  <button
+    aria-label="Close"
+    className="Button IconButton btn btn-transparent btn-sm"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-times fa-fw"
+      data-icon="times"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M207.6 256l107.72-107.72c6.23-6.23 6.23-16.34 0-22.58l-25.03-25.03c-6.23-6.23-16.34-6.23-22.58 0L160 208.4 52.28 100.68c-6.23-6.23-16.34-6.23-22.58 0L4.68 125.7c-6.23 6.23-6.23 16.34 0 22.58L112.4 256 4.68 363.72c-6.23 6.23-6.23 16.34 0 22.58l25.03 25.03c6.23 6.23 16.34 6.23 22.58 0L160 303.6l107.72 107.72c6.23 6.23 16.34 6.23 22.58 0l25.03-25.03c6.23-6.23 6.23-16.34 0-22.58L207.6 256z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>,
+  <button
+    aria-label="Expand"
+    className="Button IconButton btn btn-transparent btn-sm"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-expand-alt fa-fw"
+      data-icon="expand-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 448 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M448 56v95.005c0 21.382-25.851 32.09-40.971 16.971l-27.704-27.704-107.242 107.243c-4.686 4.686-12.284 4.686-16.971 0l-22.627-22.627c-4.686-4.686-4.686-12.284 0-16.971l107.243-107.243-27.704-27.704C296.905 57.851 307.613 32 328.995 32H424c13.255 0 24 10.745 24 24zM175.917 264.485L68.674 371.728 40.97 344.024C25.851 328.905 0 339.613 0 360.995V456c0 13.255 10.745 24 24 24h95.005c21.382 0 32.09-25.851 16.971-40.971l-27.704-27.704 107.243-107.243c4.686-4.686 4.686-12.284 0-16.971l-22.627-22.627c-4.687-4.685-12.285-4.685-16.971.001z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>,
 ]
 `;
 

--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -8825,6 +8825,59 @@ Array [
 ]
 `;
 
+exports[`Storyshots Components/IconButton Sizes 1`] = `
+Array [
+  <button
+    aria-label="Delete"
+    className="Button IconButton btn btn-transparent btn-sm"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-trash-alt fa-fw"
+      data-icon="trash-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 448 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>,
+  <button
+    aria-label="Delete"
+    className="Button IconButton btn btn-transparent btn-md"
+    disabled={false}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-trash-alt fa-fw fa-lg"
+      data-icon="trash-alt"
+      data-prefix="far"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 448 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </button>,
+]
+`;
+
 exports[`Storyshots Components/IconCell Default 1`] = `
 <div>
   <div

--- a/src/Button/Button.jsx
+++ b/src/Button/Button.jsx
@@ -8,6 +8,22 @@ import { Button as RBButton } from 'react-bootstrap';
 
 import './Button.scss';
 
+export const ButtonVariants = {
+  BRAND_GOOGLE: 'brand-google',
+  BRAND_FACEBOOK: 'brand-facebook',
+  BRAND_LINKEDIN: 'brand-linkedin',
+  BRAND_TWITTER: 'brand-twitter',
+  DANGER: 'danger',
+  LINK: 'link',
+  OUTLINE_DANGER: 'outline-danger',
+  OUTLINE_PRIMARY: 'outline-primary',
+  OUTLINE_WARNING: 'outline-warning',
+  OUTLINE_TRANSPARENT: 'outline-transparent',
+  PRIMARY: 'primary',
+  TRANSPARENT: 'transparent',
+  WARNING: 'warning',
+};
+
 const Button = forwardRef(({
   children,
   className,

--- a/src/Button/Button.jsx
+++ b/src/Button/Button.jsx
@@ -8,6 +8,11 @@ import { Button as RBButton } from 'react-bootstrap';
 
 import './Button.scss';
 
+export const ButtonSizes = {
+  SMALL: 'sm',
+  MEDIUM: 'md',
+};
+
 export const ButtonVariants = {
   BRAND_GOOGLE: 'brand-google',
   BRAND_FACEBOOK: 'brand-facebook',

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -1,1 +1,1 @@
-export { default, ButtonVariants } from './Button';
+export { default, ButtonSizes, ButtonVariants } from './Button';

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -1,3 +1,1 @@
-import Button from './Button';
-
-export default Button;
+export { default, ButtonVariants } from './Button';

--- a/src/IconButton/IconButton.jsx
+++ b/src/IconButton/IconButton.jsx
@@ -64,7 +64,10 @@ const IconButton = ({
       variant={variant}
       {...props}
     >
-      <FontAwesomeIcon className="fa-fw" icon={action ? IconButtonActions[action]?.icon : icon} />
+      <FontAwesomeIcon
+        className={classnames('fa-fw', size === ButtonSizes.MEDIUM && 'fa-lg')}
+        icon={action ? IconButtonActions[action]?.icon : icon}
+      />
     </Button>
   );
 };

--- a/src/IconButton/IconButton.jsx
+++ b/src/IconButton/IconButton.jsx
@@ -3,14 +3,15 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import Button, { ButtonVariants } from 'src/Button';
+import Button, { ButtonSizes, ButtonVariants } from 'src/Button';
 
 const IconButton = ({
- ariaLabel, className, icon, variant, ...props
+ ariaLabel, className, icon, size, variant, ...props
 }) => (
   <Button
     aria-label={ariaLabel}
     className={classnames('IconButton', className)}
+    size={size}
     variant={variant}
     {...props}
   >
@@ -24,10 +25,12 @@ IconButton.propTypes = {
   ariaLabel: PropTypes.string.isRequired,
   className: PropTypes.string,
   icon: PropTypes.object.isRequired,
+  size: PropTypes.oneOf(Object.values(ButtonSizes)),
   variant: PropTypes.string,
 };
 
 IconButton.defaultProps = {
   className: undefined,
+  size: ButtonSizes.SMALL,
   variant: ButtonVariants.TRANSPARENT,
 };

--- a/src/IconButton/IconButton.jsx
+++ b/src/IconButton/IconButton.jsx
@@ -11,6 +11,8 @@ import {
   faChevronLeft,
   faChevronRight,
   faPencil,
+  faTimes,
+  faExpandAlt,
 } from '@fortawesome/pro-regular-svg-icons';
 
 import Button, { ButtonSizes, ButtonVariants } from 'src/Button';
@@ -43,6 +45,14 @@ export const IconButtonActions = {
   PREVIOUS: {
     icon: faChevronLeft,
     ariaLabel: 'Previous',
+  },
+  CLOSE: {
+    icon: faTimes,
+    ariaLabel: 'Close',
+  },
+  EXPAND: {
+    icon: faExpandAlt,
+    ariaLabel: 'Expand',
   },
 };
 

--- a/src/IconButton/IconButton.jsx
+++ b/src/IconButton/IconButton.jsx
@@ -3,25 +3,76 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
+import {
+  faPlusCircle,
+  faMinusCircle,
+  faTrashAlt,
+  faCopy,
+  faChevronLeft,
+  faChevronRight,
+  faPencil,
+} from '@fortawesome/pro-regular-svg-icons';
+
 import Button, { ButtonSizes, ButtonVariants } from 'src/Button';
 
+export const IconButtonActions = {
+  ADD: {
+    ariaLabel: 'Add',
+    icon: faPlusCircle,
+  },
+  SUBTRACT: {
+    ariaLabel: 'Subtract',
+    icon: faMinusCircle,
+  },
+  EDIT: {
+    ariaLabel: 'Edit',
+    icon: faPencil,
+  },
+  DELETE: {
+    ariaLabel: 'Delete',
+    icon: faTrashAlt,
+  },
+  COPY: {
+    ariaLabel: 'Copy',
+    icon: faCopy,
+  },
+  NEXT: {
+    ariaLabel: 'Next',
+    icon: faChevronRight,
+  },
+  PREVIOUS: {
+    icon: faChevronLeft,
+    ariaLabel: 'Previous',
+  },
+};
+
 const IconButton = ({
- ariaLabel, className, icon, size, variant, ...props
-}) => (
-  <Button
-    aria-label={ariaLabel}
-    className={classnames('IconButton', className)}
-    size={size}
-    variant={variant}
-    {...props}
-  >
-    <FontAwesomeIcon className="fa-fw" icon={icon} />
-  </Button>
-);
+ action, ariaLabel, className, icon, size, variant, ...props
+}) => {
+  const getAriaLabel = () => {
+    if (action) {
+      return ariaLabel || IconButtonActions[action]?.ariaLabel;
+    }
+      return ariaLabel;
+  };
+
+  return (
+    <Button
+      aria-label={getAriaLabel()}
+      className={classnames('IconButton', className)}
+      size={size}
+      variant={variant}
+      {...props}
+    >
+      <FontAwesomeIcon className="fa-fw" icon={action ? IconButtonActions[action]?.icon : icon} />
+    </Button>
+  );
+};
 
 export default IconButton;
 
 IconButton.propTypes = {
+  action: PropTypes.oneOf(Object.keys(IconButtonActions)),
   ariaLabel: PropTypes.string.isRequired,
   className: PropTypes.string,
   icon: PropTypes.object.isRequired,
@@ -30,6 +81,7 @@ IconButton.propTypes = {
 };
 
 IconButton.defaultProps = {
+  action: undefined,
   className: undefined,
   size: ButtonSizes.SMALL,
   variant: ButtonVariants.TRANSPARENT,

--- a/src/IconButton/IconButton.jsx
+++ b/src/IconButton/IconButton.jsx
@@ -15,7 +15,7 @@ const IconButton = ({
     variant={variant}
     {...props}
   >
-    <FontAwesomeIcon icon={icon} />
+    <FontAwesomeIcon className="fa-fw" icon={icon} />
   </Button>
 );
 

--- a/src/IconButton/IconButton.jsx
+++ b/src/IconButton/IconButton.jsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import Button from 'src/Button';
+import Button, { ButtonVariants } from 'src/Button';
 
 const IconButton = ({
  ariaLabel, className, icon, variant, ...props
@@ -29,5 +29,5 @@ IconButton.propTypes = {
 
 IconButton.defaultProps = {
   className: undefined,
-  variant: 'transparent',
+  variant: ButtonVariants.TRANSPARENT,
 };

--- a/src/IconButton/IconButton.jsx
+++ b/src/IconButton/IconButton.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import Button from 'src/Button';
+
+const IconButton = ({
+ ariaLabel, className, icon, variant, ...props
+}) => (
+  <Button
+    aria-label={ariaLabel}
+    className={classnames('IconButton', className)}
+    variant={variant}
+    {...props}
+  >
+    <FontAwesomeIcon icon={icon} />
+  </Button>
+);
+
+export default IconButton;
+
+IconButton.propTypes = {
+  ariaLabel: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  icon: PropTypes.object.isRequired,
+  variant: PropTypes.string,
+};
+
+IconButton.defaultProps = {
+  className: undefined,
+  variant: 'transparent',
+};

--- a/src/IconButton/IconButton.mdx
+++ b/src/IconButton/IconButton.mdx
@@ -7,17 +7,29 @@ import * as ComponentStories from './IconButton.stories';
 ##
 
 <h4>
-  
-The IconButton component is used for creating clickable buttons with icons, commonly found in app bars, toolbars, and toggleable actions.
+  The IconButton component is used for creating clickable buttons with icons, commonly found in app bars, toolbars, and toggleable actions.
 </h4>
 
-<Canvas of={ComponentStories.Default} />
+<Canvas of={ComponentStories.CommonActions} />
 
 <ArgTypes of={IconButton} />
 
 
 ## Stories
 
-### Default
+### Common Actions
+- A set of common actions for the `IconButton` with default `aria-label` attached.
+- Try to use from this defined set before swapping icons.
 
-<Canvas of={ComponentStories.Default} />
+<Canvas of={ComponentStories.CommonActions} />
+
+### Aria Label
+- `aria-label` is required. 
+- use `ariaLabel` to more accurately describe the `IconButton` when necessary.
+
+<Canvas of={ComponentStories.AriaLabel} />
+
+### Sizes
+- Supports `sm` and `md` sizes
+
+<Canvas of={ComponentStories.Sizes} />

--- a/src/IconButton/IconButton.mdx
+++ b/src/IconButton/IconButton.mdx
@@ -1,0 +1,23 @@
+import { ArgTypes, Canvas } from '@storybook/blocks';
+import IconButton from './IconButton';
+import * as ComponentStories from './IconButton.stories';
+
+# IconButton
+
+##
+
+<h4>
+  
+The IconButton component is used for creating clickable buttons with icons, commonly found in app bars, toolbars, and toggleable actions.
+</h4>
+
+<Canvas of={ComponentStories.Default} />
+
+<ArgTypes of={IconButton} />
+
+
+## Stories
+
+### Default
+
+<Canvas of={ComponentStories.Default} />

--- a/src/IconButton/IconButton.stories.jsx
+++ b/src/IconButton/IconButton.stories.jsx
@@ -1,8 +1,5 @@
 import React from 'react';
 
-import {
- faChevronLeft, faChevronRight, faPencil, faTrashAlt,
-} from '@fortawesome/pro-regular-svg-icons';
 import IconButton from './IconButton';
 
 import mdx from './IconButton.mdx';
@@ -17,11 +14,23 @@ export default {
   },
 };
 
-export const Default = () => (
-  <span>
-    <IconButton ariaLabel="Previous" icon={faChevronLeft} />
-    <IconButton ariaLabel="Next" icon={faChevronRight} />
-    <IconButton ariaLabel="Delete" icon={faTrashAlt} />
-    <IconButton ariaLabel="Edit" icon={faPencil} />
-  </span>
+export const CommonActions = () => (
+  <>
+    <IconButton action="ADD" />
+    <IconButton action="SUBTRACT" />
+    <IconButton action="EDIT" />
+    <IconButton action="DELETE" />
+    <IconButton action="COPY" />
+    <IconButton action="PREVIOUS" />
+    <IconButton action="NEXT" />
+  </>
+);
+
+export const AriaLabel = () => (
+  <>
+    <IconButton action="PREVIOUS" ariaLabel="Previous page" />
+    <IconButton action="NEXT" ariaLabel="Next page" />
+    <IconButton action="DELETE" ariaLabel="Delete participant" />
+    <IconButton action="EDIT" ariaLabel="Edit note" />
+  </>
 );

--- a/src/IconButton/IconButton.stories.jsx
+++ b/src/IconButton/IconButton.stories.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import {
+ faChevronLeft, faChevronRight, faPencil, faTrashAlt,
+} from '@fortawesome/pro-regular-svg-icons';
+import IconButton from './IconButton';
+
+import mdx from './IconButton.mdx';
+
+export default {
+  title: 'Components/IconButton',
+  component: IconButton,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+};
+
+export const Default = () => (
+  <span>
+    <IconButton ariaLabel="Previous" icon={faChevronLeft} />
+    <IconButton ariaLabel="Next" icon={faChevronRight} />
+    <IconButton ariaLabel="Delete" icon={faTrashAlt} />
+    <IconButton ariaLabel="Edit" icon={faPencil} />
+  </span>
+);

--- a/src/IconButton/IconButton.stories.jsx
+++ b/src/IconButton/IconButton.stories.jsx
@@ -34,3 +34,10 @@ export const AriaLabel = () => (
     <IconButton action="EDIT" ariaLabel="Edit note" />
   </>
 );
+
+export const Sizes = () => (
+  <>
+    <IconButton action="DELETE" size="sm" />
+    <IconButton action="DELETE" size="md" />
+  </>
+);

--- a/src/IconButton/IconButton.stories.jsx
+++ b/src/IconButton/IconButton.stories.jsx
@@ -23,6 +23,8 @@ export const CommonActions = () => (
     <IconButton action="COPY" />
     <IconButton action="PREVIOUS" />
     <IconButton action="NEXT" />
+    <IconButton action="CLOSE" />
+    <IconButton action="EXPAND" />
   </>
 );
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import {
   AccordionToggle,
 } from 'src/Accordion';
 import { Alert, MessageTypes } from 'src/Alert';
-import Button, { ButtonVariants } from 'src/Button';
+import Button, { ButtonSizes, ButtonVariants } from 'src/Button';
 import Avatar from 'src/Avatar';
 import Card, { CardSizes } from 'src/Card';
 import { CardStack } from 'src/CardStack';
@@ -105,6 +105,7 @@ export {
   AsyncSelect,
   AsyncCreatableSelect,
   Button,
+  ButtonSizes,
   ButtonVariants,
   BUTTON_GROUP_ORIENTATIONS,
   Card,

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import {
   AccordionToggle,
 } from 'src/Accordion';
 import { Alert, MessageTypes } from 'src/Alert';
-import Button from 'src/Button';
+import Button, { ButtonVariants } from 'src/Button';
 import Avatar from 'src/Avatar';
 import Card, { CardSizes } from 'src/Card';
 import { CardStack } from 'src/CardStack';
@@ -105,6 +105,7 @@ export {
   AsyncSelect,
   AsyncCreatableSelect,
   Button,
+  ButtonVariants,
   BUTTON_GROUP_ORIENTATIONS,
   Card,
   CardSizes,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1932,6 +1932,22 @@
     ts-dedent "^2.0.0"
     uuid "^9.0.0"
 
+"@storybook/addon-backgrounds@7.0.8":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-7.0.8.tgz#b317b91a2ef65d8d16af49e4374ef98fc7a9fdfc"
+  integrity sha512-xDTySwXWlyROWi9SJEa12DfGyaYL8oMGADMgn/C82qzcIXGx2tpkjU4UsA/w7JvpZumLr5wEfGrZiStg2xFygA==
+  dependencies:
+    "@storybook/client-logger" "7.0.8"
+    "@storybook/components" "7.0.8"
+    "@storybook/core-events" "7.0.8"
+    "@storybook/global" "^5.0.0"
+    "@storybook/manager-api" "7.0.8"
+    "@storybook/preview-api" "7.0.8"
+    "@storybook/theming" "7.0.8"
+    "@storybook/types" "7.0.8"
+    memoizerific "^1.11.3"
+    ts-dedent "^2.0.0"
+
 "@storybook/addon-controls@^7.0.8":
   version "7.0.12"
   resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-7.0.12.tgz#24f3a579c7485dcb619c6d05cbd90c1b9e4a53eb"


### PR DESCRIPTION
closes #952 

![Screenshot 2023-06-07 at 2 19 11 PM](https://github.com/user-interviews/ui-design-system/assets/37383785/2f6c59bf-de16-4ac8-96ae-bd5e94c00de2)


Chromatic: https://62d040e741710e4f085e0647-rikhiwebhn.chromatic.com/?path=/docs/components-iconbutton--docs

The IconButton component is used for creating clickable buttons with icons, commonly found in app bars, toolbars, and toggleable actions.

We also are wanting to help encourage and enforce a set of pre-defined common actions that will be available with the `IconButton`. We're hoping that this will create a bit more consistency with which icons we use since devs are able to choose from the entire FontAwesome library and it might not always be apparent which icon weight to use. 

