### PR TITLE
Disable drawer background scrolling if drawer has background overlay

### DIFF
--- a/src/Drawer/Drawer.jsx
+++ b/src/Drawer/Drawer.jsx
@@ -59,9 +59,13 @@ const Drawer = ({
     };
   }, [handleEscKeyPress, visible]);
 
+  // console.log(isCurrentlyOpen, 'ref')
+  // console.log(visible, 'visible')
+
   useEffect(() => {
     function disableBackgroundScrolling() {
       if (visible && !isCurrentlyOpen.current) {
+        // console.log('setting css')
         document.body.classList.add('Drawer__Body--open');
         isCurrentlyOpen.current = true;
       }

--- a/src/Drawer/Drawer.jsx
+++ b/src/Drawer/Drawer.jsx
@@ -59,13 +59,13 @@ const Drawer = ({
     };
   }, [handleEscKeyPress, visible]);
 
-  // console.log(isCurrentlyOpen, 'ref')
-  // console.log(visible, 'visible')
-
   useEffect(() => {
+    // isCurrentlyOpen ref accounts for a case where you could have multiple drawers
+    // on one page and you try to access one of them via their url. Without using ref, the
+    // Drawer__Body--open would be potentially removed via other
+    // closed drawer because of a race condition
     function disableBackgroundScrolling() {
       if (visible && !isCurrentlyOpen.current) {
-        // console.log('setting css')
         document.body.classList.add('Drawer__Body--open');
         isCurrentlyOpen.current = true;
       }

--- a/src/Drawer/Drawer.jsx
+++ b/src/Drawer/Drawer.jsx
@@ -61,8 +61,6 @@ const Drawer = ({
 
   useEffect(() => {
     function disableBackgroundScrolling() {
-      if (!hasBackgroundOverlay) return;
-
       if (visible && !isCurrentlyOpen.current) {
         document.body.classList.add('Drawer__Body--open');
         isCurrentlyOpen.current = true;
@@ -74,7 +72,9 @@ const Drawer = ({
       }
     }
 
-    disableBackgroundScrolling();
+    if (hasBackgroundOverlay) {
+      disableBackgroundScrolling();
+    }
   }, [hasBackgroundOverlay, visible]);
 
   return (

--- a/src/Drawer/Drawer.jsx
+++ b/src/Drawer/Drawer.jsx
@@ -1,5 +1,5 @@
 import React, {
-  createContext, useEffect, useState, useCallback,
+  createContext, useEffect, useState, useCallback, useRef,
 } from 'react';
 import * as propTypes from 'prop-types';
 import classNames from 'classnames';
@@ -33,6 +33,7 @@ const Drawer = ({
   size,
   onRequestClose,
 }) => {
+  const isCurrentlyOpen = useRef(false);
   const [expanded, setExpanded] = useState(defaultExpanded);
 
   const handleExpand = () => setExpanded(!expanded);
@@ -57,6 +58,24 @@ const Drawer = ({
       window.removeEventListener('keydown', handleEscKeyPress);
     };
   }, [handleEscKeyPress, visible]);
+
+  useEffect(() => {
+    function disableBackgroundScrolling() {
+      if (!hasBackgroundOverlay) return;
+
+      if (visible && !isCurrentlyOpen.current) {
+        document.body.classList.add('Drawer__Body--open');
+        isCurrentlyOpen.current = true;
+      }
+
+      if (!visible && isCurrentlyOpen.current) {
+        document.body.classList.remove('Drawer__Body--open');
+        isCurrentlyOpen.current = false;
+      }
+    }
+
+    disableBackgroundScrolling();
+  }, [hasBackgroundOverlay, visible]);
 
   return (
     <>

--- a/src/Drawer/Drawer.jsx
+++ b/src/Drawer/Drawer.jsx
@@ -62,16 +62,16 @@ const Drawer = ({
   useEffect(() => {
     // isCurrentlyOpen ref accounts for a case where you could have multiple drawers
     // on one page and you try to access one of them via their url. Without using ref, the
-    // Drawer__Body--open would be potentially removed via other
+    // Drawer--open would be potentially removed via other
     // closed drawer because of a race condition
     function disableBackgroundScrolling() {
       if (visible && !isCurrentlyOpen.current) {
-        document.body.classList.add('Drawer__Body--open');
+        document.body.classList.add('Drawer--open');
         isCurrentlyOpen.current = true;
       }
 
       if (!visible && isCurrentlyOpen.current) {
-        document.body.classList.remove('Drawer__Body--open');
+        document.body.classList.remove('Drawer--open');
         isCurrentlyOpen.current = false;
       }
     }

--- a/src/Drawer/Drawer.scss
+++ b/src/Drawer/Drawer.scss
@@ -50,7 +50,7 @@
   display: flex;
   flex-direction: column;
 
-  &__Body--open {
+  &--open {
     overflow: hidden;
   }
 

--- a/src/Drawer/Drawer.scss
+++ b/src/Drawer/Drawer.scss
@@ -50,6 +50,10 @@
   display: flex;
   flex-direction: column;
 
+  &__Body--open {
+    overflow: hidden;
+  }
+
   &--behind-nav {
     padding-top: 48px;
   }

--- a/src/Drawer/Drawer.test.jsx
+++ b/src/Drawer/Drawer.test.jsx
@@ -94,6 +94,8 @@ function SetupMultipleDrawersWithOneOpen() {
 
 describe('Drawer', () => {
   beforeEach(() => {
+    // Need to manually clean classList on body since jsdom instance can stay
+    // the same across specs https://github.com/jestjs/jest/issues/1224
     window.document.body.classList.remove(...window.document.body.classList);
   });
 
@@ -200,8 +202,7 @@ describe('Drawer', () => {
   });
 
   describe('When component renders multiple Drawers', () => {
-
-    describe('When component renders multiple drawers with drawer1 visible', () => {
+    describe('with drawer1 visible', () => {
       it('body tag has Drawer__Body--open', () => {
         const { container } = render(<SetupMultipleDrawersWithOneOpen />);
         const body = container.closest('body');
@@ -225,19 +226,3 @@ describe('Drawer', () => {
     it.todo('add more spec variations');
   });
 });
-
-// describe('when hasBackgroundOverlay is falsex', () => {
-//   it('does not have drawer overlay', () => {
-//     render(<SetupDrawerWithChildren hasBackgroundOverlay={false} visible />);
-//
-//     expect(elements.drawerOverlay.query()).not.toBeInTheDocument();
-//   });
-//
-//   it('body tag does not have Drawer__Body--openx', () => {
-//     // eslint-disable-next-line max-len
-//     const { container } = render(<SetupDrawerWithChildren hasBackgroundOverlay={false} visible />);
-//     const body = container.closest('body');
-//
-//     expect(body.classList).not.toContain('Drawer__Body--open');
-//   });
-// });

--- a/src/Drawer/Drawer.test.jsx
+++ b/src/Drawer/Drawer.test.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
+import propTypes from 'prop-types';
 
-import { cleanup, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import Drawer from './Drawer';
@@ -12,21 +13,18 @@ const elements = {
   drawerChildren: {
     get: () => screen.getByText('children'),
   },
-  drawerOneChildren: {
-    get: () => screen.getByText('children1'),
-  },
   drawerOverlay: {
     get: () => screen.getByRole('presentation'),
     query: () => screen.queryByRole('presentation'),
   },
   drawerOneToggleVisibilityButton: {
-    get: () => screen.getByRole('button', { name: /toggle visibility drawer1/ }),
+    get: () => screen.getByRole('button', { name: /toggle visibility drawerOne/ }),
   },
   drawerTwoToggleVisibilityButton: {
-    get: () => screen.getByRole('button', { name: /toggle visibility drawer2/ }),
+    get: () => screen.getByRole('button', { name: /toggle visibility drawerTwo/ }),
   },
   drawerThreeToggleVisibilityButton: {
-    get: () => screen.getByRole('button', { name: /toggle visibility drawer3/ }),
+    get: () => screen.getByRole('button', { name: /toggle visibility drawerThree/ }),
   },
 };
 
@@ -42,10 +40,14 @@ function SetupDrawerWithChildren(props) {
   );
 }
 
-function SetupMultipleDrawersWithOneOpen() {
-  const [isDrawerOneVisible, setIsDrawerOneVisible] = useState(true);
-  const [isDrawerTwoVisible, setIsDrawerTwoVisible] = useState(false);
-  const [isDrawerThreeVisible, setIsDrawerThreeVisible] = useState(false);
+function SetupMultipleDrawers({
+  drawerOneVisibleDefault,
+  drawerTwoVisibleDefault,
+  drawerThreeVisibleDefault,
+}) {
+  const [isDrawerOneVisible, setIsDrawerOneVisible] = useState(drawerOneVisibleDefault);
+  const [isDrawerTwoVisible, setIsDrawerTwoVisible] = useState(drawerTwoVisibleDefault);
+  const [isDrawerThreeVisible, setIsDrawerThreeVisible] = useState(drawerThreeVisibleDefault);
 
   return (
     <div>
@@ -53,44 +55,56 @@ function SetupMultipleDrawersWithOneOpen() {
         type="button"
         onClick={() => setIsDrawerOneVisible((prevState) => !prevState)}
       >
-        toggle visibility drawer1
+        toggle visibility drawerOne
       </button>
 
       <button
         type="button"
         onClick={() => setIsDrawerTwoVisible((prevState) => !prevState)}
       >
-        toggle visibility drawer2
+        toggle visibility drawerTwo
       </button>
 
       <button
         type="button"
         onClick={() => setIsDrawerThreeVisible((prevState) => !prevState)}
       >
-        toggle visibility drawer3
+        toggle visibility drawerThree
       </button>
 
       <Drawer
         visible={isDrawerOneVisible}
         onRequestClose={() => setIsDrawerOneVisible(false)}
       >
-        <div>children1</div>
+        <div>childrenDrawerOne</div>
       </Drawer>
       <Drawer
         visible={isDrawerTwoVisible}
         onRequestClose={() => setIsDrawerTwoVisible(false)}
       >
-        <div>children2</div>
+        <div>childrenDrawerTwo</div>
       </Drawer>
       <Drawer
         visible={isDrawerThreeVisible}
         onRequestClose={() => setIsDrawerThreeVisible(false)}
       >
-        <div>children3</div>
+        <div>childrenDrawerThree</div>
       </Drawer>
     </div>
   );
 }
+
+SetupMultipleDrawers.propTypes = {
+  drawerOneVisibleDefault: propTypes.bool,
+  drawerThreeVisibleDefault: propTypes.bool,
+  drawerTwoVisibleDefault: propTypes.bool,
+};
+
+SetupMultipleDrawers.defaultProps = {
+  drawerOneVisibleDefault: false,
+  drawerTwoVisibleDefault: false,
+  drawerThreeVisibleDefault: false,
+};
 
 describe('Drawer', () => {
   beforeEach(() => {
@@ -143,6 +157,14 @@ describe('Drawer', () => {
 
           expect(elements.drawerOverlay.query()).not.toBeInTheDocument();
         });
+
+        it('body tag does not have Drawer__Body--open', () => {
+          // eslint-disable-next-line max-len
+          const { container } = render(<SetupDrawerWithChildren hasBackgroundOverlay={false} visible={false} />);
+          const body = container.closest('body');
+
+          expect(body.classList).not.toContain('Drawer__Body--open');
+        });
       });
     });
 
@@ -183,14 +205,14 @@ describe('Drawer', () => {
         expect(body.classList).toContain('Drawer__Body--open');
       });
 
-      describe('when hasBackgroundOverlay is falsex', () => {
+      describe('when hasBackgroundOverlay is false', () => {
         it('does not have drawer overlay', () => {
           render(<SetupDrawerWithChildren hasBackgroundOverlay={false} visible />);
 
           expect(elements.drawerOverlay.query()).not.toBeInTheDocument();
         });
 
-        it('body tag does not have Drawer__Body--openx', () => {
+        it('body tag does not have Drawer__Body--open', () => {
           // eslint-disable-next-line max-len
           const { container } = render(<SetupDrawerWithChildren hasBackgroundOverlay={false} visible />);
           const body = container.closest('body');
@@ -202,17 +224,17 @@ describe('Drawer', () => {
   });
 
   describe('When component renders multiple Drawers', () => {
-    describe('with drawer1 visible', () => {
+    describe('with drawerOne visible visible by default', () => {
       it('body tag has Drawer__Body--open', () => {
-        const { container } = render(<SetupMultipleDrawersWithOneOpen />);
+        const { container } = render(<SetupMultipleDrawers drawerOneVisibleDefault />);
         const body = container.closest('body');
 
         expect(body.classList).toContain('Drawer__Body--open');
       });
 
-      describe('when user clicks on drawer1 toggle visibility button', () => {
-        it('body tag does not have Drawer__body--open', () => {
-          const { container } = render(<SetupMultipleDrawersWithOneOpen />);
+      describe('when user clicks on drawerOne toggle visibility button', () => {
+        it('body tag does not have Drawer__body--open after click', () => {
+          const { container } = render(<SetupMultipleDrawers drawerOneVisibleDefault />);
           const body = container.closest('body');
 
           expect(body.classList).toContain('Drawer__Body--open');
@@ -223,6 +245,27 @@ describe('Drawer', () => {
         });
       });
     });
-    it.todo('add more spec variations');
+
+    describe('with no drawers visible by default', () => {
+      it('body tag does not have Drawer__body--open', () => {
+        const { container } = render(<SetupMultipleDrawers />);
+        const body = container.closest('body');
+
+        expect(body.classList).not.toContain('Drawer__Body--open');
+      });
+
+      describe('when user clicks on drawerOne toggle visibility button', () => {
+        it('body tag has Drawer__body--open after click', () => {
+          const { container } = render(<SetupMultipleDrawers />);
+          const body = container.closest('body');
+
+          expect(body.classList).not.toContain('Drawer__Body--open');
+
+          userEvent.click(elements.drawerOneToggleVisibilityButton.get());
+
+          expect(body.classList).toContain('Drawer__Body--open');
+        });
+      });
+    });
   });
 });

--- a/src/Drawer/Drawer.test.jsx
+++ b/src/Drawer/Drawer.test.jsx
@@ -144,11 +144,11 @@ describe('Drawer', () => {
         expect(onRequestClose).not.toHaveBeenCalled();
       });
 
-      it('body tag does not have Drawer__Body--open', () => {
+      it('body tag does not have Drawer--open', () => {
         const { container } = render(<SetupDrawerWithChildren visible={false} />);
         const body = container.closest('body');
 
-        expect(body.classList).not.toContain('Drawer__Body--open');
+        expect(body.classList).not.toContain('Drawer--open');
       });
 
       describe('when hasBackgroundOverlay is false', () => {
@@ -158,12 +158,12 @@ describe('Drawer', () => {
           expect(elements.drawerOverlay.query()).not.toBeInTheDocument();
         });
 
-        it('body tag does not have Drawer__Body--open', () => {
+        it('body tag does not have Drawer--open', () => {
           // eslint-disable-next-line max-len
           const { container } = render(<SetupDrawerWithChildren hasBackgroundOverlay={false} visible={false} />);
           const body = container.closest('body');
 
-          expect(body.classList).not.toContain('Drawer__Body--open');
+          expect(body.classList).not.toContain('Drawer--open');
         });
       });
     });
@@ -198,11 +198,11 @@ describe('Drawer', () => {
         expect(onRequestClose).toHaveBeenCalled();
       });
 
-      it('body tag has Drawer__Body--open', () => {
+      it('body tag has Drawer--open', () => {
         const { container } = render(<SetupDrawerWithChildren visible />);
         const body = container.closest('body');
 
-        expect(body.classList).toContain('Drawer__Body--open');
+        expect(body.classList).toContain('Drawer--open');
       });
 
       describe('when hasBackgroundOverlay is false', () => {
@@ -212,12 +212,12 @@ describe('Drawer', () => {
           expect(elements.drawerOverlay.query()).not.toBeInTheDocument();
         });
 
-        it('body tag does not have Drawer__Body--open', () => {
+        it('body tag does not have Drawer--open', () => {
           // eslint-disable-next-line max-len
           const { container } = render(<SetupDrawerWithChildren hasBackgroundOverlay={false} visible />);
           const body = container.closest('body');
 
-          expect(body.classList).not.toContain('Drawer__Body--open');
+          expect(body.classList).not.toContain('Drawer--open');
         });
       });
     });
@@ -225,45 +225,45 @@ describe('Drawer', () => {
 
   describe('When component renders multiple Drawers', () => {
     describe('with drawerOne visible by default', () => {
-      it('body tag has Drawer__Body--open', () => {
+      it('body tag has Drawer--open', () => {
         const { container } = render(<SetupMultipleDrawers drawerOneVisibleDefault />);
         const body = container.closest('body');
 
-        expect(body.classList).toContain('Drawer__Body--open');
+        expect(body.classList).toContain('Drawer--open');
       });
 
       describe('when user clicks on drawerOne toggle visibility button', () => {
-        it('body tag does not have Drawer__body--open after click', () => {
+        it('body tag does not have Drawer--open after click', () => {
           const { container } = render(<SetupMultipleDrawers drawerOneVisibleDefault />);
           const body = container.closest('body');
 
-          expect(body.classList).toContain('Drawer__Body--open');
+          expect(body.classList).toContain('Drawer--open');
 
           userEvent.click(elements.drawerOneToggleVisibilityButton.get());
 
-          expect(body.classList).not.toContain('Drawer__Body--open');
+          expect(body.classList).not.toContain('Drawer--open');
         });
       });
     });
 
     describe('with no drawers visible by default', () => {
-      it('body tag does not have Drawer__body--open', () => {
+      it('body tag does not have Drawer--open', () => {
         const { container } = render(<SetupMultipleDrawers />);
         const body = container.closest('body');
 
-        expect(body.classList).not.toContain('Drawer__Body--open');
+        expect(body.classList).not.toContain('Drawer--open');
       });
 
       describe('when user clicks on drawerOne toggle visibility button', () => {
-        it('body tag has Drawer__body--open after click', () => {
+        it('body tag has Drawer--open after click', () => {
           const { container } = render(<SetupMultipleDrawers />);
           const body = container.closest('body');
 
-          expect(body.classList).not.toContain('Drawer__Body--open');
+          expect(body.classList).not.toContain('Drawer--open');
 
           userEvent.click(elements.drawerOneToggleVisibilityButton.get());
 
-          expect(body.classList).toContain('Drawer__Body--open');
+          expect(body.classList).toContain('Drawer--open');
         });
       });
     });

--- a/src/Drawer/Drawer.test.jsx
+++ b/src/Drawer/Drawer.test.jsx
@@ -224,7 +224,7 @@ describe('Drawer', () => {
   });
 
   describe('When component renders multiple Drawers', () => {
-    describe('with drawerOne visible visible by default', () => {
+    describe('with drawerOne visible by default', () => {
       it('body tag has Drawer__Body--open', () => {
         const { container } = render(<SetupMultipleDrawers drawerOneVisibleDefault />);
         const body = container.closest('body');

--- a/src/Drawer/Drawer.test.jsx
+++ b/src/Drawer/Drawer.test.jsx
@@ -44,10 +44,6 @@ describe('Drawer', () => {
   }
 
   describe('When component renders single drawer', () => {
-    afterEach(() => {
-      cleanup();
-    });
-
     describe('when visible is false', () => {
       it('renders its children', () => {
         render(<SetupDrawerWithChildren visible={false} />);
@@ -138,7 +134,7 @@ describe('Drawer', () => {
           expect(elements.drawerOverlay.query()).not.toBeInTheDocument();
         });
 
-        it('body tag does not have Drawer__Body--open', () => {
+        it('body tag does not have Drawer__Body--openx', () => {
           // eslint-disable-next-line max-len
           const { container } = render(<SetupDrawerWithChildren hasBackgroundOverlay={false} visible />);
           const body = container.closest('body');
@@ -200,8 +196,6 @@ describe('Multiple Drawers', () => {
       </div>
     );
   }
-
-  afterEach(cleanup);
 
   describe('When component renders multiple drawers with drawer1 visible', () => {
     it('body tag has Drawer__Body--open', () => {

--- a/src/Drawer/Drawer.test.jsx
+++ b/src/Drawer/Drawer.test.jsx
@@ -216,5 +216,5 @@ describe('Multiple Drawers', () => {
       expect(body.classList).not.toContain('Drawer__Body--open');
     });
   });
-  it.todo('add more variations')
+  it.todo('add more spec variations');
 });

--- a/src/Drawer/Drawer.test.jsx
+++ b/src/Drawer/Drawer.test.jsx
@@ -206,14 +206,16 @@ describe('Multiple Drawers', () => {
     });
 
     describe('when user clicks on drawer1 toggle visibility button', () => {
-      const { container } = render(<SetupMultipleDrawersWithOneOpen />);
-      const body = container.closest('body');
+      it('body tag does not have Drawer__body--open', () => {
+        const { container } = render(<SetupMultipleDrawersWithOneOpen />);
+        const body = container.closest('body');
 
-      expect(body.classList).toContain('Drawer__Body--open');
+        expect(body.classList).toContain('Drawer__Body--open');
 
-      userEvent.click(elements.drawerOneToggleVisibilityButton.get());
+        userEvent.click(elements.drawerOneToggleVisibilityButton.get());
 
-      expect(body.classList).not.toContain('Drawer__Body--open');
+        expect(body.classList).not.toContain('Drawer__Body--open');
+      });
     });
   });
   it.todo('add more spec variations');

--- a/src/Drawer/Drawer.test.jsx
+++ b/src/Drawer/Drawer.test.jsx
@@ -216,4 +216,5 @@ describe('Multiple Drawers', () => {
       expect(body.classList).not.toContain('Drawer__Body--open');
     });
   });
+  it.todo('add more variations')
 });

--- a/src/Drawer/Drawer.test.jsx
+++ b/src/Drawer/Drawer.test.jsx
@@ -30,18 +30,72 @@ const elements = {
   },
 };
 
-describe('Drawer', () => {
-  function SetupDrawerWithChildren(props) {
-    const defaultProps = {
-      onRequestClose: () => {},
-    };
+function SetupDrawerWithChildren(props) {
+  const defaultProps = {
+    onRequestClose: () => {},
+  };
 
-    return (
-      <Drawer {...defaultProps} {...props}>
-        <div>children</div>
+  return (
+    <Drawer {...defaultProps} {...props}>
+      <div>children</div>
+    </Drawer>
+  );
+}
+
+function SetupMultipleDrawersWithOneOpen() {
+  const [isDrawerOneVisible, setIsDrawerOneVisible] = useState(true);
+  const [isDrawerTwoVisible, setIsDrawerTwoVisible] = useState(false);
+  const [isDrawerThreeVisible, setIsDrawerThreeVisible] = useState(false);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setIsDrawerOneVisible((prevState) => !prevState)}
+      >
+        toggle visibility drawer1
+      </button>
+
+      <button
+        type="button"
+        onClick={() => setIsDrawerTwoVisible((prevState) => !prevState)}
+      >
+        toggle visibility drawer2
+      </button>
+
+      <button
+        type="button"
+        onClick={() => setIsDrawerThreeVisible((prevState) => !prevState)}
+      >
+        toggle visibility drawer3
+      </button>
+
+      <Drawer
+        visible={isDrawerOneVisible}
+        onRequestClose={() => setIsDrawerOneVisible(false)}
+      >
+        <div>children1</div>
       </Drawer>
-    );
-  }
+      <Drawer
+        visible={isDrawerTwoVisible}
+        onRequestClose={() => setIsDrawerTwoVisible(false)}
+      >
+        <div>children2</div>
+      </Drawer>
+      <Drawer
+        visible={isDrawerThreeVisible}
+        onRequestClose={() => setIsDrawerThreeVisible(false)}
+      >
+        <div>children3</div>
+      </Drawer>
+    </div>
+  );
+}
+
+describe('Drawer', () => {
+  beforeEach(() => {
+    window.document.body.classList.remove(...window.document.body.classList);
+  });
 
   describe('When component renders single drawer', () => {
     describe('when visible is false', () => {
@@ -144,79 +198,46 @@ describe('Drawer', () => {
       });
     });
   });
-});
 
-describe('Multiple Drawers', () => {
-  function SetupMultipleDrawersWithOneOpen() {
-    const [isDrawerOneVisible, setIsDrawerOneVisible] = useState(true);
-    const [isDrawerTwoVisible, setIsDrawerTwoVisible] = useState(false);
-    const [isDrawerThreeVisible, setIsDrawerThreeVisible] = useState(false);
+  describe('When component renders multiple Drawers', () => {
 
-    return (
-      <div>
-        <button
-          type="button"
-          onClick={() => setIsDrawerOneVisible((prevState) => !prevState)}
-        >
-          toggle visibility drawer1
-        </button>
-
-        <button
-          type="button"
-          onClick={() => setIsDrawerTwoVisible((prevState) => !prevState)}
-        >
-          toggle visibility drawer2
-        </button>
-
-        <button
-          type="button"
-          onClick={() => setIsDrawerThreeVisible((prevState) => !prevState)}
-        >
-          toggle visibility drawer3
-        </button>
-
-        <Drawer
-          visible={isDrawerOneVisible}
-          onRequestClose={() => setIsDrawerOneVisible(false)}
-        >
-          <div>children1</div>
-        </Drawer>
-        <Drawer
-          visible={isDrawerTwoVisible}
-          onRequestClose={() => setIsDrawerTwoVisible(false)}
-        >
-          <div>children2</div>
-        </Drawer>
-        <Drawer
-          visible={isDrawerThreeVisible}
-          onRequestClose={() => setIsDrawerThreeVisible(false)}
-        >
-          <div>children3</div>
-        </Drawer>
-      </div>
-    );
-  }
-
-  describe('When component renders multiple drawers with drawer1 visible', () => {
-    it('body tag has Drawer__Body--open', () => {
-      const { container } = render(<SetupMultipleDrawersWithOneOpen />);
-      const body = container.closest('body');
-
-      expect(body.classList).toContain('Drawer__Body--open');
-    });
-
-    describe('when user clicks on drawer1 toggle visibility button', () => {
-      it('body tag does not have Drawer__body--open', () => {
+    describe('When component renders multiple drawers with drawer1 visible', () => {
+      it('body tag has Drawer__Body--open', () => {
         const { container } = render(<SetupMultipleDrawersWithOneOpen />);
         const body = container.closest('body');
 
         expect(body.classList).toContain('Drawer__Body--open');
+      });
 
-        userEvent.click(elements.drawerOneToggleVisibilityButton.get());
+      describe('when user clicks on drawer1 toggle visibility button', () => {
+        it('body tag does not have Drawer__body--open', () => {
+          const { container } = render(<SetupMultipleDrawersWithOneOpen />);
+          const body = container.closest('body');
 
-        expect(body.classList).not.toContain('Drawer__Body--open');
+          expect(body.classList).toContain('Drawer__Body--open');
+
+          userEvent.click(elements.drawerOneToggleVisibilityButton.get());
+
+          expect(body.classList).not.toContain('Drawer__Body--open');
+        });
       });
     });
+    it.todo('add more spec variations');
   });
-  it.todo('add more spec variations');
 });
+
+// describe('when hasBackgroundOverlay is falsex', () => {
+//   it('does not have drawer overlay', () => {
+//     render(<SetupDrawerWithChildren hasBackgroundOverlay={false} visible />);
+//
+//     expect(elements.drawerOverlay.query()).not.toBeInTheDocument();
+//   });
+//
+//   it('body tag does not have Drawer__Body--openx', () => {
+//     // eslint-disable-next-line max-len
+//     const { container } = render(<SetupDrawerWithChildren hasBackgroundOverlay={false} visible />);
+//     const body = container.closest('body');
+//
+//     expect(body.classList).not.toContain('Drawer__Body--open');
+//   });
+// });

--- a/src/Drawer/Drawer.test.jsx
+++ b/src/Drawer/Drawer.test.jsx
@@ -1,0 +1,225 @@
+import React, { useState } from 'react';
+
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import Drawer from './Drawer';
+
+const elements = {
+  drawerHeader: {
+    get: () => screen.getByRole('heading', { level: 1, name: /drawer header/ }),
+  },
+  drawerChildren: {
+    get: () => screen.getByText('children'),
+  },
+  drawerOneChildren: {
+    get: () => screen.getByText('children1'),
+  },
+  drawerOverlay: {
+    get: () => screen.getByRole('presentation'),
+    query: () => screen.queryByRole('presentation'),
+  },
+  drawerOneToggleVisibilityButton: {
+    get: () => screen.getByRole('button', { name: /toggle visibility drawer1/ }),
+  },
+  drawerTwoToggleVisibilityButton: {
+    get: () => screen.getByRole('button', { name: /toggle visibility drawer2/ }),
+  },
+  drawerThreeToggleVisibilityButton: {
+    get: () => screen.getByRole('button', { name: /toggle visibility drawer3/ }),
+  },
+};
+
+describe('Drawer', () => {
+  function SetupDrawerWithChildren(props) {
+    const defaultProps = {
+      onRequestClose: () => {},
+    };
+
+    return (
+      <Drawer {...defaultProps} {...props}>
+        <div>children</div>
+      </Drawer>
+    );
+  }
+
+  describe('When component renders single drawer', () => {
+    afterEach(() => {
+      cleanup();
+    });
+
+    describe('when visible is false', () => {
+      it('renders its children', () => {
+        render(<SetupDrawerWithChildren visible={false} />);
+
+        expect(elements.drawerChildren.get()).toBeInTheDocument();
+      });
+
+      it('has drawer overlay', () => {
+        render(<SetupDrawerWithChildren visible={false} />);
+
+        expect(elements.drawerOverlay.get()).toBeInTheDocument();
+      });
+
+      it('does not have visible drawer overlay', () => {
+        render(<SetupDrawerWithChildren visible={false} />);
+
+        expect(elements.drawerOverlay.get()).toBeInTheDocument();
+        expect(elements.drawerOverlay.get().classList).not.toContain('DrawerBackgroundOverlay--active');
+      });
+
+      it('does not call onRequestClose when pressing ESC key', () => {
+        const onRequestClose = jest.fn();
+
+        render(<SetupDrawerWithChildren visible={false} onRequestClose={onRequestClose} />);
+
+        userEvent.keyboard('{Escape}');
+
+        expect(onRequestClose).not.toHaveBeenCalled();
+      });
+
+      it('body tag does not have Drawer__Body--open', () => {
+        const { container } = render(<SetupDrawerWithChildren visible={false} />);
+        const body = container.closest('body');
+
+        expect(body.classList).not.toContain('Drawer__Body--open');
+      });
+
+      describe('when hasBackgroundOverlay is false', () => {
+        it('does not have drawer overlay', () => {
+          render(<SetupDrawerWithChildren hasBackgroundOverlay={false} visible={false} />);
+
+          expect(elements.drawerOverlay.query()).not.toBeInTheDocument();
+        });
+      });
+    });
+
+    describe('when visible is true', () => {
+      it('renders its children', () => {
+        render(<SetupDrawerWithChildren visible />);
+
+        expect(elements.drawerChildren.get()).toBeInTheDocument();
+      });
+
+      it('has drawer overlay', () => {
+        render(<SetupDrawerWithChildren visible />);
+
+        expect(elements.drawerOverlay.get()).toBeInTheDocument();
+      });
+
+      it('has visible drawer overlay', () => {
+        render(<SetupDrawerWithChildren visible />);
+
+        expect(elements.drawerOverlay.get()).toBeInTheDocument();
+        expect(elements.drawerOverlay.get().classList).toContain('DrawerBackgroundOverlay--active');
+      });
+
+      it('calls onRequestClose when pressing ESC key', () => {
+        const onRequestClose = jest.fn();
+
+        render(<SetupDrawerWithChildren visible onRequestClose={onRequestClose} />);
+
+        userEvent.keyboard('{Escape}');
+
+        expect(onRequestClose).toHaveBeenCalled();
+      });
+
+      it('body tag has Drawer__Body--open', () => {
+        const { container } = render(<SetupDrawerWithChildren visible />);
+        const body = container.closest('body');
+
+        expect(body.classList).toContain('Drawer__Body--open');
+      });
+
+      describe('when hasBackgroundOverlay is falsex', () => {
+        it('does not have drawer overlay', () => {
+          render(<SetupDrawerWithChildren hasBackgroundOverlay={false} visible />);
+
+          expect(elements.drawerOverlay.query()).not.toBeInTheDocument();
+        });
+
+        it('body tag does not have Drawer__Body--open', () => {
+          // eslint-disable-next-line max-len
+          const { container } = render(<SetupDrawerWithChildren hasBackgroundOverlay={false} visible />);
+          const body = container.closest('body');
+
+          expect(body.classList).not.toContain('Drawer__Body--open');
+        });
+      });
+    });
+  });
+});
+
+describe('Multiple Drawers', () => {
+  function SetupMultipleDrawersWithOneOpen() {
+    const [isDrawerOneVisible, setIsDrawerOneVisible] = useState(true);
+    const [isDrawerTwoVisible, setIsDrawerTwoVisible] = useState(false);
+    const [isDrawerThreeVisible, setIsDrawerThreeVisible] = useState(false);
+
+    return (
+      <div>
+        <button
+          type="button"
+          onClick={() => setIsDrawerOneVisible((prevState) => !prevState)}
+        >
+          toggle visibility drawer1
+        </button>
+
+        <button
+          type="button"
+          onClick={() => setIsDrawerTwoVisible((prevState) => !prevState)}
+        >
+          toggle visibility drawer2
+        </button>
+
+        <button
+          type="button"
+          onClick={() => setIsDrawerThreeVisible((prevState) => !prevState)}
+        >
+          toggle visibility drawer3
+        </button>
+
+        <Drawer
+          visible={isDrawerOneVisible}
+          onRequestClose={() => setIsDrawerOneVisible(false)}
+        >
+          <div>children1</div>
+        </Drawer>
+        <Drawer
+          visible={isDrawerTwoVisible}
+          onRequestClose={() => setIsDrawerTwoVisible(false)}
+        >
+          <div>children2</div>
+        </Drawer>
+        <Drawer
+          visible={isDrawerThreeVisible}
+          onRequestClose={() => setIsDrawerThreeVisible(false)}
+        >
+          <div>children3</div>
+        </Drawer>
+      </div>
+    );
+  }
+
+  afterEach(cleanup);
+
+  describe('When component renders multiple drawers with drawer1 visible', () => {
+    it('body tag has Drawer__Body--open', () => {
+      const { container } = render(<SetupMultipleDrawersWithOneOpen />);
+      const body = container.closest('body');
+
+      expect(body.classList).toContain('Drawer__Body--open');
+    });
+
+    describe('when user clicks on drawer1 toggle visibility button', () => {
+      const { container } = render(<SetupMultipleDrawersWithOneOpen />);
+      const body = container.closest('body');
+
+      expect(body.classList).toContain('Drawer__Body--open');
+
+      userEvent.click(elements.drawerOneToggleVisibilityButton.get());
+
+      expect(body.classList).not.toContain('Drawer__Body--open');
+    });
+  });
+});


### PR DESCRIPTION
### Description
[//]: # (
Provide a brief description of the intent of this pull request.
Example: Allow users to search for a specific product by name.
)

Fix #1100 

Primary: @kyleshike / @jasonbasuil / @gabescarbrough 

secondary: @frankhock / @Dchyk 

cc: @PLUCS2  


### Manual Test plan
[//]: # (
How did you test this manually? How can your reviewer test the workflow?
If this is a bug, how can you reproduce the bug?
)

Link DS locally and verify if the background for drawers with `hasBackgroundOverlay` (by default `true`) is not scrollable

When opening the drawer 

https://github.com/user-interviews/ui-design-system/assets/54962889/9d034da0-4a81-44ef-871b-fcf927642865


When going to the drawer via URL (can still scroll within drawer)


https://github.com/user-interviews/ui-design-system/assets/54962889/6e93d5f7-7fd4-4a32-83e6-c4d180326b1d






### Checklist
[//]: # (
Please review and check off the following items before moving the pull request from draft to ready for review
~~Strike through~~ any items that are not applicable to this pull request.
)

- [x]  **Perform self review**: Perform a self-review of your pull request and point out concerns and/or questions to reviewers in the summary above or as GitHub comments. Try to do this before tagging people as assignees and reviewers, to reduce Github notification noise.
- [x]  **Tests**: Ensure that all tests are passing and that new tests have been added to cover any new functionality. See [helpful testing best practices](https://www.notion.so/user-interviews/Helpful-Testing-Tricks-d1d44096d042463a82aff7bc59705ca2?pvs=4).
