### PR TITLE
remove font-weight: 100

### DIFF
--- a/scss/forms/form_control_label.scss
+++ b/scss/forms/form_control_label.scss
@@ -33,7 +33,7 @@
   }
 
   &__children {
-    @include synth-font-type-30--medium;
+    @include synth-font-type-30;
 
     margin-top: 0.5rem;
     width: 100%;

--- a/scss/forms/form_control_label.scss
+++ b/scss/forms/form_control_label.scss
@@ -35,7 +35,6 @@
   &__children {
     @include synth-font-type-30--medium;
 
-    font-weight: 100;
     margin-top: 0.5rem;
     width: 100%;
   }

--- a/scss/forms/form_group.scss
+++ b/scss/forms/form_group.scss
@@ -20,7 +20,6 @@
 
       &__helper-text {
         @include synth-font-type-30;
-        font-weight: 100;
         color: $ux-gray-900;
       }
     }


### PR DESCRIPTION
closes #1101 

We don't use `font-weight: 100` which may have been causing some weird behaviors on some people's browsers even though it should get bumped up to the nearest available 400 font weight.