### PR TITLE
Adding lateral style icon and collapsed text

### DIFF
--- a/src/Accordion/Accordion.mdx
+++ b/src/Accordion/Accordion.mdx
@@ -31,9 +31,21 @@ import * as ComponentStories from './Accordion.stories';
 
 <Canvas of={ComponentStories.DefaultOpen} />
 
+### Default with Chevron Lateral
+
+<Canvas of={ComponentStories.ChevronLateral} />
+
 ### Chevron Left
 
 <Canvas of={ComponentStories.ChevronLeft} />
+
+### Chevron Left with Chevron Lateral
+
+<Canvas of={ComponentStories.ChevronLeftLateral} />
+
+### Collapsed Text
+
+<Canvas of={ComponentStories.CollapsedText} />
 
 ### Borderless
 

--- a/src/Accordion/Accordion.stories.jsx
+++ b/src/Accordion/Accordion.stories.jsx
@@ -139,6 +139,121 @@ ChevronLeft.args = {
   title: 'Accordion Toggle',
 };
 
+export const ChevronLeftLateral = (args) => (
+  <Accordion>
+    <AccordionItem>
+      <AccordionToggle
+        eventKey="0"
+        {...args}
+      />
+      <AccordionCollapse eventKey="0">
+        <ul>
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+        </ul>
+      </AccordionCollapse>
+    </AccordionItem>
+    <AccordionItem>
+      <AccordionToggle
+        eventKey="1"
+        {...args}
+      />
+      <AccordionCollapse eventKey="1">
+        <ul>
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+        </ul>
+      </AccordionCollapse>
+    </AccordionItem>
+  </Accordion>
+);
+
+ChevronLeftLateral.args = {
+  chevronLateral: true,
+  chevronLeft: true,
+  disabled: false,
+  helperText: 'helper text',
+  title: 'Accordion Toggle',
+};
+
+export const ChevronLateral = (args) => (
+  <Accordion>
+    <AccordionItem>
+      <AccordionToggle
+        eventKey="0"
+        {...args}
+      />
+      <AccordionCollapse eventKey="0">
+        <ul>
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+        </ul>
+      </AccordionCollapse>
+    </AccordionItem>
+    <AccordionItem>
+      <AccordionToggle
+        eventKey="1"
+        {...args}
+      />
+      <AccordionCollapse eventKey="1">
+        <ul>
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+        </ul>
+      </AccordionCollapse>
+    </AccordionItem>
+  </Accordion>
+);
+
+ChevronLateral.args = {
+  chevronLateral: true,
+  disabled: false,
+  helperText: 'helper text',
+  title: 'Accordion Toggle',
+};
+
+export const CollapsedText = (args) => (
+  <Accordion defaultActiveKey="1">
+    <AccordionItem>
+      <AccordionToggle
+        eventKey="0"
+        {...args}
+      />
+      <AccordionCollapse eventKey="0">
+        <ul>
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+        </ul>
+      </AccordionCollapse>
+    </AccordionItem>
+    <AccordionItem>
+      <AccordionToggle
+        eventKey="1"
+        {...args}
+      />
+      <AccordionCollapse eventKey="1">
+        <ul>
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+        </ul>
+      </AccordionCollapse>
+    </AccordionItem>
+  </Accordion>
+);
+
+CollapsedText.args = {
+  collapsedText: 'This shows only when collapsed',
+  disabled: false,
+  helperText: 'helper text',
+  title: 'Accordion Toggle',
+};
+
 export const Borderless = (args) => (
   <Accordion flush>
     <AccordionItem borderless>

--- a/src/Accordion/AccordionToggle.jsx
+++ b/src/Accordion/AccordionToggle.jsx
@@ -12,8 +12,10 @@ import { faChevronUp } from '@fortawesome/pro-solid-svg-icons';
 
 const AccordionToggle = ({
   children,
+  chevronLateral,
   chevronLeft,
   chevronRight,
+  collapsedText,
   disabled,
   eventKey,
   helperText,
@@ -54,6 +56,7 @@ const AccordionToggle = ({
           UNSAFE_className,
           'AccordionToggle',
           { collapsed: isCollapsed },
+          { 'AccordionToggle--chevron-lateral': chevronLateral },
           { 'AccordionToggle--disabled': disabled },
         )
       }
@@ -76,6 +79,9 @@ const AccordionToggle = ({
           {title && (
             <span className="AccordionToggle__title">{title}</span>
           )}
+          {collapsedText && isCollapsed && (
+            <span className="AccordionToggle__collapsed-text">{collapsedText} </span>
+          )}
           {helperText && (
             <span className="AccordionToggle__helper-text">({helperText})</span>
           )}
@@ -95,6 +101,10 @@ const AccordionToggle = ({
 
 AccordionToggle.propTypes = {
   /**
+   Set Chevron icon to open/close quarter turn from lateral
+  */
+  chevronLateral: PropTypes.bool,
+  /**
    Aligns the Chevron icon to the left
   */
   chevronLeft: PropTypes.bool,
@@ -102,6 +112,7 @@ AccordionToggle.propTypes = {
    Aligns the Chevron icon to the right (default)
   */
   chevronRight: PropTypes.bool,
+  collapsedText: PropTypes.string,
   /**
    A unique key used to control this item's collapse/expand.
    */
@@ -114,8 +125,10 @@ AccordionToggle.propTypes = {
 };
 
 AccordionToggle.defaultProps = {
+  chevronLateral: false,
   chevronLeft: false,
   chevronRight: true,
+  collapsedText: undefined,
   disabled: undefined,
   helperText: undefined,
   leadingIcon: undefined,

--- a/src/Accordion/AccordionToggle.scss
+++ b/src/Accordion/AccordionToggle.scss
@@ -23,6 +23,20 @@
     }
   }
 
+  &--chevron-lateral {
+    .AccordionToggle__chevron-left {
+      svg {
+        transform: rotate(90deg);
+      }
+    }
+
+    .AccordionToggle__chevron-right {
+      svg {
+        transform: rotate(-90deg);
+      }
+    }
+  }
+
   &:focus-visible {
     @include btn-focus-outline;
     border-radius: $ux-border-radius;
@@ -69,6 +83,11 @@
 
   &__helper-text {
     @include font-type-30;
+  }
+
+  &__collapsed-text {
+    @include font-type-30;
+    color: $ux-gray-600;
   }
 
   &--disabled {

--- a/src/Accordion/AccordionToggle.scss
+++ b/src/Accordion/AccordionToggle.scss
@@ -32,7 +32,7 @@
 
     .AccordionToggle__chevron-right {
       svg {
-        transform: rotate(-90deg);
+        transform: rotate(90deg);
       }
     }
   }
@@ -53,6 +53,15 @@
     svg {
       transform: rotate(180deg);
       transition: $chevron-rotation-transition-time ease all;
+    }
+  }
+
+  &--chevron-lateral {
+    &:not(.collapsed) .AccordionToggle__chevron-right {
+      svg {
+        transform: rotate(180deg);
+        transition: $chevron-rotation-transition-time ease all;
+      }
     }
   }
 


### PR DESCRIPTION
Closes #985 

Within the screener improvements project there are a few tweaks that would be great to have in `AccordionToggle`.

- Allow the chevron to not go from full up to full down, instead do a quarter turn from sideways to down
- Display collapsed text which only shows if the accordion is closed

Mega short loom of them in action: https://www.loom.com/share/5b159ce1c36749869f663a885005fc63

I achieved these changes with a small amount of code:
- Added `chevronLateral` prop which when present adds a class that is used to do a little rotation to the SVG icon, **note** it doesn't look great when on the right, more natural when to the left.
- Add `collapsedText` prop which only shows if present and when `isCollapsed` is true

Hopefully I can get away with these changes! I think they are nice additions and work well but let's iterate if not... definitely want to keep using Accordion system instead of building my own show hide this this one is loooovely. Moar flattery but stellar notes and scripts to link the live version of the DS with rails server. So straightforward! 🙌 

**Also!!!** If you look at the screenshots from figma you can see there is going to be a dropdown in the `AccordionToggle` as well. I played around with passing in a dropdown prop but kinda thinking the best way to do this might be to use absolute positioning instead but your thoughts would be great.

Figma: https://www.figma.com/file/kY6sLQRhR5FZ70fUZvCmdp/Screener-Improvements?node-id=2056%3A79169&mode=dev

### Figma screenshots
<img width="490" alt="Screenshot 2023-08-28 at 7 37 10 PM" src="https://github.com/user-interviews/ui-design-system/assets/29077952/dd7b6585-1495-4f1b-bd7b-d89277daa659">

<img width="498" alt="Screenshot 2023-08-28 at 7 37 44 PM" src="https://github.com/user-interviews/ui-design-system/assets/29077952/144c14cf-a628-4479-bc21-c654288d4aef">

### Used within Rails Server

<img width="941" alt="Screenshot 2023-08-28 at 7 48 31 PM" src="https://github.com/user-interviews/ui-design-system/assets/29077952/7c0c1740-fd13-4bdc-9d07-10acacc33d0a">
<img width="933" alt="Screenshot 2023-08-28 at 7 48 39 PM" src="https://github.com/user-interviews/ui-design-system/assets/29077952/ce107c19-950a-4c27-98c5-3061e06865ae">

### Storybook screenshots

<img width="681" alt="Screenshot 2023-08-28 at 7 46 07 PM" src="https://github.com/user-interviews/ui-design-system/assets/29077952/f12c3ec6-dba6-441c-8e3e-cfaa4104598a">
<img width="684" alt="Screenshot 2023-08-28 at 7 45 57 PM" src="https://github.com/user-interviews/ui-design-system/assets/29077952/1883172b-da65-42c5-aa94-8e49baea92bc">

