### PR TITLE
Change Drawer expanded width to 90%

### DIFF
--- a/src/Drawer/Drawer.scss
+++ b/src/Drawer/Drawer.scss
@@ -41,7 +41,7 @@
 
   background-color: var(--ux-white);
   height: 100vh;
-  width: 100%;
+  width: 90%;
   position: fixed;
   bottom: 0;
   transition: 200ms ease-out;
@@ -59,7 +59,7 @@
   }
 
   &--expanded {
-    width: 100%;
+    width: 90%;
   }
 
   &--right {

--- a/src/Drawer/Drawer.scss
+++ b/src/Drawer/Drawer.scss
@@ -41,7 +41,7 @@
 
   background-color: var(--ux-white);
   height: 100vh;
-  width: 90%;
+  width: 100%;
   position: fixed;
   bottom: 0;
   transition: 200ms ease-out;


### PR DESCRIPTION
Closes: https://linear.app/user-interviews/issue/RXS-647/tweak-full-screen-drawers-to-be-90percent

Figma: https://www.figma.com/design/BXDtUK7ggGlNcDl2mtpL7i/Ad-hoc?node-id=100-172&t=X6YBKxqG0SaepoxD-0

Small change to make the fully expanded Drawer only ever take up a max of 90% of the screen. This is in response to user and product feedback about not being able to see any of the main page nav or anything else when drawers are fully expanded. 

Some examples of expanded drawers from the workspace after this change: 

<img width="1258" alt="Screenshot 2024-05-20 at 11 26 01 AM" src="https://github.com/user-interviews/ui-design-system/assets/25135946/56c7db09-35b1-4550-b7be-72aac76a4254">
<img width="1262" alt="Screenshot 2024-05-20 at 11 25 39 AM" src="https://github.com/user-interviews/ui-design-system/assets/25135946/c11061ee-3081-45b2-b962-ff3f7bb61542">
<img width="1252" alt="Screenshot 2024-05-20 at 11 25 19 AM" src="https://github.com/user-interviews/ui-design-system/assets/25135946/a49a44aa-97b3-4f7a-9b5d-f61e33588034">

Videos:

https://github.com/user-interviews/ui-design-system/assets/25135946/7acd379e-99ec-4479-8d9e-29f49f8a4ef0


https://github.com/user-interviews/ui-design-system/assets/25135946/ea5c4ea7-e912-4f32-80c8-993e35f2d40b



