### PR TITLE
Update RichTextEditor to be a forwardRef and expose setContent through useImperativeHandle

### DIFF
--- a/src/RichTextEditor/RichTextEditor.mdx
+++ b/src/RichTextEditor/RichTextEditor.mdx
@@ -10,7 +10,7 @@ import * as ComponentStories from './RichTextEditor.stories';
 
 <Canvas of={ComponentStories.Default} />
 
-### When to use 
+### When to use
 To allow users to edit text where formatting is important, such as messages to be sent via email.
 
 ### When to not use
@@ -45,3 +45,7 @@ RichTextEditor also has an error state to display that the input is invalid. The
 but by setting `hasErrors` via your provided `onChange` callback you can check the HTML produced by the RichTextEditor for any requirements that you have.
 
 <Canvas of={ComponentStories.Error} />
+
+RichTextEditor can optionally take in a forwardedRef to allow content to be programmatically manipulated.
+
+<Canvas of={ComponentStories.SetContent} />

--- a/src/RichTextEditor/RichTextEditor.stories.jsx
+++ b/src/RichTextEditor/RichTextEditor.stories.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, {useRef} from 'react';
 
+import Button from 'src/Button';
 import { RichTextEditor, RichTextEditorActions } from 'src/RichTextEditor';
 
 import mdx from './RichTextEditor.mdx';
@@ -60,3 +61,22 @@ export const Error = () => (
     onChange={() => null}
   />
 );
+
+export const SetContent = () => {
+  const ref = useRef(null);
+
+  const handleClick = () => {
+    ref.current.setContent('Oh hey');
+  }
+
+  return (
+    <>
+      <Button onClick={handleClick}>Set content to "Oh hey"</Button>
+      <RichTextEditor
+        id="text-editor"
+        ref={ref}
+        onChange={() => null}
+      />
+    </>
+  )
+}

--- a/src/RichTextEditor/RichTextEditor.stories.jsx
+++ b/src/RichTextEditor/RichTextEditor.stories.jsx
@@ -1,4 +1,4 @@
-import React, {useRef} from 'react';
+import React, { useRef } from 'react';
 
 import Button from 'src/Button';
 import { RichTextEditor, RichTextEditorActions } from 'src/RichTextEditor';
@@ -67,7 +67,7 @@ export const SetContent = () => {
 
   const handleClick = () => {
     ref.current.setContent('Oh hey');
-  }
+  };
 
   return (
     <>
@@ -78,5 +78,5 @@ export const SetContent = () => {
         onChange={() => null}
       />
     </>
-  )
-}
+  );
+};

--- a/src/RichTextEditor/RichTextEditor.tsx
+++ b/src/RichTextEditor/RichTextEditor.tsx
@@ -4,7 +4,7 @@ import type { Extension, Node as TipTapNode, Mark } from '@tiptap/core';
 
 import './RichTextEditor.scss';
 
-import React from 'react';
+import React, { forwardRef, type ForwardedRef, useImperativeHandle } from 'react';
 
 import classNames from 'classnames';
 
@@ -94,21 +94,28 @@ export type RichTextEditorProps = {
   onChange: (arg0: string) => void;
 }
 
-function RichTextEditor({
-  allowedAttributes,
-  allowedTags,
-  ariaAttributes,
-  availableActions = RichTextEditorDefaultActionsArray,
-  characterLimit,
-  className,
-  hasErrors,
-  id,
-  initialValue,
-  isOneLine,
-  onChange,
-  placeholder,
-  customExtensions = [],
-}: RichTextEditorProps) {
+export type RichTextEditorRef  = {
+  setContent: (content: string) => void;
+}
+
+const RichTextEditor = forwardRef((
+  {
+    allowedAttributes,
+    allowedTags,
+    ariaAttributes,
+    availableActions = RichTextEditorDefaultActionsArray,
+    characterLimit,
+    className,
+    hasErrors,
+    id,
+    initialValue,
+    isOneLine,
+    onChange,
+    placeholder,
+    customExtensions = [],
+  }: RichTextEditorProps,
+  ref: ForwardedRef<RichTextEditorRef> = null,
+) => {
   const oneLineExtension = isOneLine ? [OneLineLimit] : [];
 
   const requiredExtensions = [
@@ -183,6 +190,13 @@ function RichTextEditor({
     },
   });
 
+  useImperativeHandle(ref, () => ({
+    setContent: (content: string) => {
+      editor?.commands.setContent(content);
+      onChange(content);
+    },
+  }));
+
   return (
     editor ? (
       <div
@@ -221,7 +235,7 @@ function RichTextEditor({
       </>
     )
   );
-}
+})
 
 // eslint-disable-next-line import/no-default-export
 export default RichTextEditor;

--- a/src/RichTextEditor/RichTextEditor.tsx
+++ b/src/RichTextEditor/RichTextEditor.tsx
@@ -94,7 +94,7 @@ export type RichTextEditorProps = {
   onChange: (arg0: string) => void;
 }
 
-export type RichTextEditorRef  = {
+export type RichTextEditorRef = {
   setContent: (content: string) => void;
 }
 
@@ -235,7 +235,7 @@ const RichTextEditor = forwardRef((
       </>
     )
   );
-})
+});
 
 // eslint-disable-next-line import/no-default-export
 export default RichTextEditor;


### PR DESCRIPTION
Us at rx-fast want a way to programmatically set the content within the RichTextEditor. Specifically for the team email templates page, we have an action to reset the editor content to a default. This exposes a `setContent` function that uses `setContent` from the editor object returned by the `useEditor` hook. Nat and I thought it was best to not have this be an extension as the behavior for email templates are pretty specific and so a generic reset icon within the actions toolbar might be ambiguous. 


https://github.com/user-interviews/ui-design-system/assets/65802187/18a36d31-1d2c-4cf2-9bed-10d8a194ab38