### PR TITLE
fix alignment of Option with checkbox and description

### DIFF
--- a/src/Select/Option.jsx
+++ b/src/Select/Option.jsx
@@ -17,14 +17,16 @@ import './Option.scss';
 const Option = forwardRef(({ indeterminate, ...props }, ref) => (
   <components.Option {...props}>
     <div className="Option">
-      <CheckboxButton
-        checked={props.isSelected}
-        className="Checkbox"
-        id={props.label}
-        indeterminate={indeterminate}
-        ref={ref}
-        onChange={() => null}
-      />
+      <div className="CheckboxContainer">
+        <CheckboxButton
+          checked={props.isSelected}
+          className="Checkbox"
+          id={props.label}
+          indeterminate={indeterminate}
+          ref={ref}
+          onChange={() => null}
+        />
+      </div>
       <div className="TitleDescriptionContainer">
         <label
           className={classNames({

--- a/src/Select/Option.scss
+++ b/src/Select/Option.scss
@@ -1,8 +1,8 @@
 .Option {
   display: flex;
-  align-items: center;
-
+  
   .Checkbox {
+    margin-top: var(--synth-spacing-1);
     margin-right: var(--synth-spacing-3);
   }
 


### PR DESCRIPTION
closes REC-16

Needed the alignment of the Option with checkbox and description to be top aligned

fIgma: https://www.figma.com/design/7oRnbovk9fZ1lgxfcSjWl9/Q2-%E2%80%93-Participant-Targeting?node-id=1985-24512&t=I3gIhs3EhmW3aYVm-0

Before:

![Screenshot 2024-07-10 at 1 15 58 PM](https://github.com/user-interviews/ui-design-system/assets/37383785/541ef739-1404-4db8-9c40-85fbedae696f)

After:

![Screenshot 2024-07-10 at 1 17 22 PM](https://github.com/user-interviews/ui-design-system/assets/37383785/8d96ec78-bee2-441c-ad82-9287286869a5)

On RS:

![Screenshot 2024-07-10 at 1 23 25 PM](https://github.com/user-interviews/ui-design-system/assets/37383785/506010c8-936b-4b01-b595-90b3e6f82f48)


