### PR TITLE
use extract_version once

### DIFF
--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -77,9 +77,6 @@ jobs:
       # Build assets
       - run: yarn build
       - run: npm pack
-      - name: Extract Package Version
-        id: extract_version
-        uses: Saionaro/extract-package-version@v1.2.1
 
       - name: Create Release
         id: create_release


### PR DESCRIPTION
Can only call `extract_version` once.

`The workflow is not valid. .github/workflows/create-new-release.yml (Line: 81, Col: 13): The identifier 'extract_version' may not be used more than once within the same scope`