### PR TITLE
add border to Card under Synthesized class

### DIFF
--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -1,5 +1,12 @@
 @import '../../scss/theme';
 
+.Synthesized {
+  .Card {
+    border: 1px solid $ux-gray-400;
+    box-shadow: none;
+  }
+}
+
 .Card {
   background-color: $ux-white;
   border: none;


### PR DESCRIPTION
closes #1070 

Adds border to `Card` under the `.Synthesized` class. This should only affect the `Card` component when `.Synthesized` class is applied to the `<body>` when `@is_new_navigation_enabled` is enabled.

Looks like this (removing the border already applied in `app/javascript/researcher/account_project_dashboard/account_project_dashboard.scss`):
 
![Screenshot 2023-11-21 at 1 18 32 PM](https://github.com/user-interviews/ui-design-system/assets/37383785/c49b5c93-aa87-486c-9b70-64838756454b)

![Screenshot 2023-11-21 at 1 18 45 PM](https://github.com/user-interviews/ui-design-system/assets/37383785/c55f32e6-994d-4e75-ac7f-754945be5b6a)

When `@is_new_navigation_enabled` is off:

![Screenshot 2023-11-21 at 1 21 18 PM](https://github.com/user-interviews/ui-design-system/assets/37383785/706fe64d-db41-4129-82ff-9206899d98cf)

