### PR TITLE
Add Synthesis colors from Figma

### DIFF
--- a/scss/colors/synthesis-palette.scss
+++ b/scss/colors/synthesis-palette.scss
@@ -1,23 +1,24 @@
 // stoplight color system
-$synth-green-1-success: #015029;
-$synth-green-2-success: #09914f;
-$synth-green-3-success: #d4f6e5;
+$synth-success-green-dark: #015029;
+$synth-success-green-medium: #09914f;
+$synth-success-green-light: #d4f6e5;
 
-$synth-red-1-error: #c71f1f;
-$synth-red-2-error: #e03131;
-$synth-red-3-error: #fae1e1;
+$synth-error-red-dark: #c71f1f;
+$synth-error-red-medium: #e03131;
+$synth-error-red-light: #fae1e1;
 
-$synth-yellow-1-warn: #fbda36;
-$synth-yellow-2-warn: #ffe356;
-$synth-yellow-3-warn: #fff1ab;
+$synth-warning-amber-dark: #fbda36;
+$synth-warning-amber-medium: #ffe356;
+$synth-warning-amber-light: #fff1ab;
+$synth-warning-amber-alternate: #f59c27;
 
 // neutrals
-$synth-alert-bg-gray: #f4f4f4;
-$synth-div-stroke-gray: #dedede;
-$synth-header-gray: #fbfbfb;
-$synth-page-white: #fdfdfd;
-$synth-text-black: #1b1b1b;
-$synth-unselected-gray: #5b5b5b;
+$synth-alert-bg-neutral: #f4f4f4;
+$synth-div-stroke-neutral: #dedede;
+$synth-header-neutral: #fbfbfb;
+$synth-page-neutral: #fdfdfd;
+$synth-text-neutral: #1b1b1b;
+$synth-unselected-neutral: #5b5b5b;
 
 // main schema - visual hierarchy
 $synth-accent-green: #158d71;
@@ -29,8 +30,7 @@ $synth-primary-cta-blue: #162c4e;
 $synth-selected-state-green: #c6e2db;
 
 // feedback and signifier colors
-$synth-hyperlink: #3f6dca;
-$synth-orange-1-warn: #f59c27;
+$synth-hyperlink-color: #3f6dca;
 
 $synth-hover-blue: #e5ecff;
 $synth-header-gray-blue: #eef2f8;

--- a/scss/colors/synthesis-palette.scss
+++ b/scss/colors/synthesis-palette.scss
@@ -1,0 +1,36 @@
+// stoplight color system
+$synth-green-1-success: #015029;
+$synth-green-2-success: #09914f;
+$synth-green-3-success: #d4f6e5;
+
+$synth-red-1-error: #c71f1f;
+$synth-red-2-error: #e03131;
+$synth-red-3-error: #fae1e1;
+
+$synth-yellow-1-warn: #fbda36;
+$synth-yellow-2-warn: #ffe356;
+$synth-yellow-3-warn: #fff1ab;
+
+// neutrals
+$synth-alert-bg-gray: #f4f4f4;
+$synth-div-stroke-gray: #dedede;
+$synth-header-gray: #fbfbfb;
+$synth-page-white: #fdfdfd;
+$synth-text-black: #1b1b1b;
+$synth-unselected-gray: #5b5b5b;
+
+// main schema - visual hierarchy
+$synth-accent-green: #158d71;
+$synth-dark-background-selected-blue: #162c4e;
+$synth-hover-state: #eef9f6;
+$synth-indicator-stroke-green: #91cabb;
+$synth-navbar-blue: #010812;
+$synth-primary-cta-blue: #162c4e;
+$synth-selected-state-green: #c6e2db;
+
+// feedback and signifier colors
+$synth-hyperlink: #3f6dca;
+$synth-orange-1-warn: #f59c27;
+
+$synth-hover-blue: #e5ecff;
+$synth-header-gray-blue: #eef2f8;

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -2,21 +2,26 @@
 @import './colors/synthesis-palette';
 
 :export {
-  SYNTH_GREEN_1_SUCCESS: $synth-green-1-success;
-  SYNTH_GREEN_2_SUCCESS: $synth-green-2-success;
-  SYNTH_GREEN_3_SUCCESS: $synth-green-3-success;
-  SYNTH_RED_1_ERROR: $synth-red-1-error;
-  SYNTH_RED_2_ERROR: $synth-red-2-error;
-  SYNTH_RED_3_ERROR: $synth-red-3-error;
-  SYNTH_YELLOW_1_WARN: $synth-yellow-1-warn;
-  SYNTH_YELLOW_2_WARN: $synth-yellow-2-warn;
-  SYNTH_YELLOW_3_WARN: $synth-yellow-3-warn;
-  SYNTH_ALERT_BG_GRAY: $synth-alert-bg-gray;
-  SYNTH_DIV_STROKE_GRAY: $synth-div-stroke-gray;
-  SYNTH_HEADER_GRAY: $synth-header-gray;
-  SYNTH_PAGE_WHITE: $synth-page-white;
-  SYNTH_TEXT_BLACK: $synth-text-black;
-  SYNTH_UNSELECTED_GRAY: $synth-unselected-gray;
+  SYNTH_SUCCESS_GREEN_DARK: $synth-success-green-dark;
+  SYNTH_SUCCESS_GREEN_MEDIUM: $synth-success-green-medium;
+  SYNTH_SUCCESS_GREEN_LIGHT: $synth-success-green-light;
+
+  SYNTH_ERROR_RED_DARK: $synth-error-red-dark;
+  SYNTH_ERROR_RED_MEDIUM: $synth-error-red-medium;
+  SYNTH_ERROR_RED_LIGHT: $synth-error-red-light;
+
+  SYNTH_WARNING_AMBER_DARK: $synth-warning-amber-dark;
+  SYNTH_WARNING_AMBER_MEDIUM: $synth-warning-amber-medium;
+  SYNTH_WARNING_AMBER_LIGHT: $synth-warning-amber-light;
+  SYNTH_WARNING_AMBER_ALTERNATE: $synth-warning-amber-alternate;
+
+  SYNTH_ALERT_BG_NEUTRAL: $synth-alert-bg-neutral;
+  SYNTH_DIV_STROKE_NEUTRAL: $synth-div-stroke-neutral;
+  SYNTH_HEADER_NEUTRAL: $synth-header-neutral;
+  SYNTH_PAGE_NEUTRAL: $synth-page-neutral;
+  SYNTH_TEXT_NEUTRAL: $synth-text-neutral;
+  SYNTH_UNSELECTED_NEUTRAL: $synth-unselected-neutral;
+
   SYNTH_ACCENT_GREEN: $synth-accent-green;
   SYNTH_DARK_BACKGROUND_SELECTED_BLUE: $synth-dark-background-selected-blue;
   SYNTH_HOVER_STATE: $synth-hover-state;
@@ -24,8 +29,9 @@
   SYNTH_NAVBAR_BLUE: $synth-navbar-blue;
   SYNTH_PRIMARY_CTA_BLUE: $synth-primary-cta-blue;
   SYNTH_SELECTED_STATE_GREEN: $synth-selected-state-green;
-  SYNTH_HYPERLINK: $synth-hyperlink;
-  SYNTH_ORANGE_1_WARN: $synth-orange-1-warn;
+
+  SYNTH_HYPERLINK_COLOR: $synth-hyperlink-color;
+
   SYNTH_HOVER_BLUE: $synth-hover-blue;
   SYNTH_HEADER_GRAY_BLUE: $synth-header-gray-blue;
 

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -1,6 +1,34 @@
 @import './colors/palette';
+@import './colors/synthesis-palette';
 
 :export {
+  SYNTH_GREEN_1_SUCCESS: $synth-green-1-success;
+  SYNTH_GREEN_2_SUCCESS: $synth-green-2-success;
+  SYNTH_GREEN_3_SUCCESS: $synth-green-3-success;
+  SYNTH_RED_1_ERROR: $synth-red-1-error;
+  SYNTH_RED_2_ERROR: $synth-red-2-error;
+  SYNTH_RED_3_ERROR: $synth-red-3-error;
+  SYNTH_YELLOW_1_WARN: $synth-yellow-1-warn;
+  SYNTH_YELLOW_2_WARN: $synth-yellow-2-warn;
+  SYNTH_YELLOW_3_WARN: $synth-yellow-3-warn;
+  SYNTH_ALERT_BG_GRAY: $synth-alert-bg-gray;
+  SYNTH_DIV_STROKE_GRAY: $synth-div-stroke-gray;
+  SYNTH_HEADER_GRAY: $synth-header-gray;
+  SYNTH_PAGE_WHITE: $synth-page-white;
+  SYNTH_TEXT_BLACK: $synth-text-black;
+  SYNTH_UNSELECTED_GRAY: $synth-unselected-gray;
+  SYNTH_ACCENT_GREEN: $synth-accent-green;
+  SYNTH_DARK_BACKGROUND_SELECTED_BLUE: $synth-dark-background-selected-blue;
+  SYNTH_HOVER_STATE: $synth-hover-state;
+  SYNTH_INDICATOR_STROKE_GREEN: $synth-indicator-stroke-green;
+  SYNTH_NAVBAR_BLUE: $synth-navbar-blue;
+  SYNTH_PRIMARY_CTA_BLUE: $synth-primary-cta-blue;
+  SYNTH_SELECTED_STATE_GREEN: $synth-selected-state-green;
+  SYNTH_HYPERLINK: $synth-hyperlink;
+  SYNTH_ORANGE_1_WARN: $synth-orange-1-warn;
+  SYNTH_HOVER_BLUE: $synth-hover-blue;
+  SYNTH_HEADER_GRAY_BLUE: $synth-header-gray-blue;
+
   UX_BLACK: $ux-black;
   UX_BLUE: $ux-blue;
   UX_CREAM: $ux-cream;


### PR DESCRIPTION
Adds Sass variables for the [new Synthesis colors from Figma](https://www.figma.com/file/dmmTbSjuPXqt9m82YaewXO/Synthesis-Design-System?type=design&node-id=0-1&mode=design&t=lkmh9m9vVaDMtER6-0)

Todo:
- [x] Discuss and finalize color names
- [ ] Add new colors to docs
- [ ] Mark legacy colors not included in Brand Colors as deprecated in docs