### PR TITLE
noMargin prop for FormGroup

### DIFF
--- a/scss/forms/form_group.scss
+++ b/scss/forms/form_group.scss
@@ -54,6 +54,10 @@
     }
   }
 
+  &--no-margin {
+    margin: 0;
+  }
+
   &__helper-text {
     @include synth-font-type-20;
     color: var(--ux-gray-900);

--- a/src/FormGroup/FormGroup.mdx
+++ b/src/FormGroup/FormGroup.mdx
@@ -42,6 +42,12 @@ be beneficial to the user
 
 <Canvas of={ComponentStories.Required} />
 
+### No margin
+
+- Remove the default margin on the FormGroup.
+
+<Canvas of={ComponentStories.NoMargin} />
+
 ### With Label Tooltip
 
 - Information users will typically only reference once (and then it's learned) or here and there.

--- a/src/FormGroup/FormGroup.stories.tsx
+++ b/src/FormGroup/FormGroup.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { faSearch } from '@fortawesome/pro-solid-svg-icons';
 
+import { FlexContainer } from 'src/FlexContainer';
 import FormGroup from '.';
 import Input from '../Input';
 import FormControlLabel from '../FormControlLabel';
@@ -54,6 +55,27 @@ export const Required = () => (
   >
     <InputComponent id="with-required-input" name="required" placeholder="Text is required" />
   </FormGroup>
+);
+
+export const NoMargin = () => (
+  <FlexContainer flexDirection="column" gap={4}>
+    <FormGroup
+      label="Label"
+      labelHtmlFor="no-margin-1-input"
+      noMargin
+      required
+    >
+      <InputComponent id="no-margin-1-input" placeholder="This FormGroup has no default margin" />
+    </FormGroup>
+    <FormGroup
+      label="Label"
+      labelHtmlFor="no-margin-2-input"
+      noMargin
+      required
+    >
+      <InputComponent id="no-margin-2-input" placeholder="This FormGroup has no default margin" />
+    </FormGroup>
+  </FlexContainer>
 );
 
 export const WithLabelTooltip = () => (

--- a/src/FormGroup/FormGroup.tsx
+++ b/src/FormGroup/FormGroup.tsx
@@ -57,6 +57,7 @@ export type FormGroupProps = {
   labelHelperText?: string;
   labelHtmlFor?: string;
   labelTooltip?: React.ReactNode;
+  noMargin?: boolean;
   required?: boolean;
 };
 
@@ -76,6 +77,7 @@ export default function FormGroup({
   labelHelperText,
   labelHtmlFor = '',
   labelTooltip,
+  noMargin,
   required,
 }: FormGroupProps) {
   const errorMessage = buildErrorMessage(errors[inputKey || ''], label);
@@ -137,6 +139,7 @@ export default function FormGroup({
            'FormGroup--is-invalid': hasErrors,
            'FormGroup--bordered': bordered,
            'FormGroup--inline': inline,
+           'FormGroup--no-margin': noMargin,
          },
        ),
        id,


### PR DESCRIPTION
add `noMargin` prop for `FormGroup`. Wasn't sure if `variant` made sense to use here or even `spacing="none"`. Open to suggestions 

Or maybe even make a `FormGroupContainer` that has spacing={ 1 | 2 | 3 etc.) and uses the `<FlexContainer>`

![Screenshot 2024-07-02 at 3 02 27 PM](https://github.com/user-interviews/ui-design-system/assets/37383785/3ff32dad-94ff-409e-b5a0-1f5714a948ee)
