### PR TITLE
adds max height to template variable popup

### DIFF
--- a/src/RichTextEditor/TemplateVariable.scss
+++ b/src/RichTextEditor/TemplateVariable.scss
@@ -1,21 +1,23 @@
 @import '../../scss/theme';
 
 .RichTextEditor__TemplateVariables__Items {
-  border: 1px solid $synth-div-stroke-neutral;
   background-color: $ux-white;
   border-radius: $ux-border-radius;
+  border: 1px solid $synth-div-stroke-neutral;
+  max-height: 200px;
+  overflow: auto;
   padding: $ux-spacing-20 0;
 }
 
 .RichTextEditor__TemplateVariables__Item {
   @include synth-font-type-30;
   background: $ux-white;
+  border: 0;
+  color: $ux-gray-900;
+  outline: 0;
+  padding: $ux-spacing-10 $ux-spacing-40;
   text-align: left;
   width: 100%;
-  border: 0;
-  outline: 0;
-  color: $ux-gray-900;
-  padding: $ux-spacing-10 $ux-spacing-40;
 }
 
 .RichTextEditor__TemplateVariables__Item:active, 


### PR DESCRIPTION
When the variable list is too long, it would overflow the window and the bottom items become inaccessible.  This just sets a reasonable max-height.  This is sort of a hot fix and the popup should be updated to calculate it's height based on its position, but for now this does the trick.