### PR TITLE
FormGroup helperText prop type string or node'

### DIFF
--- a/src/FormGroup/FormGroup.jsx
+++ b/src/FormGroup/FormGroup.jsx
@@ -118,7 +118,7 @@ FormGroup.propTypes = {
   displayErrorText: PropTypes.bool,
   elementType: PropTypes.oneOf(FORM_GROUP_ELEMENT_TYPES),
   errors: PropTypes.object,
-  helperText: PropTypes.string,
+  helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   id: PropTypes.string,
   inline: PropTypes.bool,
   inputKey: PropTypes.string,


### PR DESCRIPTION
Fix #1086 

I need to paste a mix of regular text with a url link to a helperText in `FormGroup` component. This is currently not supported because `helperText` is only allowed to be a string and JS specs blow up on this warning and you cannot merge your PR. Example of what I need to pass
```
        <FormGroup
          className={styles.detailFormItem}
          errors={{ 'compensation-amount': errors }}
          helperText={(
            <>
              {INCENTIVE_CALCULATOR_TEXT}
              <ExternalLink
                aria-label={INCENTIVE_CALCULATOR_LINK_TEXT}
                href={Routes.incentive_calculator_path()}
                text={INCENTIVE_CALCULATOR_LINK_TEXT}
              />
            </>
 )}
          inputKey="compensation-amount"
          label="Incentive amount"
          labelHtmlFor="compensation-amount"
        >
```