### PR TITLE
update DropdownItem hover state, remove danger variant

### DIFF
--- a/src/Dropdown/DropdownItem.jsx
+++ b/src/Dropdown/DropdownItem.jsx
@@ -36,7 +36,7 @@ const DropdownItem = ({
     onClick={onClick}
     {...props}
   >
-    { leadingIcon && <FontAwesomeIcon className="icon-left fa-fw" icon={leadingIcon} /> }
+    { leadingIcon && <FontAwesomeIcon className={classNames(styles.DropdownItemIcon, 'icon-left', 'fa-fw')} icon={leadingIcon} /> }
     { children }
   </RBDropdown.Item>
   );

--- a/src/Dropdown/DropdownItem.jsx
+++ b/src/Dropdown/DropdownItem.jsx
@@ -8,10 +8,6 @@ import { Dropdown as RBDropdown } from 'react-bootstrap';
 
 import styles from './DropdownItem.module.scss';
 
-const DropdownItemVariants = {
-  DANGER: 'danger',
-};
-
 const DropdownItem = ({
   active,
   as,
@@ -22,7 +18,6 @@ const DropdownItem = ({
   href,
   leadingIcon,
   onClick,
-  variant,
   bsPrefix,
   ...props
 }) => (
@@ -33,7 +28,7 @@ const DropdownItem = ({
     className={classNames(
       className,
       'DropdownItem',
-      styles.DropdownItem
+      styles.DropdownItem,
     )}
     disabled={disabled}
     eventKey={eventKey}
@@ -75,10 +70,6 @@ DropdownItem.propTypes = {
   href: PropTypes.string,
   leadingIcon: PropTypes.object,
   /**
-    Optional variant for controlling color and hover states (e.g. destructive actions)
-   */
-  variant: PropTypes.oneOf(Object.values(DropdownItemVariants)),
-  /**
     Callback fired when the menu item is clicked.
    */
   onClick: PropTypes.func,
@@ -93,7 +84,6 @@ DropdownItem.defaultProps = {
   eventKey: undefined,
   href: undefined,
   leadingIcon: undefined,
-  variant: undefined,
   onClick: undefined,
 };
 

--- a/src/Dropdown/DropdownItem.jsx
+++ b/src/Dropdown/DropdownItem.jsx
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { Dropdown as RBDropdown } from 'react-bootstrap';
 
-import './DropdownItem.scss';
+import styles from './DropdownItem.module.scss';
 
 const DropdownItemVariants = {
   DANGER: 'danger',
@@ -33,7 +33,7 @@ const DropdownItem = ({
     className={classNames(
       className,
       'DropdownItem',
-      variant && `DropdownItem--${variant}`,
+      styles.DropdownItem
     )}
     disabled={disabled}
     eventKey={eventKey}

--- a/src/Dropdown/DropdownItem.module.scss
+++ b/src/Dropdown/DropdownItem.module.scss
@@ -1,45 +1,20 @@
 @import '../../scss/theme';
 
-.Synthesized {
-  .DropdownItem {
-    @include synth-font-type-30;
-    color: $ux-gray-900;
-  
-    i, svg {
-      &.icon-left {
-        margin-right: $ux-spacing-20;
-      }
-    }
-  
-    &:hover {
-      background-color: $synth-hover-state;
-      text-decoration: none;
-    }
-  
-    &:focus {
-      background-color: $synth-selected-state-green;
-      color: $ux-gray-900;
-    }
-  }
-}
-
 .DropdownItem {
   @include synth-font-type-30;
   color: $ux-gray-900;
 
-  i, svg {
-    &.icon-left {
-      margin-right: $ux-spacing-20;
-    }
-  }
-
   &:hover {
-    background-color: $ux-blue-100;
+    background-color: $synth-hover-state;
     text-decoration: none;
   }
 
   &:focus {
-    background-color: $ux-blue-200;
+    background-color: $synth-selected-state-green;
     color: $ux-gray-900;
   }
+}
+
+.DropdownItemIcon {
+  margin-right: $ux-spacing-20;
 }

--- a/src/Dropdown/DropdownItem.module.scss
+++ b/src/Dropdown/DropdownItem.module.scss
@@ -1,5 +1,28 @@
 @import '../../scss/theme';
 
+.Synthesized {
+  .DropdownItem {
+    @include synth-font-type-30;
+    color: $ux-gray-900;
+  
+    i, svg {
+      &.icon-left {
+        margin-right: $ux-spacing-20;
+      }
+    }
+  
+    &:hover {
+      background-color: $synth-hover-state;
+      text-decoration: none;
+    }
+  
+    &:focus {
+      background-color: $synth-selected-state-green;
+      color: $ux-gray-900;
+    }
+  }
+}
+
 .DropdownItem {
   @include synth-font-type-30;
   color: $ux-gray-900;
@@ -11,12 +34,12 @@
   }
 
   &:hover {
-    background-color: $synth-hover-state;
+    background-color: $ux-blue-100;
     text-decoration: none;
   }
 
   &:focus {
-    background-color: $synth-selected-state-green;
+    background-color: $ux-blue-200;
     color: $ux-gray-900;
   }
 }

--- a/src/Dropdown/DropdownItem.module.scss
+++ b/src/Dropdown/DropdownItem.module.scss
@@ -16,7 +16,7 @@
   }
 
   &:focus {
-    background-color: $ux-blue-200;
+    background-color: $synth-selected-state-green;
     color: $ux-gray-900;
   }
 }

--- a/src/Dropdown/DropdownItem.module.scss
+++ b/src/Dropdown/DropdownItem.module.scss
@@ -11,21 +11,12 @@
   }
 
   &:hover {
-    background-color: $ux-blue-100;
+    background-color: $synth-hover-state;
     text-decoration: none;
   }
 
   &:focus {
     background-color: $ux-blue-200;
     color: $ux-gray-900;
-  }
-
-  &--danger {
-    color: $ux-red;
-    
-    &:hover {
-      background-color: $ux-red-100;
-      color: $ux-red-600;
-    }
   }
 }


### PR DESCRIPTION
closes #1090 

- Update the `DropdownItem` hover state to synth hover color (also uses CSS modules to avoid bootstrap collision)
- removes danger variant (we only use in one place currently, but PD says we can get rid of it)

Before:

https://github.com/user-interviews/ui-design-system/assets/37383785/b009f61f-fa5e-48ff-90f7-4d753794ecec

After:

https://github.com/user-interviews/ui-design-system/assets/37383785/a98c28d4-9aff-4ab4-9694-1b20bffc7288

