### PR TITLE
Fix GH actions to work with Yarn 4

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -4,8 +4,17 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "The version you want to release."
+        description: "Select the version increment"
         required: true
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+          - premajor
+          - preminor
+          - prepatch
+          - prerelease
 
 jobs:
   prepare-release:
@@ -28,40 +37,47 @@ jobs:
       - name: Setup env
         run: echo "FONTAWESOME_NPM_AUTH_TOKEN=${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}" > .env
 
+      - name: Bump version in package.json
+        run: yarn version ${{ github.event.inputs.version }}
+
+      - name: Extract version from package.json
+        id: extract_version
+        run: |
+          version=$(grep '"version"' package.json | sed -E 's/.*"version": "([^"]+)".*/\1/')
+          echo "Extracted version: $version"
+          echo "::set-output name=version::$version"
+
       - name: Create release branch
-        run: git checkout -b release/${{ github.event.inputs.version }}
+        run: git checkout -b release/v${{ steps.extract_version.outputs.version }}
 
       - name: Initialize mandatory git config
         uses: fregante/setup-git-user@v2
-
-      - name: Bump version in package.json
-        run: yarn version ${{ github.event.inputs.version }}
 
       - name: Commit manifest files
         id: make-commit
         run: |
           git add package.json
-          git commit --message "Prepare release ${{ github.event.inputs.version }}"
+          git commit --message "Prepare release v${{ steps.extract_version.outputs.version }}"
 
           echo "::set-output name=commit::$(git rev-parse HEAD)"
 
       - name: Publish release branch
-        run: git push origin release/${{ github.event.inputs.version }}
+        run: git push origin release/v${{ steps.extract_version.outputs.version }}
 
       - name: Merge release into main branch
         uses: thomaseizinger/create-pull-request@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          head: release/${{ github.event.inputs.version }}
+          head: release/v${{ steps.extract_version.outputs.version }}
           base: main
-          title: Merge release/${{ github.event.inputs.version }} into main branch
+          title: "Merge release/v${{ steps.extract_version.outputs.version }} into main branch"
 
       - name: Merge release into develop branch
         uses: thomaseizinger/create-pull-request@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          head: release/${{ github.event.inputs.version }}
+          head: release/v${{ steps.extract_version.outputs.version }}
           base: develop
-          title: Merge release/${{ github.event.inputs.version }} into develop branch
+          title: "Merge release/v${{ steps.extract_version.outputs.version }} into develop branch"


### PR DESCRIPTION
Yarn 4 changes how `yarn version` works.  Where it previously accepted a numeric value, now it accepts `major, minor, patch` etc and bumps the version in package.json

Our previous GH workflow assumed this numeric value from user input and used it throughout for creating a corresponding branch, etc.  This PR fixes that by using the newer `yarn version` options for the user input of the workflow, and uses a script to read that value from the package.json file anywhere else that it's needed