### PR TITLE
add feature variant to Alert / Callout, unpublish announcement variant

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -1091,64 +1091,6 @@ Array [
 ]
 `;
 
-exports[`Storyshots Components/Alert Announcement 1`] = `
-<div
-  className="Alert Alert-announcement"
-  style={null}
->
-  <div
-    className="Alert__icon"
-  >
-    <svg
-      aria-hidden="true"
-      className="svg-inline--fa fa-bullhorn "
-      data-icon="bullhorn"
-      data-prefix="fas"
-      focusable="false"
-      role="img"
-      style={
-        Object {
-          "transformOrigin": "0.5625em 0.5em",
-        }
-      }
-      viewBox="0 0 576 512"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g
-        style={Object {}}
-        transform="translate(288 256)"
-      >
-        <g
-          style={Object {}}
-          transform="translate(0, 0)  scale(1.125, 1.125)  rotate(0 0 0)"
-        >
-          <path
-            d="M576 240c0-23.63-12.95-44.04-32-55.12V32.01C544 23.26 537.02 0 512 0c-7.12 0-14.19 2.38-19.98 7.02l-85.03 68.03C364.28 109.19 310.66 128 256 128H64c-35.35 0-64 28.65-64 64v96c0 35.35 28.65 64 64 64h33.7c-1.39 10.48-2.18 21.14-2.18 32 0 39.77 9.26 77.35 25.56 110.94 5.19 10.69 16.52 17.06 28.4 17.06h74.28c26.05 0 41.69-29.84 25.9-50.56-16.4-21.52-26.15-48.36-26.15-77.44 0-11.11 1.62-21.79 4.41-32H256c54.66 0 108.28 18.81 150.98 52.95l85.03 68.03a32.023 32.023 0 0 0 19.98 7.02c24.92 0 32-22.78 32-32V295.13C563.05 284.04 576 263.63 576 240zm-96 141.42l-33.05-26.44C392.95 311.78 325.12 288 256 288v-96c69.12 0 136.95-23.78 190.95-66.98L480 98.58v282.84z"
-            fill="currentColor"
-            style={Object {}}
-            transform="translate(-288 -256)"
-          />
-        </g>
-      </g>
-    </svg>
-  </div>
-  <div
-    className="Alert__content"
-  >
-    <div
-      className="Alert__title"
-    >
-      Announcement title
-    </div>
-    <div
-      className="Alert__message"
-    >
-      Announcement message
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Storyshots Components/Alert Error 1`] = `
 <div
   className="Alert Alert-error"
@@ -1203,6 +1145,64 @@ exports[`Storyshots Components/Alert Error 1`] = `
       tabIndex={-1}
     >
       Error message
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Components/Alert Feature 1`] = `
+<div
+  className="Alert Alert-feature"
+  style={null}
+>
+  <div
+    className="Alert__icon"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-bullhorn "
+      data-icon="bullhorn"
+      data-prefix="fas"
+      focusable="false"
+      role="img"
+      style={
+        Object {
+          "transformOrigin": "0.5625em 0.5em",
+        }
+      }
+      viewBox="0 0 576 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        style={Object {}}
+        transform="translate(288 256)"
+      >
+        <g
+          style={Object {}}
+          transform="translate(0, 0)  scale(1.125, 1.125)  rotate(0 0 0)"
+        >
+          <path
+            d="M576 240c0-23.63-12.95-44.04-32-55.12V32.01C544 23.26 537.02 0 512 0c-7.12 0-14.19 2.38-19.98 7.02l-85.03 68.03C364.28 109.19 310.66 128 256 128H64c-35.35 0-64 28.65-64 64v96c0 35.35 28.65 64 64 64h33.7c-1.39 10.48-2.18 21.14-2.18 32 0 39.77 9.26 77.35 25.56 110.94 5.19 10.69 16.52 17.06 28.4 17.06h74.28c26.05 0 41.69-29.84 25.9-50.56-16.4-21.52-26.15-48.36-26.15-77.44 0-11.11 1.62-21.79 4.41-32H256c54.66 0 108.28 18.81 150.98 52.95l85.03 68.03a32.023 32.023 0 0 0 19.98 7.02c24.92 0 32-22.78 32-32V295.13C563.05 284.04 576 263.63 576 240zm-96 141.42l-33.05-26.44C392.95 311.78 325.12 288 256 288v-96c69.12 0 136.95-23.78 190.95-66.98L480 98.58v282.84z"
+            fill="currentColor"
+            style={Object {}}
+            transform="translate(-288 -256)"
+          />
+        </g>
+      </g>
+    </svg>
+  </div>
+  <div
+    className="Alert__content"
+  >
+    <div
+      className="Alert__title"
+    >
+      New feature alert!
+    </div>
+    <div
+      className="Alert__message"
+    >
+      Some context around new feature if needed.
     </div>
   </div>
 </div>
@@ -1720,100 +1720,6 @@ Array [
     </div>
   </div>,
   <div
-    className="Alert Alert-announcement"
-    style={null}
-  >
-    <div
-      className="Alert__icon"
-    >
-      <svg
-        aria-hidden="true"
-        className="svg-inline--fa fa-bullhorn "
-        data-icon="bullhorn"
-        data-prefix="fas"
-        focusable="false"
-        role="img"
-        style={
-          Object {
-            "transformOrigin": "0.5625em 0.5em",
-          }
-        }
-        viewBox="0 0 576 512"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <g
-          style={Object {}}
-          transform="translate(288 256)"
-        >
-          <g
-            style={Object {}}
-            transform="translate(0, 0)  scale(1.125, 1.125)  rotate(0 0 0)"
-          >
-            <path
-              d="M576 240c0-23.63-12.95-44.04-32-55.12V32.01C544 23.26 537.02 0 512 0c-7.12 0-14.19 2.38-19.98 7.02l-85.03 68.03C364.28 109.19 310.66 128 256 128H64c-35.35 0-64 28.65-64 64v96c0 35.35 28.65 64 64 64h33.7c-1.39 10.48-2.18 21.14-2.18 32 0 39.77 9.26 77.35 25.56 110.94 5.19 10.69 16.52 17.06 28.4 17.06h74.28c26.05 0 41.69-29.84 25.9-50.56-16.4-21.52-26.15-48.36-26.15-77.44 0-11.11 1.62-21.79 4.41-32H256c54.66 0 108.28 18.81 150.98 52.95l85.03 68.03a32.023 32.023 0 0 0 19.98 7.02c24.92 0 32-22.78 32-32V295.13C563.05 284.04 576 263.63 576 240zm-96 141.42l-33.05-26.44C392.95 311.78 325.12 288 256 288v-96c69.12 0 136.95-23.78 190.95-66.98L480 98.58v282.84z"
-              fill="currentColor"
-              style={Object {}}
-              transform="translate(-288 -256)"
-            />
-          </g>
-        </g>
-      </svg>
-    </div>
-    <div
-      className="Alert__content"
-    >
-      <div
-        className="Alert__title"
-      >
-        Announcement title
-      </div>
-      <div
-        className="Alert__message"
-      >
-        Announcement message
-      </div>
-    </div>
-    <div
-      className="Alert__action"
-    >
-      <a
-        className="Alert-announcement primary-action"
-        href="https://www.userinterviews.com/"
-        rel="noopener noreferrer"
-      >
-        Primary action
-      </a>
-    </div>
-    <div
-      className="Alert__close"
-    >
-      <button
-        aria-label="close announcement"
-        className="close"
-        onClick={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          className="svg-inline--fa fa-times "
-          data-icon="times"
-          data-prefix="fas"
-          focusable="false"
-          role="img"
-          style={Object {}}
-          viewBox="0 0 352 512"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-            fill="currentColor"
-            style={Object {}}
-          />
-        </svg>
-      </button>
-    </div>
-  </div>,
-  <div
     className="Alert Alert-error"
     style={null}
   >
@@ -1978,6 +1884,100 @@ Array [
     >
       <button
         aria-label="close warning"
+        className="close"
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-times "
+          data-icon="times"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 352 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+      </button>
+    </div>
+  </div>,
+  <div
+    className="Alert Alert-feature"
+    style={null}
+  >
+    <div
+      className="Alert__icon"
+    >
+      <svg
+        aria-hidden="true"
+        className="svg-inline--fa fa-bullhorn "
+        data-icon="bullhorn"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        style={
+          Object {
+            "transformOrigin": "0.5625em 0.5em",
+          }
+        }
+        viewBox="0 0 576 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          style={Object {}}
+          transform="translate(288 256)"
+        >
+          <g
+            style={Object {}}
+            transform="translate(0, 0)  scale(1.125, 1.125)  rotate(0 0 0)"
+          >
+            <path
+              d="M576 240c0-23.63-12.95-44.04-32-55.12V32.01C544 23.26 537.02 0 512 0c-7.12 0-14.19 2.38-19.98 7.02l-85.03 68.03C364.28 109.19 310.66 128 256 128H64c-35.35 0-64 28.65-64 64v96c0 35.35 28.65 64 64 64h33.7c-1.39 10.48-2.18 21.14-2.18 32 0 39.77 9.26 77.35 25.56 110.94 5.19 10.69 16.52 17.06 28.4 17.06h74.28c26.05 0 41.69-29.84 25.9-50.56-16.4-21.52-26.15-48.36-26.15-77.44 0-11.11 1.62-21.79 4.41-32H256c54.66 0 108.28 18.81 150.98 52.95l85.03 68.03a32.023 32.023 0 0 0 19.98 7.02c24.92 0 32-22.78 32-32V295.13C563.05 284.04 576 263.63 576 240zm-96 141.42l-33.05-26.44C392.95 311.78 325.12 288 256 288v-96c69.12 0 136.95-23.78 190.95-66.98L480 98.58v282.84z"
+              fill="currentColor"
+              style={Object {}}
+              transform="translate(-288 -256)"
+            />
+          </g>
+        </g>
+      </svg>
+    </div>
+    <div
+      className="Alert__content"
+    >
+      <div
+        className="Alert__title"
+      >
+        New feature alert!
+      </div>
+      <div
+        className="Alert__message"
+      >
+        Some context around new feature if needed
+      </div>
+    </div>
+    <div
+      className="Alert__action"
+    >
+      <a
+        className="Alert-feature primary-action"
+        href="https://www.userinterviews.com/"
+        rel="noopener noreferrer"
+      >
+        Primary action
+      </a>
+    </div>
+    <div
+      className="Alert__close"
+    >
+      <button
+        aria-label="close feature"
         className="close"
         onClick={[Function]}
         type="button"

--- a/src/Alert/Alert.jsx
+++ b/src/Alert/Alert.jsx
@@ -18,6 +18,7 @@ export const MessageTypes = {
   SUCCESS: 'success',
   INFO: 'info',
   ANNOUNCEMENT: 'announcement',
+  FEATURE: 'feature',
   WARNING: 'warning',
   ERROR: 'error',
 };
@@ -39,6 +40,8 @@ const getAlertIcon = (type) => {
         </span>
       );
     case MessageTypes.ANNOUNCEMENT:
+      return (<FontAwesomeIcon icon={faBullhorn} transform="grow-2" />);
+    case MessageTypes.FEATURE:
       return (<FontAwesomeIcon icon={faBullhorn} transform="grow-2" />);
     case MessageTypes.WARNING:
       return (<FontAwesomeIcon icon={faExclamationTriangle} transform="grow-2" />);

--- a/src/Alert/Alert.mdx
+++ b/src/Alert/Alert.mdx
@@ -14,14 +14,6 @@ import * as ComponentStories from './Alert.stories';
 
 <Canvas of={ComponentStories.Success} />
 
-### When to use 
-- Reason 1
-- Reason 2
-
-### When to not use
-- Reason 1
-- Reason 2
-
 ## Props
 
 <ArgTypes of={Alert} />
@@ -40,6 +32,13 @@ import * as ComponentStories from './Alert.stories';
 page and are not affected by an event.
 
 <Canvas of={ComponentStories.Info} />
+
+### Feature
+
+- Use when showcasing a new feature to a user.
+- NOTE: use this variant instead of the Announcement variant (this will be deprecated soon)
+
+<Canvas of={ComponentStories.Feature} />
 
 ### Error
 

--- a/src/Alert/Alert.scss
+++ b/src/Alert/Alert.scss
@@ -145,6 +145,20 @@
   }
 }
 
+.Alert-feature {
+  background-color: $ux-teal-100;
+  color: $ux-teal-800;
+  border: 2px solid $ux-teal-600;
+
+  .close {
+    @include close-action($ux-teal-600, $ux-teal-800)
+  }
+
+  .primary-action {
+    @include primary-action($ux-teal-600, $ux-teal-700, $ux-white)
+  }
+}
+
 .Alert-warning {
   background-color: $ux-yellow-100;
   color: $ux-yellow-900;

--- a/src/Alert/Alert.stories.jsx
+++ b/src/Alert/Alert.stories.jsx
@@ -42,13 +42,13 @@ export const Info = () => (
   />
 );
 
-export const Announcement = () => (
+export const Feature = () => (
   <Alert
     id="3"
-    message={text('Message', 'Announcement message')}
+    message={text('Message', 'Some context around new feature if needed.')}
     removeBorderLeft={boolean('removeBorderLeft', false)}
-    title={text('Title', 'Announcement title')}
-    type={MessageTypes.ANNOUNCEMENT}
+    title={text('Title', 'New feature alert!')}
+    type={MessageTypes.FEATURE}
   />
 );
 
@@ -130,15 +130,6 @@ export const WithCallToAction = () => (
     />
     <Alert
       action={{ content: 'Primary action', url: 'https://www.userinterviews.com/' }}
-      id="10"
-      message="Announcement message"
-      removeBorderLeft={boolean('removeBorderLeft', false)}
-      title="Announcement title"
-      type={MessageTypes.ANNOUNCEMENT}
-      onDismiss={onDismiss}
-    />
-    <Alert
-      action={{ content: 'Primary action', url: 'https://www.userinterviews.com/' }}
       id="11"
       message="Error message"
       removeBorderLeft={boolean('removeBorderLeft', false)}
@@ -153,6 +144,15 @@ export const WithCallToAction = () => (
       removeBorderLeft={boolean('removeBorderLeft', false)}
       title="Warning title"
       type={MessageTypes.WARNING}
+      onDismiss={onDismiss}
+    />
+    <Alert
+      action={{ content: 'Primary action', url: 'https://www.userinterviews.com/' }}
+      id="13"
+      message="Some context around new feature if needed"
+      removeBorderLeft={boolean('removeBorderLeft', false)}
+      title="New feature alert!"
+      type={MessageTypes.FEATURE}
       onDismiss={onDismiss}
     />
 


### PR DESCRIPTION
closes #962 

## Description

RX Scheduling is wanting to use a new feature Alert (internally we're calling it a Callout) for their MVP launch. We're also un-publishing the `Announcement` variant story in favor for the `Feature` variant (since the Announcement and Info variant are essentially the same color and pattern, we want to reduce the visual fatigue for having both). We only use the Announcement variant in two places and can possibly swap those out when this is released.

Chromatic: https://62d040e741710e4f085e0647-jcpkzkmxws.chromatic.com/?path=/docs/components-alert--docs#feature

Figma: https://www.figma.com/file/471iS3QrpPtXZpS1xbsJ20/Component-Library?type=design&node-id=12552-18929&mode=design&t=ENoIba8smtwEtWbn-0

![Screenshot 2023-07-06 at 11 02 40 AM](https://github.com/user-interviews/ui-design-system/assets/37383785/74178263-c7c2-4976-b000-61afb558dcf8)


## Reviewers 

Primary: Kyle
Secondary: Devin, Wen 
