### PR TITLE
Allow prop type node for Card title

### DIFF
--- a/src/Card/Card.jsx
+++ b/src/Card/Card.jsx
@@ -91,7 +91,7 @@ Card.propTypes = {
   noPadding: PropTypes.bool,
   size: PropTypes.string,
   subTitle: PropTypes.string,
-  title: PropTypes.string,
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 };
 
 Card.defaultProps = {

--- a/src/Card/Card.jsx
+++ b/src/Card/Card.jsx
@@ -91,7 +91,7 @@ Card.propTypes = {
   noPadding: PropTypes.bool,
   size: PropTypes.string,
   subTitle: PropTypes.string,
-  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  title: PropTypes.node,
 };
 
 Card.defaultProps = {


### PR DESCRIPTION
Allowing prop `title` from `Card` component to be have `node` type