### PR TITLE
Allow drawer to be expanded by default

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -6033,6 +6033,113 @@ Array [
 ]
 `;
 
+exports[`Storyshots Components/Drawer Default Expanded 1`] = `
+Array [
+  <button
+    className="Button btn btn-primary"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+  >
+    Open
+  </button>,
+  <div
+    className="DrawerBackgroundOverlay"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="presentation"
+  />,
+  <div
+    className="Drawer Drawer--right Drawer--sm Drawer--expanded Drawer--behind-nav"
+  >
+    <div
+      className="Drawer__header Drawer__header--bordered"
+    >
+      <div
+        className="Drawer__title"
+      >
+        Title goes here
+      </div>
+      <button
+        aria-label="Close"
+        className="Drawer__header-action"
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-xmark "
+          data-icon="xmark"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 384 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      className="Drawer__body"
+    >
+      <p>
+        Proin elementum vitae nibh nec tincidunt. Donec vel placerat mi, vitae malesuada odio. Sed varius libero sed erat faucibus ultrices. Suspendisse potenti. Mauris sit amet sollicitudin urna. Donec porttitor, est quis aliquet condimentum, nisi felis porta odio, eu luctus dui ex id nisi. Curabitur ultrices enim in dolor laoreet porta. Proin vehicula at nisl a maximus. Sed lorem enim, elementum in arcu eu, lacinia consequat arcu. Pellentesque non nibh viverra, imperdiet purus at, finibus turpis. Sed mattis erat a risus dignissim, eu ultrices est rhoncus. Fusce nec feugiat tortor. Quisque tincidunt nulla urna, ut egestas massa congue a. Quisque metus felis, auctor sit amet posuere eu, aliquam blandit libero. Mauris sodales, velit sit amet egestas aliquet, ipsum arcu porta lacus, vitae mattis felis elit in metus. Nulla ligula ligula, laoreet in dictum sit amet, pretium ac est.
+      </p>
+    </div>
+    <div
+      className="DrawerFooter"
+    >
+      <div />
+      <div
+        className="DrawerFooter__actions"
+      >
+        <button
+          aria-disabled={false}
+          className="Button btn btn-transparent"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          Cancel
+        </button>
+        <button
+          aria-disabled={false}
+          className="Button btn btn-primary"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-envelope icon-left"
+            data-icon="envelope"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={Object {}}
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M48 64C21.5 64 0 85.5 0 112c0 15.1 7.1 29.3 19.2 38.4L236.8 313.6c11.4 8.5 27 8.5 38.4 0L492.8 150.4c12.1-9.1 19.2-23.3 19.2-38.4c0-26.5-21.5-48-48-48H48zM0 176V384c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V176L294.4 339.2c-22.8 17.1-54 17.1-76.8 0L0 176z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+          Send
+        </button>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
 exports[`Storyshots Components/Drawer Empty 1`] = `
 Array [
   <button

--- a/src/Drawer/Drawer.jsx
+++ b/src/Drawer/Drawer.jsx
@@ -25,6 +25,7 @@ const Drawer = ({
   behindNav,
   children,
   className,
+  defaultExpanded,
   expandable,
   hasBackgroundOverlay,
   visible,
@@ -32,7 +33,7 @@ const Drawer = ({
   size,
   onRequestClose,
 }) => {
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(defaultExpanded);
 
   const handleExpand = () => setExpanded(!expanded);
 
@@ -86,6 +87,7 @@ Drawer.propTypes = {
   behindNav: propTypes.bool,
   children: propTypes.node,
   className: propTypes.string,
+  defaultExpanded: propTypes.bool,
   expandable: propTypes.bool,
   hasBackgroundOverlay: propTypes.bool,
   orientation: propTypes.oneOf([ORIENTATION_LEFT, ORIENTATION_RIGHT]),
@@ -98,6 +100,7 @@ Drawer.defaultProps = {
   behindNav: true,
   children: undefined,
   className: null,
+  defaultExpanded: false,
   expandable: false,
   hasBackgroundOverlay: true,
   orientation: ORIENTATION_RIGHT,

--- a/src/Drawer/Drawer.mdx
+++ b/src/Drawer/Drawer.mdx
@@ -15,7 +15,7 @@ import * as ComponentStories from './Drawer.stories';
 
 <Canvas of={ComponentStories.Default} />
 
-### When to use 
+### When to use
 When we want to focus the user’s attention on an interactive interface or a large amount of information
 
 ### When to not use
@@ -50,7 +50,11 @@ Pass `orientation="left"` to override the default behavior of sliding in from th
 
 ### Expandable
 
-Setting `expandable` allows the drawer to expand to the full size of the viewport
+Setting `expandable` allows the drawer to expand to the full size of the viewport when the expand button is clicked.
+
+### Default Expanded
+
+Setting `defaultExpanded` allows the drawer to expand the full size of the viewport by default.
 
 ### Additional Actions
 

--- a/src/Drawer/Drawer.mdx
+++ b/src/Drawer/Drawer.mdx
@@ -54,8 +54,8 @@ Setting `expandable` allows the drawer to expand to the full size of the viewpor
 
 ### Default Expanded
 
-Setting `defaultExpanded` allows the drawer to expand the full size of the viewport by default.
-
+Setting `defaultExpanded` allows the drawer to expand the full size of the viewport by default. This can be used in conjunction with `expandable.` For example if
+you want the drawer to be the full width of the viewport but you want to disable the ability to collapse it, you can set `expandable=false` and `defaultExpanded=true`.
 ### Additional Actions
 
 If additional components are required to be included, pass them as children to the `DrawerFooter`. This example also doesn't have a title or a border on the header, and the background overlay is turned off to allow interaction with outside elements.

--- a/src/Drawer/Drawer.stories.jsx
+++ b/src/Drawer/Drawer.stories.jsx
@@ -37,6 +37,7 @@ export const Default = () => {
       <Button onClick={toggleVisible}>Open</Button>
       <Drawer
         behindNav={(boolean('behindNav', true))}
+        defaultExpanded={boolean('defaultExpanded', false)}
         expandable={boolean('expandable', false)}
         hasBackgroundOverlay={boolean('hasBackgroundOverlay', true)}
         orientation={select('orientation', ['left', 'right'], 'right')}
@@ -89,6 +90,7 @@ export const Orientation = () => {
       <Button onClick={toggleVisible}>Open</Button>
       <Drawer
         behindNav={(boolean('behindNav', true))}
+        defaultExpanded={boolean('defaultExpanded', false)}
         expandable={boolean('expandable', false)}
         hasBackgroundOverlay={boolean('hasBackgroundOverlay', true)}
         orientation={select('orientation', ['left', 'right'], 'left')}
@@ -141,7 +143,61 @@ export const Expandable = () => {
       <Button onClick={toggleVisible}>Open</Button>
       <Drawer
         behindNav={(boolean('behindNav', true))}
+        defaultExpanded={boolean('defaultExpanded', false)}
         expandable={boolean('expandable', true)}
+        hasBackgroundOverlay={boolean('hasBackgroundOverlay', true)}
+        orientation={select('orientation', ['left', 'right'], 'right')}
+        size={select('size', DrawerSizes, 'sm')}
+        visible={isVisible}
+        onRequestClose={toggleVisible}
+      >
+        <DrawerHeader
+          bordered={boolean('bordered', true)}
+          title="Title goes here"
+          onRequestClose={toggleVisible}
+        />
+        <DrawerBody>
+          <p>
+            Proin elementum vitae nibh nec tincidunt. Donec vel placerat mi,
+            vitae malesuada odio. Sed varius libero sed erat faucibus ultrices.
+            Suspendisse potenti. Mauris sit amet sollicitudin urna. Donec
+            porttitor, est quis aliquet condimentum, nisi felis porta odio, eu
+            luctus dui ex id nisi. Curabitur ultrices enim in dolor laoreet
+            porta. Proin vehicula at nisl a maximus. Sed lorem enim, elementum in
+            arcu eu, lacinia consequat arcu. Pellentesque non nibh viverra,
+            imperdiet purus at, finibus turpis. Sed mattis erat a risus
+            dignissim, eu ultrices est rhoncus. Fusce nec feugiat tortor. Quisque
+            tincidunt nulla urna, ut egestas massa congue a. Quisque metus felis,
+            auctor sit amet posuere eu, aliquam blandit libero. Mauris sodales,
+            velit sit amet egestas aliquet, ipsum arcu porta lacus, vitae mattis
+            felis elit in metus. Nulla ligula ligula, laoreet in dictum sit amet,
+            pretium ac est.
+          </p>
+        </DrawerBody>
+        <DrawerFooter
+          primaryActionIcon={faEnvelope}
+          primaryActionText="Send"
+          secondaryActionText="Cancel"
+          onPrimaryAction={() => null}
+          onSecondaryAction={toggleVisible}
+        />
+      </Drawer>
+    </>
+  );
+};
+
+export const DefaultExpanded = () => {
+  const [isVisible, setVisible] = useState(false);
+
+  const toggleVisible = () => setVisible(!isVisible);
+
+  return (
+    <>
+      <Button onClick={toggleVisible}>Open</Button>
+      <Drawer
+        behindNav={(boolean('behindNav', true))}
+        defaultExpanded={boolean('defaultExpanded', true)}
+        expandable={boolean('expandable', false)}
         hasBackgroundOverlay={boolean('hasBackgroundOverlay', true)}
         orientation={select('orientation', ['left', 'right'], 'right')}
         size={select('size', DrawerSizes, 'sm')}
@@ -193,6 +249,7 @@ export const AdditionalActions = () => {
       <Button onClick={toggleVisible}>Open</Button>
       <Drawer
         behindNav={(boolean('behindNav', true))}
+        defaultExpanded={boolean('defaultExpanded', false)}
         expandable={boolean('expandable', true)}
         hasBackgroundOverlay={boolean('hasBackgroundOverlay', false)}
         orientation={select('orientation', ['left', 'right'], 'right')}


### PR DESCRIPTION
### Description
This is a feature that us at rx-workflow wanted as the contents that we were putting in was too big for the non-expanded state (needed to put the Calendar component inside). With that we wanted the drawer to be able to be expanded by default while not allowing for the user to click on a expanded button.

### Changes
Creates a new prop `defaultExpanded`, which I chose the naming based off react-select's `defaultMenuIsOpen` naming (open to changes tho), that will set the initial value of the expanded state