### PR TITLE
Adds description to `Option`

### DIFF
--- a/src/Select/Option.jsx
+++ b/src/Select/Option.jsx
@@ -14,7 +14,7 @@ import './Option.scss';
 
 /* eslint-disable react/prop-types */
 const Option = forwardRef(({ indeterminate, ...props }, ref) => {
-  const description = props.data?.description;
+  const description = props.data.description;
   return (
     <components.Option {...props}>
       <div className="Option">

--- a/src/Select/Option.jsx
+++ b/src/Select/Option.jsx
@@ -1,4 +1,5 @@
 import React, { forwardRef } from 'react';
+import classNames from 'classnames';
 import { components } from 'react-select';
 
 import CheckboxButton from 'src/CheckboxButton';
@@ -25,7 +26,13 @@ const Option = forwardRef(({ indeterminate, ...props }, ref) => (
         onChange={() => null}
       />
       <div className="TitleDescriptionContainer">
-        <label>{props.label}</label>
+        <label
+          className={classNames({
+            'Label--bold': props.description,
+          })}
+        >
+          {props.label}
+        </label>
         { props.description && (
           <span className="Description">{ props.description }</span>
         )}

--- a/src/Select/Option.jsx
+++ b/src/Select/Option.jsx
@@ -13,21 +13,29 @@ import './Option.scss';
 // See: https://react-select.com/components#replaceable-components
 
 /* eslint-disable react/prop-types */
-const Option = forwardRef(({ indeterminate, ...props }, ref) => (
-  <components.Option {...props}>
-    <div className="Option">
-      <CheckboxButton
-        checked={props.isSelected}
-        className="Checkbox"
-        id={props.label}
-        indeterminate={indeterminate}
-        ref={ref}
-        onChange={() => null}
-      />
-      <label>{props.label}</label>
-    </div>
-  </components.Option>
-  ));
+const Option = forwardRef(({ indeterminate, ...props }, ref) => {
+  const description = props.data?.description;
+  return (
+    <components.Option {...props}>
+      <div className="Option">
+        <CheckboxButton
+          checked={props.isSelected}
+          className="Checkbox"
+          id={props.label}
+          indeterminate={indeterminate}
+          ref={ref}
+          onChange={() => null}
+        />
+        <div className="TitleDescriptionContainer">
+          <label>{props.label}</label>
+          { description && (
+            <span className="Description">{ description }</span>
+          )}
+        </div>
+      </div>
+    </components.Option>
+  );
+});
 /* eslint-enable react/prop-types */
 
 export default Option;

--- a/src/Select/Option.jsx
+++ b/src/Select/Option.jsx
@@ -13,29 +13,26 @@ import './Option.scss';
 // See: https://react-select.com/components#replaceable-components
 
 /* eslint-disable react/prop-types */
-const Option = forwardRef(({ indeterminate, ...props }, ref) => {
-  const description = props.data.description;
-  return (
-    <components.Option {...props}>
-      <div className="Option">
-        <CheckboxButton
-          checked={props.isSelected}
-          className="Checkbox"
-          id={props.label}
-          indeterminate={indeterminate}
-          ref={ref}
-          onChange={() => null}
-        />
-        <div className="TitleDescriptionContainer">
-          <label>{props.label}</label>
-          { description && (
-            <span className="Description">{ description }</span>
-          )}
-        </div>
+const Option = forwardRef(({ indeterminate, ...props }, ref) => (
+  <components.Option {...props}>
+    <div className="Option">
+      <CheckboxButton
+        checked={props.isSelected}
+        className="Checkbox"
+        id={props.label}
+        indeterminate={indeterminate}
+        ref={ref}
+        onChange={() => null}
+      />
+      <div className="TitleDescriptionContainer">
+        <label>{props.label}</label>
+        { props.description && (
+          <span className="Description">{ props.description }</span>
+        )}
       </div>
-    </components.Option>
-  );
-});
+    </div>
+  </components.Option>
+));
 /* eslint-enable react/prop-types */
 
 export default Option;

--- a/src/Select/Option.scss
+++ b/src/Select/Option.scss
@@ -5,4 +5,13 @@
   .Checkbox {
     margin-right: var(--synth-spacing-3);
   }
+
+  .TitleDescriptionContainer {
+    display: flex;
+    flex-direction: column;
+
+    .Description {
+      color: var(--ux-gray-800);
+    }
+  }
 }

--- a/src/Select/Option.scss
+++ b/src/Select/Option.scss
@@ -10,6 +10,12 @@
     display: flex;
     flex-direction: column;
 
+    .Label {
+      &--bold {
+        font-weight: var(--synth-font-weight-bold);
+      }
+    }
+
     .Description {
       color: var(--ux-gray-800);
     }

--- a/src/Select/SingleSelect.stories.jsx
+++ b/src/Select/SingleSelect.stories.jsx
@@ -20,10 +20,26 @@ export default {
 };
 
 const options = [
-  { label: '1-on-1 interview', value: 1 },
-  { label: 'Focus group', value: 2 },
-  { label: 'Multi-day study', value: 3 },
-  { label: 'Unmoderated task', value: 4 },
+  {
+    label: '1-on-1 interview',
+    value: 1,
+    description: 'Interviews are typically a conversation between you and a researcher.',
+  },
+  {
+    label: 'Focus group',
+    value: 2,
+    description: 'Focus groups involve interacting with a small group of your peers.',
+  },
+  {
+    label: 'Multi-day study',
+    value: 3,
+    description: 'Diary and multiday studies are days or weeks long commitments.',
+  },
+  {
+    label: 'Unmoderated task',
+    value: 4 ,
+    description: 'An unmoderated task is just that—an opportunity for a user to try out a product, app, website, etc and share feedback.',
+  },
 ];
 
 const peopleOptions = [
@@ -168,6 +184,30 @@ export const GroupedOptions = () => {
   );
 };
 
+export const CustomOptionWithDescriptionAndCheckbox = () => (
+  <FormGroup label="Option with Description"
+    labelHtmlFor="option-with-description-select"
+  >
+    <SingleSelect
+      components={{
+        Option: (props) => (
+          <Option
+            {...props}
+            description={props.data.description}
+          />
+        ),
+      }}
+      inputId="custom-option-with-description-select"
+      options={options}
+      onChange={onChange}
+    />
+  </FormGroup>
+);
+
+/**
+  If you're adding a new code, prefer the use of `Option` with a `description` prop.
+  `OptionWithDescription` is effectively deprecated and will be merged into `Option`.
+ */
 export const CustomOptionWithDescription = () => {
   const optionsWithDescriptions = [
     {

--- a/src/Select/SingleSelect.stories.jsx
+++ b/src/Select/SingleSelect.stories.jsx
@@ -37,7 +37,7 @@ const options = [
   },
   {
     label: 'Unmoderated task',
-    value: 4 ,
+    value: 4,
     description: 'An unmoderated task is just that—an opportunity for a user to try out a product, app, website, etc and share feedback.',
   },
 ];
@@ -185,14 +185,16 @@ export const GroupedOptions = () => {
 };
 
 export const CustomOptionWithDescriptionAndCheckbox = () => (
-  <FormGroup label="Option with Description"
-    labelHtmlFor="option-with-description-select"
+  <FormGroup
+    label="Custom Option with Description And Checkbox"
+    labelHtmlFor="custom-option-with-description-and-checkbox-select"
   >
     <SingleSelect
       components={{
-        Option: (props) => (
+        Option: ({ ...props }) => (
           <Option
             {...props}
+            // eslint-disable-next-line react/prop-types
             description={props.data.description}
           />
         ),


### PR DESCRIPTION
This PR allows you to use a description that's passed through the `data` prop so you get something that looks like this:

![image](https://github.com/user-interviews/ui-design-system/assets/1207371/2e9fe29d-8e14-46c9-9dd9-82cbe4995408)

Since the `Option` component and its accessible props seem dictated by React Select, it looked like `data` was the best place to access this. Let me know if that's wrong and if you think there's a better way to do this.