### PR TITLE
Add forwardRef to DrawerBody

### DIFF
--- a/src/Drawer/DrawerBody.jsx
+++ b/src/Drawer/DrawerBody.jsx
@@ -1,15 +1,18 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import * as propTypes from 'prop-types';
 
 import './DrawerBody.scss';
 
-const DrawerBody = ({
+const DrawerBody = forwardRef(({
   children,
-}) => (
-  <div className="Drawer__body">
+}, ref) => (
+  <div
+    className="Drawer__body"
+    ref={ref}
+  >
     {children}
   </div>
-);
+));
 
 DrawerBody.propTypes = {
   children: propTypes.node.isRequired,


### PR DESCRIPTION
Need to pass a ref to this component to not show google places autocomplete when scrolling; rough idea in this PR https://github.com/user-interviews/rails-server/pull/24206