### PR TITLE
Fix DropdownToggle focus

### DIFF
--- a/src/Dropdown/DropdownToggle.scss
+++ b/src/Dropdown/DropdownToggle.scss
@@ -4,18 +4,6 @@ $primary: $ux-emerald-600;
 $danger: $ux-red;
 $warning: $ux-yellow-400; 
 
-.Synthesized {
-  .DropdownToggle {
-    &.btn-primary {
-      @include synthesis-btn-primary;
-    }
-  
-    &.btn-outline-primary {
-      @include synthesis-btn-outline-primary;
-    }
-  }
-}
-
 .DropdownToggle {
   @include synth-font-type-30--bold;
 
@@ -99,5 +87,17 @@ $warning: $ux-yellow-400;
 
   &.btn-outline-transparent {
     @include btn-outline-transparent;
+  }
+}
+
+.Synthesized {
+  .DropdownToggle {
+    &.btn-primary {
+      @include synthesis-btn-primary;
+    }
+
+    &.btn-outline-primary {
+      @include synthesis-btn-outline-primary;
+    }
   }
 }

--- a/src/Dropdown/DropdownToggle.scss
+++ b/src/Dropdown/DropdownToggle.scss
@@ -11,10 +11,6 @@ $warning: $ux-yellow-400;
     all: unset;
   }
 
-  &--unstyled {
-    all: unset;
-  }
-
   i, svg {
     &.icon-left {
       margin-right: $synth-spacing-2;

--- a/src/Dropdown/DropdownToggle.scss
+++ b/src/Dropdown/DropdownToggle.scss
@@ -39,6 +39,14 @@ $warning: $ux-yellow-400;
 
   &.btn-primary {
     @include btn-primary;
+
+    &:focus {
+      background: $ux-emerald-600;
+    }
+
+    &.show:focus {
+      background: $ux-emerald-700;
+    }
   }
 
   &.btn-outline-primary {
@@ -47,6 +55,14 @@ $warning: $ux-yellow-400;
 
   &.btn-danger {
     @include btn-danger;
+
+    &:focus {
+      background: $ux-red-500;
+    }
+
+    &.show:focus {
+      background: $ux-red-700;
+    }
   }
   
   &.btn-outline-danger {
@@ -55,6 +71,14 @@ $warning: $ux-yellow-400;
   
   &.btn-warning {
     @include btn-warning;
+
+    &:focus {
+      background: $ux-yellow-400;
+    }
+
+    &.show:focus {
+      background: $ux-yellow-600;
+    }
   }
   
   &.btn-outline-warning {
@@ -63,6 +87,14 @@ $warning: $ux-yellow-400;
 
   &.btn-transparent {
     @include btn-transparent;
+
+    &:focus {
+      background: transparent;
+    }
+
+    &.show:focus {
+      background: $ux-gray-400;
+    }
   }
 
   &.btn-outline-transparent {


### PR DESCRIPTION
Closes #1153

If you click on the `DropdownToggle` to open the `Dropdown` then the button is `active`, which our CSS styles to be a different color. If you click it again then it closes but has focus so it is still the `active` color. If you click away then it loses `focus` and goes back to the original color.

As [this goofy JSFiddle](https://jsfiddle.net/eo7fhaL6/) demonstrates that is the expected behavior for buttons when they are clicked twice since clicking it gives it focus. You generally don't notice this since something usually happens to takes focus away from the button when it is clicked (like a form submit) and button focus states aren't styled that often.

It feels really wonky for a dropdown toggle, however. So this PR changes the styles to what we expected, which is that if you click the button to open the dropdown and then click it to close it the button goes back to the original color.

### Before

https://github.com/user-interviews/ui-design-system/assets/20173797/56ece63e-0e45-4715-aeb0-be034e8a2cc4

https://github.com/user-interviews/ui-design-system/assets/20173797/746e874a-1ca9-4328-b333-6bb61e7330ea

### After

https://github.com/user-interviews/ui-design-system/assets/20173797/a9575071-7d91-42f9-9f68-6709f06a00b6

https://github.com/user-interviews/ui-design-system/assets/20173797/5ff1bcf3-c97b-4f74-acfe-adfdab2a4e74

