### PR TITLE
give default sizes to levels, make weight and size optional

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -9054,8 +9054,8 @@ Array [
 `;
 
 exports[`Storyshots Components/Heading Default 1`] = `
-<h2
-  className="Heading Heading--xxl Heading--bold"
+<h1
+  className="Heading Heading--xxxl Heading--bold"
   style={
     Object {
       "textAlign": undefined,
@@ -9063,7 +9063,7 @@ exports[`Storyshots Components/Heading Default 1`] = `
   }
 >
   The fastest way to recruit research participants
-</h2>
+</h1>
 `;
 
 exports[`Storyshots Components/Heading Levels 1`] = `
@@ -9128,7 +9128,72 @@ Array [
   >
     The fastest way to recruit research participants
   </h6>,
-  <h6
+]
+`;
+
+exports[`Storyshots Components/Heading Sizes 1`] = `
+Array [
+  <h2
+    className="Heading Heading--xxxl Heading--bold"
+    style={
+      Object {
+        "textAlign": undefined,
+      }
+    }
+  >
+    This is a heading level 2 with size="xxxl"
+  </h2>,
+  <h2
+    className="Heading Heading--xxl Heading--bold"
+    style={
+      Object {
+        "textAlign": undefined,
+      }
+    }
+  >
+    This is a heading level 2 with size="xxl"
+  </h2>,
+  <h2
+    className="Heading Heading--xl Heading--bold"
+    style={
+      Object {
+        "textAlign": undefined,
+      }
+    }
+  >
+    This is a heading level 2 with size="xl"
+  </h2>,
+  <h2
+    className="Heading Heading--lg Heading--bold"
+    style={
+      Object {
+        "textAlign": undefined,
+      }
+    }
+  >
+    This is a heading level 2 with size="lg"
+  </h2>,
+  <h2
+    className="Heading Heading--md Heading--bold"
+    style={
+      Object {
+        "textAlign": undefined,
+      }
+    }
+  >
+    This is a heading level 2 with size="md"
+  </h2>,
+  <h2
+    className="Heading Heading--sm Heading--bold"
+    style={
+      Object {
+        "textAlign": undefined,
+      }
+    }
+  >
+    This is a heading level 2 with size="sm"
+  </h2>,
+  <h2
     className="Heading Heading--xs Heading--bold"
     style={
       Object {
@@ -9136,8 +9201,8 @@ Array [
       }
     }
   >
-    The fastest way to recruit research participants
-  </h6>,
+    This is a heading level 2 with size="xs"
+  </h2>,
 ]
 `;
 
@@ -10428,8 +10493,8 @@ exports[`Storyshots Components/MoneyInput Default 1`] = `
     value="$ 1,250.99"
   />
   <br />
-  <h2
-    className="Heading Heading--xxl Heading--bold"
+  <h1
+    className="Heading Heading--xxxl Heading--bold"
     style={
       Object {
         "textAlign": undefined,
@@ -10438,7 +10503,7 @@ exports[`Storyshots Components/MoneyInput Default 1`] = `
   >
     Value: 
     1250.99
-  </h2>
+  </h1>
 </div>
 `;
 
@@ -10472,8 +10537,8 @@ exports[`Storyshots Components/MoneyInput Prefix 1`] = `
     value="USD$ 500"
   />
   <br />
-  <h2
-    className="Heading Heading--xxl Heading--bold"
+  <h1
+    className="Heading Heading--xxxl Heading--bold"
     style={
       Object {
         "textAlign": undefined,
@@ -10482,7 +10547,7 @@ exports[`Storyshots Components/MoneyInput Prefix 1`] = `
   >
     Value: 
     500
-  </h2>
+  </h1>
 </div>
 `;
 
@@ -10516,8 +10581,8 @@ exports[`Storyshots Components/MoneyInput Step 1`] = `
     value="$ 200"
   />
   <br />
-  <h2
-    className="Heading Heading--xxl Heading--bold"
+  <h1
+    className="Heading Heading--xxxl Heading--bold"
     style={
       Object {
         "textAlign": undefined,
@@ -10526,7 +10591,7 @@ exports[`Storyshots Components/MoneyInput Step 1`] = `
   >
     Value: 
     200
-  </h2>
+  </h1>
 </div>
 `;
 

--- a/src/Heading/Heading.stories.tsx
+++ b/src/Heading/Heading.stories.tsx
@@ -62,12 +62,12 @@ export const Default: Story = {
 export const Levels: Story = {
   render: () => (
     <>
-      <Heading level={1}>The fastest way to recruit research participants</Heading>
-      <Heading level={2}>The fastest way to recruit research participants</Heading>
-      <Heading level={3}>The fastest way to recruit research participants</Heading>
-      <Heading level={4}>The fastest way to recruit research participants</Heading>
-      <Heading level={5}>The fastest way to recruit research participants</Heading>
-      <Heading level={6}>The fastest way to recruit research participants</Heading>
+      <Heading level={1} size="xxxl">The fastest way to recruit research participants</Heading>
+      <Heading level={2} size="xxl">The fastest way to recruit research participants</Heading>
+      <Heading level={3} size="xl">The fastest way to recruit research participants</Heading>
+      <Heading level={4} size="lg">The fastest way to recruit research participants</Heading>
+      <Heading level={5} size="md">The fastest way to recruit research participants</Heading>
+      <Heading level={6} size="sm">The fastest way to recruit research participants</Heading>
     </>
   ),
 };

--- a/src/Heading/Heading.stories.tsx
+++ b/src/Heading/Heading.stories.tsx
@@ -24,6 +24,7 @@ type Story = StoryObj<typeof Heading>;
 export const Default: Story = {
   args: {
     children: 'The fastest way to recruit research participants',
+    level: 1,
   },
 };
 
@@ -61,13 +62,30 @@ export const Default: Story = {
 export const Levels: Story = {
   render: () => (
     <>
-      <Heading level={1} size="xxxl" weight="bold">The fastest way to recruit research participants</Heading>
-      <Heading level={2} size="xxl" weight="bold">The fastest way to recruit research participants</Heading>
-      <Heading level={3} size="xl" weight="bold">The fastest way to recruit research participants</Heading>
-      <Heading level={4} size="lg" weight="bold">The fastest way to recruit research participants</Heading>
-      <Heading level={5} size="md" weight="bold">The fastest way to recruit research participants</Heading>
-      <Heading level={6} size="sm" weight="bold">The fastest way to recruit research participants</Heading>
-      <Heading level={6} size="xs" weight="bold">The fastest way to recruit research participants</Heading>
+      <Heading level={1}>The fastest way to recruit research participants</Heading>
+      <Heading level={2}>The fastest way to recruit research participants</Heading>
+      <Heading level={3}>The fastest way to recruit research participants</Heading>
+      <Heading level={4}>The fastest way to recruit research participants</Heading>
+      <Heading level={5}>The fastest way to recruit research participants</Heading>
+      <Heading level={6}>The fastest way to recruit research participants</Heading>
+    </>
+  ),
+};
+
+/**
+  Headings come with default sizes based on their level, but you are able to
+  adjust its size based on visual hierarchy needs.
+*/
+export const Sizes: Story = {
+  render: () => (
+    <>
+      <Heading level={2} size="xxxl">This is a heading level 2 with size="xxxl"</Heading>
+      <Heading level={2} size="xxl">This is a heading level 2 with size="xxl"</Heading>
+      <Heading level={2} size="xl">This is a heading level 2 with size="xl"</Heading>
+      <Heading level={2} size="lg">This is a heading level 2 with size="lg"</Heading>
+      <Heading level={2} size="md">This is a heading level 2 with size="md"</Heading>
+      <Heading level={2} size="sm">This is a heading level 2 with size="sm"</Heading>
+      <Heading level={2} size="xs">This is a heading level 2 with size="xs"</Heading>
     </>
   ),
 };

--- a/src/Heading/Heading.tsx
+++ b/src/Heading/Heading.tsx
@@ -8,16 +8,27 @@ export interface HeadingProps {
   children?: ReactNode;
   className?: string;
   level: 1 | 2 | 3 | 4 | 5 | 6;
-  size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | 'xxxl';
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | 'xxxl';
   textAlign?: 'left' | 'center' | 'right';
-  weight: 'regular' | 'medium' | 'bold';
+  weight?: 'regular' | 'medium' | 'bold';
 }
+
+const LevelToSizeMap = {
+  1: 'xxxl',
+  2: 'xxl',
+  3: 'xl',
+  4: 'lg',
+  5: 'md',
+  6: 'sm',
+};
+
+const getHeadingSizeClassFromLevel = (level: number) => `Heading--${LevelToSizeMap[level]}`;
 
 const Heading = ({
   children,
   className,
-  level = 2,
-  size = 'xxl',
+  level = 1,
+  size,
   textAlign,
   weight = 'bold',
   ...props
@@ -28,6 +39,7 @@ const Heading = ({
       className: classNames(
         className,
         'Heading',
+        !size && getHeadingSizeClassFromLevel(level),
         {
           [`Heading--${size}`]: !!size,
           [`Heading--${weight}`]: !!weight,

--- a/src/Heading/Heading.tsx
+++ b/src/Heading/Heading.tsx
@@ -7,8 +7,22 @@ import './Heading.scss';
 export interface HeadingProps {
   children?: ReactNode;
   className?: string;
+  /**
+   * @type {number}
+   * @description Choose the appropriate heading level (h1 to h6) based on a
+   * page's semantic structure.
+   * Headings define the document structure, and screen readers use them for navigation.
+   * For accessibility, a page must contain at least one h1, headings should follow a
+   * logical hierarchy where each heading level represents a sublevel of the previous one,
+   * and avoid skipping levels.
+   */
   level: 1 | 2 | 3 | 4 | 5 | 6;
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | 'xxxl';
+  /**
+   * @type {string}
+   * @description Sizes map to the available font-sizes from the defined list of font-types.
+   * Adjust for visual hierarchy.
+   */
+  size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | 'xxxl';
   textAlign?: 'left' | 'center' | 'right';
   weight?: 'regular' | 'medium' | 'bold';
 }


### PR DESCRIPTION
closes #1095 

Chromatic: https://62d040e741710e4f085e0647-xcmihmyrti.chromatic.com/?path=/story/components-heading--sizes

- Makes only `level` and `size` required on `Heading`
- Changes default level from `2` to `1`
- Assigns default `size` props to every Heading `level`
- If `size` or `weight` are assigned, they will overtake the defaults 

I think this should simplify the need to assign each one of these props on the `Heading` component every time. Given a required `level`, it should be able to default to the a more logical sizing based on level. A dev can always override the size or weight based on visual hierarchy needs, but hopefully this reduces the friction to using the `Heading` component. 

Primary: Kyle, Gabe