### PR TITLE
Add optional disabling of drawer close on background overlay click

### DIFF
--- a/src/Drawer/Drawer.test.tsx
+++ b/src/Drawer/Drawer.test.tsx
@@ -215,6 +215,45 @@ describe('Drawer', () => {
         });
       });
 
+      it('calls onRequestClose when closeOnOverlayClick is not defined', async () => {
+        const onRequestClose = jest.fn();
+
+        const { container } = render(
+          <SetupDrawerWithChildren
+            visible
+            onRequestClose={onRequestClose}
+          />,
+        );
+
+        const [overlay] = Array.from(container.getElementsByClassName('DrawerBackgroundOverlay'));
+
+        userEvent.click(overlay);
+
+        await waitFor(() => {
+          expect(onRequestClose).toHaveBeenCalled();
+        });
+      });
+
+      it('does not call onRequestClose when closeOnOverlayClick is set to false', async () => {
+        const onRequestClose = jest.fn();
+
+        const { container } = render(
+          <SetupDrawerWithChildren
+            closeOnOverlayClick={false}
+            visible
+            onRequestClose={onRequestClose}
+          />,
+        );
+
+        const [overlay] = Array.from(container.getElementsByClassName('DrawerBackgroundOverlay'));
+
+        userEvent.click(overlay);
+
+        await waitFor(() => {
+          expect(onRequestClose).not.toHaveBeenCalled();
+        });
+      });
+
       it('body tag has Drawer--open', () => {
         const { container } = render(<SetupDrawerWithChildren visible />);
         const body = container.closest('body');

--- a/src/Drawer/Drawer.tsx
+++ b/src/Drawer/Drawer.tsx
@@ -28,6 +28,7 @@ type DrawerProps = {
   behindNav?: boolean;
   children?: React.ReactNode;
   className?: string;
+  closeOnOverlayClick?: boolean;
   defaultExpanded?: boolean;
   expandable?: boolean;
   hasBackgroundOverlay?: boolean;
@@ -42,6 +43,7 @@ function Drawer({
   children,
   className = '',
   defaultExpanded = false,
+  closeOnOverlayClick = true,
   expandable = false,
   hasBackgroundOverlay = true,
   visible,
@@ -122,7 +124,7 @@ function Drawer({
               })
             }
             role="presentation"
-            onClick={onRequestClose}
+            onClick={closeOnOverlayClick ? onRequestClose : undefined}
             onKeyDown={handleEscKeyPress}
           />
         )


### PR DESCRIPTION
This is a common request that keeps coming in from users so this seems like a quick fix for now, until we can implement fully prompting before closing on drawers when anything has been changed (which is TBD [here](https://linear.app/user-interviews/issue/RXS-304/drawer-behavior) already) 

https://userinterviews.slack.com/archives/C5Y7A9A1M/p1724078969522259

https://linear.app/user-interviews/issue/RXS-1384/disable-survey-drawer-closing-on-background-clicks

Demo: 

https://github.com/user-attachments/assets/4e633245-2bd7-4771-b527-f090a5cf1dc1

