### PR TITLE
add pointer to CheckboxButton and RadioButton

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -5566,12 +5566,14 @@ exports[`Storyshots Components/CheckboxButton Indeterminate 1`] = `
 >
   <input
     checked={false}
+    className=""
     id="select-all"
     onChange={[Function]}
     type="checkbox"
   />
   <input
     checked={false}
+    className=""
     id="1"
     onChange={[Function]}
     type="checkbox"
@@ -5579,6 +5581,7 @@ exports[`Storyshots Components/CheckboxButton Indeterminate 1`] = `
   />
   <input
     checked={false}
+    className=""
     id="2"
     onChange={[Function]}
     type="checkbox"
@@ -5586,6 +5589,7 @@ exports[`Storyshots Components/CheckboxButton Indeterminate 1`] = `
   />
   <input
     checked={false}
+    className=""
     id="3"
     onChange={[Function]}
     type="checkbox"
@@ -11143,6 +11147,7 @@ exports[`Storyshots Components/Profile Cell With Trailing Icon 1`] = `
 exports[`Storyshots Components/RadioButton Default 1`] = `
 <input
   checked={false}
+  className=""
   disabled={false}
   id="1"
   name=""
@@ -19518,6 +19523,7 @@ exports[`Storyshots Components/Table Table With Multiple Select 1`] = `
         style={null}
       >
         <input
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -19580,6 +19586,7 @@ exports[`Storyshots Components/Table Table With Multiple Select 1`] = `
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -19638,6 +19645,7 @@ exports[`Storyshots Components/Table Table With Multiple Select 1`] = `
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -19696,6 +19704,7 @@ exports[`Storyshots Components/Table Table With Multiple Select 1`] = `
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -19752,6 +19761,7 @@ exports[`Storyshots Components/Table Table With Multiple Select 1`] = `
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -19808,6 +19818,7 @@ exports[`Storyshots Components/Table Table With Multiple Select 1`] = `
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -19866,6 +19877,7 @@ exports[`Storyshots Components/Table Table With Multiple Select 1`] = `
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -19924,6 +19936,7 @@ exports[`Storyshots Components/Table Table With Multiple Select 1`] = `
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -19980,6 +19993,7 @@ exports[`Storyshots Components/Table Table With Multiple Select 1`] = `
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -20038,6 +20052,7 @@ exports[`Storyshots Components/Table Table With Multiple Select 1`] = `
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -20096,6 +20111,7 @@ exports[`Storyshots Components/Table Table With Multiple Select 1`] = `
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -20167,6 +20183,7 @@ exports[`Storyshots Components/Table Table With Multiple Select And Multiple Sti
         }
       >
         <input
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -20278,6 +20295,7 @@ exports[`Storyshots Components/Table Table With Multiple Select And Multiple Sti
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -20376,6 +20394,7 @@ exports[`Storyshots Components/Table Table With Multiple Select And Multiple Sti
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -20474,6 +20493,7 @@ exports[`Storyshots Components/Table Table With Multiple Select And Multiple Sti
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -20570,6 +20590,7 @@ exports[`Storyshots Components/Table Table With Multiple Select And Multiple Sti
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -20666,6 +20687,7 @@ exports[`Storyshots Components/Table Table With Multiple Select And Multiple Sti
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -20764,6 +20786,7 @@ exports[`Storyshots Components/Table Table With Multiple Select And Multiple Sti
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -20862,6 +20885,7 @@ exports[`Storyshots Components/Table Table With Multiple Select And Multiple Sti
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -20958,6 +20982,7 @@ exports[`Storyshots Components/Table Table With Multiple Select And Multiple Sti
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -21056,6 +21081,7 @@ exports[`Storyshots Components/Table Table With Multiple Select And Multiple Sti
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"
@@ -21154,6 +21180,7 @@ exports[`Storyshots Components/Table Table With Multiple Select And Multiple Sti
       >
         <input
           checked={false}
+          className=""
           id="checkbox"
           onChange={[Function]}
           type="checkbox"

--- a/src/CheckboxButton/CheckboxButton.jsx
+++ b/src/CheckboxButton/CheckboxButton.jsx
@@ -1,6 +1,10 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
+import classNames from 'classnames';
+
+import styles from './CheckboxButton.module.scss';
+
 export const CHECKED_STATES = {
   CHECKED: true,
   UNCHECKED: false,
@@ -28,7 +32,7 @@ const CheckboxButton = React.forwardRef(({
   return (
     <input
       checked={checked}
-      className={className}
+      className={classNames(className, styles.checkboxButton)}
       disabled={disabled}
       id={id}
       name={name}

--- a/src/CheckboxButton/CheckboxButton.module.scss
+++ b/src/CheckboxButton/CheckboxButton.module.scss
@@ -1,0 +1,3 @@
+.checkboxButton {
+  cursor: pointer;
+}

--- a/src/CheckboxButtonGroup/__snapshots__/CheckboxButtonGroup.test.jsx.snap
+++ b/src/CheckboxButtonGroup/__snapshots__/CheckboxButtonGroup.test.jsx.snap
@@ -8,6 +8,7 @@ exports[`CheckboxButtonGroup sets initial value properly 1`] = `
   <input
     bordered={true}
     checked={true}
+    className=""
     id="first"
     label="First value"
     onChange={[Function]}
@@ -17,6 +18,7 @@ exports[`CheckboxButtonGroup sets initial value properly 1`] = `
   <input
     bordered={true}
     checked={true}
+    className=""
     id="second"
     label="Second value"
     onChange={[Function]}
@@ -34,6 +36,7 @@ exports[`CheckboxButtonGroup will update array state to check a new item 1`] = `
   <input
     bordered={true}
     checked={true}
+    className=""
     id="first"
     label="First value"
     onChange={[Function]}
@@ -43,6 +46,7 @@ exports[`CheckboxButtonGroup will update array state to check a new item 1`] = `
   <input
     bordered={true}
     checked={false}
+    className=""
     id="second"
     label="Second value"
     onChange={[Function]}
@@ -60,6 +64,7 @@ exports[`CheckboxButtonGroup will update array state to uncheck an item 1`] = `
   <input
     bordered={true}
     checked={false}
+    className=""
     id="first"
     label="First value"
     onChange={[Function]}
@@ -69,6 +74,7 @@ exports[`CheckboxButtonGroup will update array state to uncheck an item 1`] = `
   <input
     bordered={true}
     checked={false}
+    className=""
     id="second"
     label="Second value"
     onChange={[Function]}

--- a/src/RadioButton/RadioButton.jsx
+++ b/src/RadioButton/RadioButton.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import classNames from 'classnames';
+
+import styles from './RadioButton.module.scss';
+
 const RadioButton = React.forwardRef(({
   checked,
   className,
@@ -13,7 +17,7 @@ const RadioButton = React.forwardRef(({
 }, ref) => (
   <input
     checked={checked}
-    className={className}
+    className={classNames(className, styles.radioButton)}
     disabled={disabled}
     id={id}
     name={name}

--- a/src/RadioButton/RadioButton.module.scss
+++ b/src/RadioButton/RadioButton.module.scss
@@ -1,0 +1,3 @@
+.radioButton {
+  cursor: pointer;
+}


### PR DESCRIPTION
closes #1073 

Small interaction detail, but an important one! `RadioButton` and `CheckboxButton` should have a `cursor: pointer` on them. 

Whoopsie: https://www.notion.so/user-interviews/No-pointer-cursor-on-checkboxes-or-radios-564eb93215394e82829a73dbd2672226

Primary: Devin, Kyle