### PR TITLE
add trailingText to Input component

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -8250,6 +8250,39 @@ exports[`Storyshots Components/Form Elements/Form Group With Trailing Icon And B
 </div>
 `;
 
+exports[`Storyshots Components/Form Elements/Form Group With Trailing Text 1`] = `
+<div
+  className="FormGroup"
+  id="with-trailing-text"
+>
+  <label
+    className="InputLabel"
+    htmlFor="trailing-text-input"
+  >
+    Form Group with trailing text
+  </label>
+  <div
+    className="Input input-group"
+  >
+    <input
+      className="Input form-control"
+      disabled={false}
+      id="trailing-text-input"
+      name="default"
+      onChange={[Function]}
+      placeholder="Session length"
+      type="number"
+      value=""
+    />
+    <span
+      className="input-trailing-text input-trailing-text--input-type-number"
+    >
+      min
+    </span>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Components/Form Elements/RadioButtonGroup Bordered Column Full Width 1`] = `
 <fieldset
   className="FormGroup"

--- a/src/FormGroup/FormGroup.mdx
+++ b/src/FormGroup/FormGroup.mdx
@@ -54,6 +54,10 @@ helpful if they do!
 
 <Canvas of={ComponentStories.WithLeadingIcon} />
 
+### Trailing Text
+
+<Canvas of={ComponentStories.WithTrailingText} />
+
 ### Trailing Icon
 
 <Canvas of={ComponentStories.WithTrailingIcon} />

--- a/src/FormGroup/FormGroup.stories.jsx
+++ b/src/FormGroup/FormGroup.stories.jsx
@@ -90,6 +90,16 @@ export const WithLeadingIcon = () => (
   </FormGroup>
 );
 
+export const WithTrailingText = () => (
+  <FormGroup
+    id="with-trailing-text"
+    label="Form Group with trailing text"
+    labelHtmlFor="trailing-text-input"
+  >
+    <InputComponent id="trailing-text-input" name="default" placeholder="Session length" trailingText="min" type="number" />
+  </FormGroup>
+);
+
 export const WithTrailingIcon = () => (
   <FormGroup
     helperText="with trailing icon"

--- a/src/Input/Input.jsx
+++ b/src/Input/Input.jsx
@@ -16,6 +16,7 @@ const Input = React.forwardRef((props, ref) => {
     trailingIconLabel,
     trailingIconOnClick,
     trailingIconOnClickSubmit,
+    trailingText,
     type,
     value,
     onChange,
@@ -47,6 +48,11 @@ const Input = React.forwardRef((props, ref) => {
         onChange={onChange}
         {...rest}
       />
+      {trailingText && (
+        <span className={`input-trailing-text ${type === 'number' ? 'input-trailing-text--input-type-number' : ''}`}>
+          {trailingText}
+        </span>
+      )}
       {(trailingIcon && trailingIconOnClick) && (
         <button
           aria-label={trailingIconLabel}
@@ -78,6 +84,7 @@ Input.propTypes = {
   trailingIconLabel: PropTypes.string,
   trailingIconOnClick: PropTypes.func,
   trailingIconOnClickSubmit: PropTypes.bool,
+  trailingText: PropTypes.string,
   type: PropTypes.string,
   value: PropTypes.string,
   onChange: PropTypes.func,
@@ -91,6 +98,7 @@ Input.defaultProps = {
   trailingIconLabel: '',
   trailingIconOnClick: undefined,
   trailingIconOnClickSubmit: false,
+  trailingText: undefined,
   type: 'text',
   value: undefined,
   onChange: undefined,

--- a/src/Input/Input.scss
+++ b/src/Input/Input.scss
@@ -1,5 +1,7 @@
 @import '../../scss/theme';
 
+$input-trailing-text-spacing-for-type-number: 2.1875rem;
+
 .Input {
   @include font-type-30;
   box-shadow: $input-box-shadow;
@@ -22,6 +24,19 @@
 
   .input-group-text {
     background-color: $ux-gray-100;
+  }
+
+  .input-trailing-text {
+    position: absolute;
+    right: $ux-spacing-40;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none; 
+    z-index: 3;
+
+    &--input-type-number {
+      right: $input-trailing-text-spacing-for-type-number;
+    }
   }
 
   .trailing-icon-button {

--- a/src/Input/Input.scss
+++ b/src/Input/Input.scss
@@ -1,6 +1,7 @@
 @import '../../scss/theme';
 
 $input-trailing-text-spacing-for-type-number: 2.1875rem;
+$input-trailing-text-max-width-before-hiding: 12.5rem;
 
 .Input {
   @include font-type-30;
@@ -36,6 +37,10 @@ $input-trailing-text-spacing-for-type-number: 2.1875rem;
 
     &--input-type-number {
       right: $input-trailing-text-spacing-for-type-number;
+    }
+
+    @media (max-width: $input-trailing-text-max-width-before-hiding) {
+      display: none;
     }
   }
 


### PR DESCRIPTION
Adds `trailingText` to `Input`

Figma: https://www.figma.com/file/wU1NfHuJchd9xLirqBREQN/Research-Set-up?type=design&node-id=3569-7744&mode=design&t=aB8GD4SuTxyA5Mbs-0

Chromatic: https://62d040e741710e4f085e0647-nsyrdovjii.chromatic.com/?path=/story/components-form-elements-form-group--with-trailing-text


If `<Input type='number'`, add spacing for chevrons

https://github.com/user-interviews/ui-design-system/assets/37383785/bf820320-14a2-469e-9309-4ba4d1f5fd7e




If not `type='number'`, no spacing adjustment
![Screenshot 2023-11-01 at 1 39 36 PM](https://github.com/user-interviews/ui-design-system/assets/37383785/203a5aba-e28a-49ab-b8a2-b0927de667c4)

