### PR TITLE
Adds necessary final step for unlinking rs

### DIFF
--- a/bin/unlink-rs
+++ b/bin/unlink-rs
@@ -10,3 +10,4 @@ fi
 cd $RAILS_SERVER_PATH
 yalc remove @user-interviews/ui-design-system
 yalc installations clean @user-interviews/ui-design-system
+yarn --check-files


### PR DESCRIPTION
Occasionally when running `yarn rs:unlink`, rails-server would then fail to compile.  Running `yarn --check-files` after unlinking should prevent this from happening moving forward.  Will need to monitor to confirm this is fully resolved.