### PR TITLE
Add support for arrays of active event keys to Accordion

### DIFF
--- a/src/Accordion/Accordion.stories.tsx
+++ b/src/Accordion/Accordion.stories.tsx
@@ -64,6 +64,48 @@ Default.args = {
   title: 'Accordion Toggle',
 };
 
+export function AlwaysOpen(args) {
+  return (
+    <Accordion alwaysOpen>
+      <AccordionItem eventKey="0">
+        <AccordionToggle
+          eventKey="0"
+          leadingIcon={faCreditCard}
+          {...args}
+        />
+        <AccordionCollapse eventKey="0">
+          <ul>
+            <li>Item 1</li>
+            <li>Item 2</li>
+            <li>Item 3</li>
+          </ul>
+        </AccordionCollapse>
+      </AccordionItem>
+      <AccordionItem eventKey="1">
+        <AccordionToggle
+          eventKey="1"
+          leadingIcon={faCreditCard}
+          {...args}
+        />
+        <AccordionCollapse eventKey="1">
+          <ul>
+            <li>Item 1</li>
+            <li>Item 2</li>
+            <li>Item 3</li>
+          </ul>
+        </AccordionCollapse>
+      </AccordionItem>
+    </Accordion>
+  );
+}
+
+AlwaysOpen.args = {
+  chevronLeft: false,
+  disabled: false,
+  helperText: 'helper text',
+  title: 'Accordion Toggle - always open',
+};
+
 export function DefaultOpen(args) {
   return (
     <Accordion defaultActiveKey="1">

--- a/src/Accordion/Accordion.stories.tsx
+++ b/src/Accordion/Accordion.stories.tsx
@@ -349,6 +349,50 @@ Borderless.args = {
   title: 'Accordion Toggle',
 };
 
+export function BorderlessBorderBottomFlushToggles(args) {
+  return (
+    <Accordion flush>
+      <AccordionItem borderless eventKey="0">
+        <AccordionToggle
+          borderBottom
+          eventKey="0"
+          flush
+          {...args}
+        />
+        <AccordionCollapse eventKey="0">
+          <ul>
+            <li>Item 1</li>
+            <li>Item 2</li>
+            <li>Item 3</li>
+          </ul>
+        </AccordionCollapse>
+      </AccordionItem>
+      <AccordionItem borderless eventKey="1">
+        <AccordionToggle
+          borderBottom
+          eventKey="1"
+          flush
+          {...args}
+        />
+        <AccordionCollapse eventKey="1">
+          <ul>
+            <li>Item 1</li>
+            <li>Item 2</li>
+            <li>Item 3</li>
+          </ul>
+        </AccordionCollapse>
+      </AccordionItem>
+    </Accordion>
+  );
+}
+
+BorderlessBorderBottomFlushToggles.args = {
+  chevronLeft: false,
+  disabled: false,
+  helperText: 'helper text',
+  title: 'Accordion Toggle',
+};
+
 export function InCard(args) {
   return (
     <>

--- a/src/Accordion/AccordionCollapse.scss
+++ b/src/Accordion/AccordionCollapse.scss
@@ -16,3 +16,9 @@
     padding-top: 0px !important;
   }
 }
+ /* If the parent AccordionToggle has a border-bottom applied, remove the top one here */
+.borderBottom {
+  .AccordionCollapse {
+    border-top: none;
+  }
+}

--- a/src/Accordion/AccordionToggle.scss
+++ b/src/Accordion/AccordionToggle.scss
@@ -9,10 +9,6 @@
     grid-template-columns: auto 24px;
     grid-template-areas: 'content chevron-right';
     padding: 16px 24px;
-
-    &.borderBottom {
-      border-bottom: 1px solid var(--ux-gray-400);
-    }
     
     &.flush {
       padding: 16px 4px;
@@ -28,6 +24,14 @@
 
     &--content {
       grid-area: content;
+    }
+  }
+
+  &.collapsed {
+    .AccordionToggle__container {
+      &.borderBottom {
+        border-bottom: 1px solid var(--ux-gray-400);
+      }
     }
   }
 

--- a/src/Accordion/AccordionToggle.scss
+++ b/src/Accordion/AccordionToggle.scss
@@ -9,6 +9,10 @@
     grid-template-columns: auto 24px;
     grid-template-areas: 'content chevron-right';
     padding: 16px 24px;
+
+    &.borderBottom {
+      border-bottom: 1px solid var(--ux-gray-400);
+    }
     
     &.flush {
       padding: 16px 4px;
@@ -24,14 +28,6 @@
 
     &--content {
       grid-area: content;
-    }
-  }
-
-  &.collapsed {
-    .AccordionToggle__container {
-      &.borderBottom {
-        border-bottom: 1px solid var(--ux-gray-400);
-      }
     }
   }
 

--- a/src/Accordion/AccordionToggle.scss
+++ b/src/Accordion/AccordionToggle.scss
@@ -10,6 +10,14 @@
     grid-template-areas: 'content chevron-right';
     padding: 16px 24px;
 
+    &.borderBottom {
+      border-bottom: 1px solid var(--ux-gray-400);
+    }
+    
+    &.flush {
+      padding: 16px 4px;
+    }
+
     &--right {
       grid-area: chevron-right;
       

--- a/src/Accordion/AccordionToggle.tsx
+++ b/src/Accordion/AccordionToggle.tsx
@@ -10,6 +10,8 @@ import AccordionContext from 'react-bootstrap/AccordionContext';
 import './AccordionToggle.scss';
 import { faChevronUp } from '@fortawesome/pro-solid-svg-icons';
 
+import { isEventKeyActive } from './utils';
+
 type AccordionToggleProps = {
   /**
    Set Chevron icon to open/close quarter turn from lateral
@@ -54,10 +56,12 @@ function AccordionToggle({
 }: AccordionToggleProps) {
   const { activeEventKey } = React.useContext(AccordionContext);
 
+  const eventKeyIsActive = isEventKeyActive(eventKey, activeEventKey);
+
   const [isCollapsed, setIsCollapsed] = useState(true);
 
   const decoratedOnClick = useAccordionButton(eventKey, () => {
-    if (eventKey !== activeEventKey) {
+    if (!eventKeyIsActive) {
       setIsCollapsed(false);
     }
     setIsCollapsed((prev) => !prev);
@@ -68,14 +72,14 @@ function AccordionToggle({
   };
 
   useEffect(() => {
-    if (activeEventKey && eventKey !== activeEventKey) {
+    if (!eventKeyIsActive) {
       handleCloseInactiveToggle();
     }
 
-    if (activeEventKey && eventKey === activeEventKey) {
+    if (eventKeyIsActive) {
       setIsCollapsed(((prev) => !prev));
     }
-  }, [activeEventKey, eventKey]);
+  }, [eventKeyIsActive]);
 
   return (
     <button

--- a/src/Accordion/AccordionToggle.tsx
+++ b/src/Accordion/AccordionToggle.tsx
@@ -13,6 +13,7 @@ import { faChevronUp } from '@fortawesome/pro-solid-svg-icons';
 import { isEventKeyActive } from './utils';
 
 type AccordionToggleProps = {
+  borderBottom?: boolean;
   /**
    Set Chevron icon to open/close quarter turn from lateral
   */
@@ -32,6 +33,7 @@ type AccordionToggleProps = {
    */
   disabled?: boolean;
   eventKey: string;
+  flush?: boolean;
   helperText?: string;
   leadingIcon?: object;
   title?: string;
@@ -40,6 +42,7 @@ type AccordionToggleProps = {
 };
 
 function AccordionToggle({
+  borderBottom,
   children,
   chevronLateral,
   chevronLeft,
@@ -47,6 +50,7 @@ function AccordionToggle({
   collapsedText,
   disabled,
   eventKey,
+  flush,
   helperText,
   leadingIcon,
   title,
@@ -96,7 +100,7 @@ function AccordionToggle({
       type="button"
       onClick={decoratedOnClick}
     >
-      <div className="AccordionToggle__container">
+      <div className={classNames('AccordionToggle__container', { flush }, { borderBottom })}>
         <div className="AccordionToggle__container--content">
           {chevronLeft && (
             <span className="AccordionToggle__chevron-left">

--- a/src/Accordion/utils.ts
+++ b/src/Accordion/utils.ts
@@ -1,0 +1,9 @@
+import type { AccordionEventKey } from 'react-bootstrap/esm/AccordionContext';
+
+export function isEventKeyActive(eventKey: string | null | undefined,
+  activeEventKey: AccordionEventKey) {
+  if (!eventKey) return false;
+
+  return (Array.isArray(activeEventKey) && activeEventKey.includes(eventKey)) ||
+    eventKey === activeEventKey;
+}


### PR DESCRIPTION
I noticed that adding the `alwaysOpen` prop to the Accordion caused the chevrons to stop rotating when the accordions were opened. This PR resolves that by allowing for arrays of `activeKeys` as well as single strings.

https://github.com/user-attachments/assets/34974478-7ff2-4b31-a1ba-1db4f4d73de1

