### PR TITLE
add target to Alert action

### DIFF
--- a/src/Alert/Alert.jsx
+++ b/src/Alert/Alert.jsx
@@ -108,6 +108,7 @@ function Alert(props) {
                 className={classNames(`Alert-${(props.type)}`, 'primary-action')}
                 href={props.action.url}
                 rel="noopener noreferrer"
+                target={props.actionTarget}
               >
                 {props.action.content}
               </a>
@@ -139,6 +140,10 @@ Alert.propTypes = {
   */
   action: PropTypes.oneOfType([PropTypes.object, PropTypes.node]),
   /**
+    Specifies where to open the linked document
+  */
+  actionTarget: PropTypes.string,
+  /**
    Determines whether the Alert will disappear automatically
   */
   autoDismiss: PropTypes.bool,
@@ -155,6 +160,7 @@ Alert.propTypes = {
 
 Alert.defaultProps = {
   action: undefined,
+  actionTarget: undefined,
   autoDismiss: false,
   removeBorderLeft: false,
   title: undefined,


### PR DESCRIPTION
closes #973 

Needing the option to set the `target` attribute on the Alert `action` in order to open a new tab. 

![Screenshot 2023-07-18 at 1 27 46 PM](https://github.com/user-interviews/ui-design-system/assets/37383785/dacf8fce-d64c-45c0-824f-7332ca638dd4)
