### PR TITLE
Set RichTextEditor value to empty string if editor is empty

### DIFF
--- a/src/RichTextEditor/RichTextEditor.tsx
+++ b/src/RichTextEditor/RichTextEditor.tsx
@@ -171,7 +171,7 @@ const RichTextEditor = forwardRef((
     extensions: editorExtensions,
     content: initialValue,
     onUpdate: ({ editor: ttEditor }) => {
-      const html = ttEditor.getHTML();
+      const html = ttEditor.isEmpty ? '' : ttEditor.getHTML();
 
       // if allowAttributes or allowedTags aren't passed
       // then use defaults from sanitize-html by not passing that key in the options


### PR DESCRIPTION
More context here https://github.com/ueberdosis/tiptap/issues/154

Changing this to empty string if tiptap deems its content to be empty instead of saving `<p></p>` which could create some unexpected behavior when checking if string is empty 

primary: @kyleshike 

seconday: @gabescarbrough @jasonbasuil 