### PR TITLE
add warning and error tooltips

### DIFF
--- a/spec/__snapshots__/Storyshots.test.js.snap
+++ b/spec/__snapshots__/Storyshots.test.js.snap
@@ -25535,7 +25535,7 @@ exports[`Storyshots Components/Tooltip Default 1`] = `
 </div>
 `;
 
-exports[`Storyshots Components/Tooltip Gray Icon 1`] = `
+exports[`Storyshots Components/Tooltip Error Icon 1`] = `
 <div
   style={
     Object {
@@ -25545,15 +25545,15 @@ exports[`Storyshots Components/Tooltip Gray Icon 1`] = `
 >
   <span
     aria-hidden="true"
-    className="Tooltip__icon Tooltip__icon--gray"
+    className="Tooltip__icon Tooltip__icon--error"
     onClick={[Function]}
     onKeyPress={[Function]}
     tabIndex="0"
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-circle-question "
-      data-icon="circle-question"
+      className="svg-inline--fa fa-circle-exclamation "
+      data-icon="circle-exclamation"
       data-prefix="fas"
       focusable="false"
       role="img"
@@ -25562,43 +25562,7 @@ exports[`Storyshots Components/Tooltip Gray Icon 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM169.8 165.3c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"
-        fill="currentColor"
-        style={Object {}}
-      />
-    </svg>
-  </span>
-</div>
-`;
-
-exports[`Storyshots Components/Tooltip Green Icon 1`] = `
-<div
-  style={
-    Object {
-      "padding": "4rem",
-    }
-  }
->
-  <span
-    aria-hidden="true"
-    className="Tooltip__icon Tooltip__icon--primary"
-    onClick={[Function]}
-    onKeyPress={[Function]}
-    tabIndex="0"
-  >
-    <svg
-      aria-hidden="true"
-      className="svg-inline--fa fa-circle-question "
-      data-icon="circle-question"
-      data-prefix="fas"
-      focusable="false"
-      role="img"
-      style={Object {}}
-      viewBox="0 0 512 512"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM169.8 165.3c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"
+        d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zm0-384c13.3 0 24 10.7 24 24V264c0 13.3-10.7 24-24 24s-24-10.7-24-24V152c0-13.3 10.7-24 24-24zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"
         fill="currentColor"
         style={Object {}}
       />
@@ -25635,6 +25599,78 @@ exports[`Storyshots Components/Tooltip Light 1`] = `
     >
       <path
         d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM169.8 165.3c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </span>
+</div>
+`;
+
+exports[`Storyshots Components/Tooltip Neutral Icon 1`] = `
+<div
+  style={
+    Object {
+      "padding": "4rem",
+    }
+  }
+>
+  <span
+    aria-hidden="true"
+    className="Tooltip__icon Tooltip__icon--neutral"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex="0"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-circle-question "
+      data-icon="circle-question"
+      data-prefix="fas"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM169.8 165.3c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </span>
+</div>
+`;
+
+exports[`Storyshots Components/Tooltip Warning Icon 1`] = `
+<div
+  style={
+    Object {
+      "padding": "4rem",
+    }
+  }
+>
+  <span
+    aria-hidden="true"
+    className="Tooltip__icon Tooltip__icon--warning"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex="0"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-circle-exclamation "
+      data-icon="circle-exclamation"
+      data-prefix="fas"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zm0-384c13.3 0 24 10.7 24 24V264c0 13.3-10.7 24-24 24s-24-10.7-24-24V152c0-13.3 10.7-24 24-24zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"
         fill="currentColor"
         style={Object {}}
       />

--- a/src/Tooltip/Tooltip.mdx
+++ b/src/Tooltip/Tooltip.mdx
@@ -31,13 +31,17 @@ import * as ComponentStories from './Tooltip.stories';
 
 <Canvas of={ComponentStories.WithHtml} />
 
-### Green Icon
+### Neutral Icon
 
-<Canvas of={ComponentStories.GreenIcon} />
+<Canvas of={ComponentStories.NeutralIcon} />
 
-### Gray Icon
+### Warning Icon 
 
-<Canvas of={ComponentStories.GrayIcon} />
+<Canvas of={ComponentStories.WarningIcon} />
+
+### Error Icon 
+
+<Canvas of={ComponentStories.ErrorIcon} />
 
 ### With Tracking
 

--- a/src/Tooltip/Tooltip.scss
+++ b/src/Tooltip/Tooltip.scss
@@ -9,12 +9,16 @@
     margin-right: $synth-spacing-2;
     vertical-align: middle;
 
-    &--gray {
+    &--neutral {
       color: $ux-gray-800;
     }
 
-    &--primary {
-      color: $ux-emerald;
+    &--warning {
+      color: $synth-warning-amber-alternate;
+    }
+
+    &--error {
+      color: $synth-error-red-medium;
     }
   }
 

--- a/src/Tooltip/Tooltip.stories.jsx
+++ b/src/Tooltip/Tooltip.stories.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { withKnobs, radios, text } from '@storybook/addon-knobs';
 
+import { faExclamationCircle } from '@fortawesome/pro-solid-svg-icons';
+
 import Tooltip from 'src/Tooltip';
 import mdx from './Tooltip.mdx';
 
@@ -54,19 +56,29 @@ export const WithHtml = () => (
   />
 );
 
-export const GreenIcon = () => (
+export const NeutralIcon = () => (
   <Tooltip
-    iconClasses="Tooltip__icon--primary"
+    iconClasses="Tooltip__icon--neutral"
     placement="right"
-    text={text('Tooltip Text', 'Green Icon')}
+    text={text('Tooltip Text', 'Neutral Icon')}
   />
 );
 
-export const GrayIcon = () => (
+export const WarningIcon = () => (
   <Tooltip
-    iconClasses="Tooltip__icon--gray"
+    icon={faExclamationCircle}
+    iconClasses="Tooltip__icon--warning"
     placement="right"
-    text={text('Tooltip Text', 'Gray Icon')}
+    text={text('Tooltip Text', 'Warning Icon')}
+  />
+);
+
+export const ErrorIcon = () => (
+  <Tooltip
+    icon={faExclamationCircle}
+    iconClasses="Tooltip__icon--error"
+    placement="right"
+    text={text('Tooltip Text', 'Error Icon')}
   />
 );
 


### PR DESCRIPTION
closes #1125 

![image](https://github.com/user-interviews/ui-design-system/assets/37383785/5724ab3d-e43d-478f-9055-b7b63fc6d715)

![image](https://github.com/user-interviews/ui-design-system/assets/37383785/f36f9627-ab47-4c94-82bd-e1b55692e6d6)

Warning: https://62d040e741710e4f085e0647-dcwnoaugyn.chromatic.com/?path=/story/components-tooltip--warning-icon
Error: https://62d040e741710e4f085e0647-dcwnoaugyn.chromatic.com/?path=/story/components-tooltip--error-icon


- Adds a warning and error Tooltips, set via `iconClasses`
- Removes green Tooltip as it is not currently used
- Renames gray Tooltip to neutral 