### PR TITLE
Fix tabs styles in RS

### DIFF
--- a/src/Tabs/tabs.module.scss
+++ b/src/Tabs/tabs.module.scss
@@ -1,6 +1,6 @@
 @import '../../scss/theme.scss';
 
-.tabs {
+.tabs.tabs {
   --border-width: 0.125rem;
 
   border-bottom: var(--border-width) solid $ux-gray-400;
@@ -25,11 +25,11 @@
   }
 }
 
-.flexWrapUnset {
+.flexWrapUnset.flexWrapUnset {
   flex-wrap: nowrap;
 }
 
-.navItemButtonFullHeight {
+.navItemButtonFullHeight.navItemButtonFullHeight {
   :global(.nav-item .button) {
     height: calc(100% + var(--border-width));
   }


### PR DESCRIPTION
Rails server includes bootstrap _after_ the DS, which means that bootstrap's own styles take precedence over our own that are built on top. By doubling up the class name selectors here, we ensure that our styles take precedence.

**This should be treated as an interim solution.** 

Ultimately, we should have the DS own bootstrap & react-bootstrap altogether, with rails server only consuming BS _through_ the DS.

### Before:
<img width="493" alt="Screenshot 2023-10-23 at 11 23 15 AM" src="https://github.com/user-interviews/ui-design-system/assets/3161151/57e37601-a071-4dcd-9939-a7d007327271">

**Active tab state getting overridden**
<img width="268" alt="Screenshot 2023-10-23 at 11 24 24 AM" src="https://github.com/user-interviews/ui-design-system/assets/3161151/f7732557-b7b8-49f2-a285-4893611316f6">

**flexWrapUnset getting overidden** 
<img width="273" alt="Screenshot 2023-10-23 at 11 25 18 AM" src="https://github.com/user-interviews/ui-design-system/assets/3161151/bb56d464-b83a-4b8c-8537-9e6c781e60a6">

### After:
<img width="491" alt="Screenshot 2023-10-23 at 11 23 42 AM" src="https://github.com/user-interviews/ui-design-system/assets/3161151/fb19eac6-8d5f-4b6a-b7e8-890a86e16713">

