### PR TITLE
update Toast dismiss timing

### DIFF
--- a/src/Alert/Alert.jsx
+++ b/src/Alert/Alert.jsx
@@ -52,7 +52,8 @@ const getAlertIcon = (type) => {
   }
 };
 
-const AUTO_DISMISS_TIMEOUT = 5000;
+const AUTO_DISMISS_TIMEOUT_SUCCESS = 3000;
+const AUTO_DISMISS_TIMEOUT_DEFAULT = 5000;
 
 const getAlertClassName = (type) => {
   if (!Object.values(MessageTypes).includes(type)) {
@@ -68,12 +69,14 @@ function Alert(props) {
   useEffect(() => {
     let timeout;
     if (autoDismiss) {
-      timeout = setTimeout(() => (onDismiss(id)), AUTO_DISMISS_TIMEOUT);
+      timeout = setTimeout(() => (onDismiss(id)),
+      props.type === MessageTypes.SUCCESS ?
+      AUTO_DISMISS_TIMEOUT_SUCCESS : AUTO_DISMISS_TIMEOUT_DEFAULT);
     }
     return () => {
       clearTimeout(timeout);
     };
-  }, [autoDismiss, onDismiss, id]);
+  }, [autoDismiss, onDismiss, id, props.type]);
 
   return (
     <div


### PR DESCRIPTION
closes #1114 

Chromatic: https://62d040e741710e4f085e0647-dgnqhmugfu.chromatic.com/?path=/story/components-toast--default

- Sets Success variant dismiss timing to 3 seconds. This should make sense for Success messages as they tend to be shorter in word length and require less time to read (e.g. "Message successfully sent", "Email template saved successfully." I read in a couple places that a success toast can vary between 2-5 seconds so we've probably been on the longer end. Nat thought 3 seconds was good length.
- Keeps all other Toast variants at 5 seconds by default as users may need a bit more time to read and comprehend these messages. 

We could probably refine more, but this seems to solve the issue Nat described in Workflow.

![Screenshot 2024-01-02 at 2 51 14 PM](https://github.com/user-interviews/ui-design-system/assets/37383785/95f299f7-31d0-4efd-b884-a1519b3c01d3)

