### PR TITLE
add deprecation warnings to components

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -35,6 +35,7 @@ const preview = {
     },
     options: {
       storySort: {
+        method: 'alphabetical',
         order: ['Foundations', 'Components'],
       },
     },

--- a/src/CardStack/CardStack.stories.tsx
+++ b/src/CardStack/CardStack.stories.tsx
@@ -7,7 +7,7 @@ import CardStack from './CardStack';
 import mdx from './CardStack.mdx';
 
 export default {
-  title: 'Layouts/CardStack',
+  title: 'Components/CardStack',
   component: CardStack,
   parameters: {
     docs: {

--- a/src/Container/Col.tsx
+++ b/src/Container/Col.tsx
@@ -4,6 +4,8 @@ import {
   type ColProps as ReactBootstrapColProps,
 } from 'react-bootstrap';
 
+import { useDeprecationWarning } from 'src/utils';
+
 export type ColProps = {
   /**
    You can use a custom element for this component
@@ -66,6 +68,8 @@ export function Col({
   bsPrefix = 'col',
   ...props
 }: ColProps) {
+  useDeprecationWarning({ componentName: 'Col', message: 'Please use FlexContainer instead.' });
+
   return (
     <ReactBootstrapCol
       as={as}

--- a/src/Container/Container.mdx
+++ b/src/Container/Container.mdx
@@ -1,8 +1,10 @@
-import { ArgTypes,  Canvas } from '@storybook/blocks';
+import { Canvas } from '@storybook/blocks';
 import Container from './Container';
 import * as ComponentStories from './Container.stories';
 
-# Container
+# Container (Deprecated)
+
+<b>⚠️ Deprecated: please use <code>FlexContainer</code> instead</b>
 
 <h4>
   A high level grid system to help create responsive application layouts. 
@@ -24,8 +26,6 @@ There are six default breakpoints, sometimes referred to as grid tiers, for buil
 | extra extra large | xxl         | {'≥'}1400px    |
 
 <Canvas of={ComponentStories.Default} />
-
-<ArgTypes of={Container} />
 
 ## Stories
 

--- a/src/Container/Container.stories.tsx
+++ b/src/Container/Container.stories.tsx
@@ -5,7 +5,7 @@ import { Col, Container, Row } from '.';
 import mdx from './Container.mdx';
 
 export default {
-  title: 'Layouts/Container',
+  title: 'Deprecated/Container',
   component: Container,
   parameters: {
     docs: {

--- a/src/Container/Container.tsx
+++ b/src/Container/Container.tsx
@@ -4,6 +4,8 @@ import {
   type ContainerProps as ReactBootstrapContainerProps,
 } from 'react-bootstrap';
 
+import { useDeprecationWarning } from 'src/utils';
+
 export type ContainerProps = {
   /**
    You can use a custom element for this component
@@ -30,6 +32,9 @@ export function Container({
   bsPrefix = 'container',
   ...props
 }: ContainerProps) {
+  
+  useDeprecationWarning({ componentName: 'Container', message: 'Please use FlexContainer instead.' });
+
   return (
     <ReactBootstrapContainer
       as={as}

--- a/src/Container/Container.tsx
+++ b/src/Container/Container.tsx
@@ -32,7 +32,6 @@ export function Container({
   bsPrefix = 'container',
   ...props
 }: ContainerProps) {
-  
   useDeprecationWarning({ componentName: 'Container', message: 'Please use FlexContainer instead.' });
 
   return (

--- a/src/Container/Row.tsx
+++ b/src/Container/Row.tsx
@@ -68,7 +68,6 @@ export function Row({
   bsPrefix = 'row',
   ...props
 }: RowProps) {
-  
   useDeprecationWarning({ componentName: 'Row', message: 'Please use FlexContainer instead.' });
 
   return (

--- a/src/Container/Row.tsx
+++ b/src/Container/Row.tsx
@@ -4,6 +4,8 @@ import {
   type RowProps as ReactBootstrapRowProps,
 } from 'react-bootstrap';
 
+import { useDeprecationWarning } from 'src/utils';
+
 export type RowProps = {
   /**
    You can use a custom element for this component
@@ -66,6 +68,9 @@ export function Row({
   bsPrefix = 'row',
   ...props
 }: RowProps) {
+  
+  useDeprecationWarning({ componentName: 'Row', message: 'Please use FlexContainer instead.' });
+
   return (
     <ReactBootstrapRow
       as={as}

--- a/src/Flex/Flex.mdx
+++ b/src/Flex/Flex.mdx
@@ -1,10 +1,10 @@
-import { ArgTypes,  Canvas } from '@storybook/blocks';
+import { Canvas } from '@storybook/blocks';
 import Flex from './Flex';
 import * as ComponentStories from './Flex.stories';
 
-# Flex
+# Flex (Deprecated)
 
-##
+<b>⚠️ Deprecated: please use <code>FlexContainer</code> instead</b>
 
 <h4>
   Flex is a utility component for creating consistent spacing between items. Use this for quick alignment and spacing in your layouts.
@@ -19,21 +19,3 @@ Flexbox CSS properties in the following documentation:
 </ul>
 
 <Canvas of={ComponentStories.Default} />
-
-## Props
-
-<ArgTypes of={Flex} />
-
-## Stories
-
-### Default
-
-<Canvas of={ComponentStories.Default} />
-
-### Flex Container
-
-<Canvas of={ComponentStories.FlexContainer} />
-
-### Flex Item
-
-<Canvas of={ComponentStories.FlexItem} />

--- a/src/Flex/Flex.stories.tsx
+++ b/src/Flex/Flex.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Flex> = {
   component: Flex,
   parameters: {
     docs: {
-      page: mdx
+      page: mdx,
     },
   },
   title: 'Deprecated/Flex',

--- a/src/Flex/Flex.stories.tsx
+++ b/src/Flex/Flex.stories.tsx
@@ -4,16 +4,16 @@ import type { Meta, StoryObj } from '@storybook/react';
 import Card from '../Card';
 import Flex from './Flex';
 
+import mdx from './Flex.mdx';
+
 const meta: Meta<typeof Flex> = {
   component: Flex,
   parameters: {
     docs: {
-      description: {
-        component: 'Flex is a utility component for creating consistent spacing between items. Use this for quick alignment and spacing in your layouts.',
-      },
+      page: mdx
     },
   },
-  title: 'Layouts/Flex',
+  title: 'Deprecated/Flex',
 };
 
 export default meta;

--- a/src/Flex/Flex.tsx
+++ b/src/Flex/Flex.tsx
@@ -1,6 +1,8 @@
 import { ReactNode, ElementType, createElement } from 'react';
 import classNames from 'classnames';
 
+import { useDeprecationWarning } from 'src/utils';
+
 import styles from './Flex.module.scss';
 
 export interface FlexProps {
@@ -63,6 +65,9 @@ function Flex({
   width,
   ...props
 }: FlexProps) {
+  
+  useDeprecationWarning({ componentName: 'Flex', message: 'Please use FlexContainer instead.' });
+
   // Defined flex properties as strings
   const flexClasses = [
     container ? styles[`flex-container`] : styles.container,

--- a/src/Flex/Flex.tsx
+++ b/src/Flex/Flex.tsx
@@ -65,7 +65,6 @@ function Flex({
   width,
   ...props
 }: FlexProps) {
-  
   useDeprecationWarning({ componentName: 'Flex', message: 'Please use FlexContainer instead.' });
 
   // Defined flex properties as strings

--- a/src/IconCell/IconCell.mdx
+++ b/src/IconCell/IconCell.mdx
@@ -2,9 +2,7 @@ import { ArgTypes,  Canvas } from '@storybook/blocks';
 import IconCell from './IconCell';
 import * as ComponentStories from './IconCell.stories';
 
-# Icon Cell
-
-##
+# Icon Cell (Deprecated)
 
 <h4>
   An icon with a colored background used to draw more attention to surrounding elements.

--- a/src/IconCell/IconCell.stories.tsx
+++ b/src/IconCell/IconCell.stories.tsx
@@ -8,7 +8,7 @@ import IconCell from '.';
 import mdx from './IconCell.mdx';
 
 export default {
-  title: 'Components/IconCell',
+  title: 'Deprecated/IconCell',
   component: IconCell,
   parameters: {
     docs: {

--- a/src/IconCell/IconCell.tsx
+++ b/src/IconCell/IconCell.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { type IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
+import { useDeprecationWarning } from 'src/utils';
+
 import './IconCell.scss';
 
 export type IconCellProps = {
@@ -12,6 +14,9 @@ export type IconCellProps = {
 function IconCell({
   icon,
 }: IconCellProps) {
+  
+  useDeprecationWarning({ componentName: 'IconCell' });
+
   return (
     <div className="IconCell">
       <FontAwesomeIcon icon={icon} />

--- a/src/IconCell/IconCell.tsx
+++ b/src/IconCell/IconCell.tsx
@@ -14,7 +14,6 @@ export type IconCellProps = {
 function IconCell({
   icon,
 }: IconCellProps) {
-  
   useDeprecationWarning({ componentName: 'IconCell' });
 
   return (

--- a/src/Main/Main.stories.tsx
+++ b/src/Main/Main.stories.tsx
@@ -6,7 +6,7 @@ import Main from './Main';
 import mdx from './Main.mdx';
 
 export default {
-  title: 'Layouts/Main',
+  title: 'Components/Main',
   component: Main,
   parameters: {
     docs: {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './useDeprecationWarning';

--- a/src/utils/useDeprecationWarning.ts
+++ b/src/utils/useDeprecationWarning.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+type useDeprecationWarningProps = {
+  componentName: string,
+  message?: string,
+}
+
+export function useDeprecationWarning({
+  componentName,
+  message = '',
+} : useDeprecationWarningProps) {
+  useEffect(() => {
+    const warningMessage = `Warning: ${componentName} is deprecated and will be removed in a future release.${
+      message ? ` ${message}` : ''}`;
+
+    if (process.env.NODE_ENV === 'development') {
+      // eslint-disable-next-line no-console
+      console.warn(warningMessage);
+    }
+  }, [componentName, message]);
+}


### PR DESCRIPTION
closes ENG-226

- Adds `useDeprecationWarning` hook and adds them to the following components under a Deprecated storybook folder
- Deprecated components: `Flex`, `Container`, `Col`, `Row`, `IconCell`
- Moves the `Layout` component under `Components` just for ease of discovery amongst all components until / if we want to organize the folders another way.
- Updates story sort to ensure all components shown are now alphabetical in Storybook nav.

Should only warn in dev environments
![Screenshot 2024-09-17 at 9 29 34 AM](https://github.com/user-attachments/assets/72261a88-9219-4d82-887d-dcb22e034278)

No longer have that funky non-alphabetical sort that was happening with the remaining JSX files
![Screenshot 2024-09-17 at 9 46 52 AM](https://github.com/user-attachments/assets/8596d16f-3973-47b0-beae-e769e875da8f)

