### PR TITLE
ensure EmptyState title and subtitle have same margin-bottom

### DIFF
--- a/src/EmptyState/EmptyState.scss
+++ b/src/EmptyState/EmptyState.scss
@@ -7,6 +7,9 @@ $empty-state-margin-top-sm: 4rem;
 $empty-state-margin-top-md: 6rem;
 $empty-state-margin-top-lg: 12.5rem;
 
+$empty-state-title-margin-bottom: $ux-spacing-40;
+$empty-state-subtitle-margin-bottom: $ux-spacing-40;
+
 .EmptyState {
   display: flex;
   flex-direction: row;
@@ -40,6 +43,14 @@ $empty-state-margin-top-lg: 12.5rem;
 
     margin-bottom: $ux-spacing-40;
     max-height: $empty-state-max-image-height;
+  }
+
+  &__title {
+    margin-bottom: $empty-state-title-margin-bottom;
+  }
+
+  &__subtitle {
+    margin-bottom: $empty-state-subtitle-margin-bottom;
   }
 
   &__actions {


### PR DESCRIPTION
closes #982 

Related to: https://github.com/user-interviews/rails-server/pull/19944#discussion_r1287648545

Adjusting the title and subtitle of the EmptyState component to have the same `margin-bottom: 16px`. We ran into the case where there wasn't a need for a subtitle in one of the empty states and the distance between the title and primary action was just slightly squished. 

Chromatic: https://62d040e741710e4f085e0647-uwvngvhwqs.chromatic.com/?path=/story/components-emptystate--primary-action