### PR TITLE
Reduce bundle size fortawesome

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -173,6 +173,22 @@
         "ts": "never",
         "tsx": "never"
       }
-   ]
+   ],
+    "no-restricted-imports": ["error", {
+      "patterns": [
+        {
+          "group": ["@fortawesome/free-brands-svg-icons/*", "@fortawesome/free-brands-svg-icons"],
+          "message": "Direct imports from @fortawesome/free-brands-svg-icons is not allowed. Import from src/ib/font_awesome/brands instead."
+        },
+        {
+          "group": ["@fortawesome/pro-regular-svg-icons/*", "@fortawesome/pro-regular-svg-icons"],
+          "message": "Direct imports from @fortawesome/pro-regular-svg-icons is not allowed. Import from src/lib/font_awesome/regular instead."
+        },
+        {
+          "group": ["@fortawesome/pro-solid-svg-icons/*", "@fortawesome/pro-solid-svg-icons"],
+          "message": "Direct imports from @fortawesome/pro-solid-svg-icons is not allowed. Import from src/lib/font_awesome/solid instead."
+        }
+      ]
+    }]
   }
 }

--- a/src/Accordion/Accordion.stories.tsx
+++ b/src/Accordion/Accordion.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { faCreditCard } from 'src/font_awesome/regular';
+import { faCreditCard } from '../font_awesome/regular';
 import Card from '../Card';
 
 import {

--- a/src/Accordion/Accordion.stories.tsx
+++ b/src/Accordion/Accordion.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { faCreditCard } from '@fortawesome/pro-regular-svg-icons';
+import { faCreditCard } from 'src/font_awesome/regular';
 import Card from '../Card';
 
 import {

--- a/src/Accordion/AccordionToggle.tsx
+++ b/src/Accordion/AccordionToggle.tsx
@@ -7,7 +7,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useAccordionButton } from 'react-bootstrap/AccordionButton';
 import AccordionContext from 'react-bootstrap/AccordionContext';
 
-import { faChevronUp } from 'src/font_awesome/solid';
+import { faChevronUp } from '../font_awesome/solid';
 
 import './AccordionToggle.scss';
 

--- a/src/Accordion/AccordionToggle.tsx
+++ b/src/Accordion/AccordionToggle.tsx
@@ -7,8 +7,9 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useAccordionButton } from 'react-bootstrap/AccordionButton';
 import AccordionContext from 'react-bootstrap/AccordionContext';
 
+import { faChevronUp } from 'src/font_awesome/solid';
+
 import './AccordionToggle.scss';
-import { faChevronUp } from '@fortawesome/pro-solid-svg-icons';
 
 import { isEventKeyActive } from './utils';
 

--- a/src/Alert/Alert.tsx
+++ b/src/Alert/Alert.tsx
@@ -10,7 +10,7 @@ import {
   faExclamationTriangle,
   faInfo,
   faTimes,
-} from 'src/font_awesome/solid';
+} from '../font_awesome/solid';
 
 import './Alert.scss';
 

--- a/src/Alert/Alert.tsx
+++ b/src/Alert/Alert.tsx
@@ -10,7 +10,7 @@ import {
   faExclamationTriangle,
   faInfo,
   faTimes,
-} from '@fortawesome/pro-solid-svg-icons';
+} from 'src/font_awesome/solid';
 
 import './Alert.scss';
 

--- a/src/Button/Button.mdx
+++ b/src/Button/Button.mdx
@@ -37,8 +37,8 @@ import * as ComponentStories from './Button.stories';
 ### Iconography
 - Font Awesome library
   - We utilize the Regular and Solid Font Awesome icons
-  - Only use Solid icons on icon-only buttons. import `@fortawesome/pro-solid-svg-icons`
-  - Use Regular icons for all other buttons. import `@fortawesome/pro-regular-svg-icons`
+  - Only use Solid icons on icon-only buttons. import `src/font_awesome/solid`
+  - Use Regular icons for all other buttons. import `src/font_awesome/regular`
 - Use a leading icon alongside a label if there is a primary action verb (e.g. Edit, Share, Copy)
 - Icon-only buttons should only be permitted if
 	- Space is limited (e.g. too small for text alone)

--- a/src/Button/Button.mdx
+++ b/src/Button/Button.mdx
@@ -37,8 +37,8 @@ import * as ComponentStories from './Button.stories';
 ### Iconography
 - Font Awesome library
   - We utilize the Regular and Solid Font Awesome icons
-  - Only use Solid icons on icon-only buttons. import `src/font_awesome/solid`
-  - Use Regular icons for all other buttons. import `src/font_awesome/regular`
+  - Only use Solid icons on icon-only buttons. import relatively from `src/font_awesome/solid`
+  - Use Regular icons for all other buttons. import relatively from `src/font_awesome/regular`
 - Use a leading icon alongside a label if there is a primary action verb (e.g. Edit, Share, Copy)
 - Icon-only buttons should only be permitted if
 	- Space is limited (e.g. too small for text alone)

--- a/src/Button/Button.stories.tsx
+++ b/src/Button/Button.stories.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
-import { faFileAlt, faCaretDown, faPaperPlane } from '@fortawesome/pro-regular-svg-icons';
+import { faFileAlt, faCaretDown, faPaperPlane } from 'src/font_awesome/regular';
 import {
  faGoogle, faFacebook, faLinkedin, faTwitter,
-} from '@fortawesome/free-brands-svg-icons';
+} from 'src/font_awesome/brands';
 import Button from '.';
 import mdx from './Button.mdx';
 

--- a/src/Button/Button.stories.tsx
+++ b/src/Button/Button.stories.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
-import { faFileAlt, faCaretDown, faPaperPlane } from 'src/font_awesome/regular';
+import { faFileAlt, faCaretDown, faPaperPlane } from '../font_awesome/regular';
 import {
  faGoogle, faFacebook, faLinkedin, faTwitter,
-} from 'src/font_awesome/brands';
+} from '../font_awesome/brands';
 import Button from '.';
 import mdx from './Button.mdx';
 

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -2,12 +2,12 @@ import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSpinnerThird } from 'src/font_awesome/regular';
-
 import {
   Button as RBButton,
   type ButtonProps as RBButtonProps,
 } from 'react-bootstrap';
+
+import { faSpinnerThird } from '../font_awesome/regular';
 
 import './Button.scss';
 

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSpinnerThird } from '@fortawesome/pro-regular-svg-icons';
+import { faSpinnerThird } from 'src/font_awesome/regular';
 
 import {
   Button as RBButton,

--- a/src/Container/Col.tsx
+++ b/src/Container/Col.tsx
@@ -4,7 +4,7 @@ import {
   type ColProps as ReactBootstrapColProps,
 } from 'react-bootstrap';
 
-import { useDeprecationWarning } from 'src/utils';
+import { useDeprecationWarning } from '../utils';
 
 export type ColProps = {
   /**

--- a/src/Container/Container.tsx
+++ b/src/Container/Container.tsx
@@ -4,7 +4,7 @@ import {
   type ContainerProps as ReactBootstrapContainerProps,
 } from 'react-bootstrap';
 
-import { useDeprecationWarning } from 'src/utils';
+import { useDeprecationWarning } from '../utils';
 
 export type ContainerProps = {
   /**

--- a/src/Container/Row.tsx
+++ b/src/Container/Row.tsx
@@ -4,7 +4,7 @@ import {
   type RowProps as ReactBootstrapRowProps,
 } from 'react-bootstrap';
 
-import { useDeprecationWarning } from 'src/utils';
+import { useDeprecationWarning } from '../utils';
 
 export type RowProps = {
   /**

--- a/src/CopyToClipboardButton/CopyToClipboardButton.tsx
+++ b/src/CopyToClipboardButton/CopyToClipboardButton.tsx
@@ -5,7 +5,7 @@ import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { type IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import { faCopy } from 'src/font_awesome/regular';
+import { faCopy } from '../font_awesome/regular';
 
 import TrackedButton from '../TrackedButton';
 import Popper from '../Popper';

--- a/src/CopyToClipboardButton/CopyToClipboardButton.tsx
+++ b/src/CopyToClipboardButton/CopyToClipboardButton.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import classNames from 'classnames';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+
 import { type IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCopy } from '@fortawesome/pro-regular-svg-icons';
-import { CopyToClipboard } from 'react-copy-to-clipboard';
+
+import { faCopy } from 'src/font_awesome/regular';
 
 import TrackedButton from '../TrackedButton';
 import Popper from '../Popper';

--- a/src/DateTimePicker/PickerEnforcedInput.tsx
+++ b/src/DateTimePicker/PickerEnforcedInput.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { isValid } from 'date-fns';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCalendarAlt } from 'src/font_awesome/regular';
+import { faCalendarAlt } from '../font_awesome/regular';
 
 type PickerEnforcedInputProps = {
   disabled?: boolean;

--- a/src/DateTimePicker/PickerEnforcedInput.tsx
+++ b/src/DateTimePicker/PickerEnforcedInput.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { isValid } from 'date-fns';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCalendarAlt } from '@fortawesome/pro-regular-svg-icons';
+import { faCalendarAlt } from 'src/font_awesome/regular';
 
 type PickerEnforcedInputProps = {
   disabled?: boolean;

--- a/src/Drawer/Drawer.stories.tsx
+++ b/src/Drawer/Drawer.stories.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faEnvelope, faChevronLeft, faChevronRight, faTrash,
-} from 'src/font_awesome/solid';
+} from '../font_awesome/solid';
 import {
  Drawer, DrawerBody, DrawerFooter, DrawerHeader,
 } from '.';

--- a/src/Drawer/Drawer.stories.tsx
+++ b/src/Drawer/Drawer.stories.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faEnvelope, faChevronLeft, faChevronRight, faTrash,
-} from '@fortawesome/pro-solid-svg-icons';
+} from 'src/font_awesome/solid';
 import {
  Drawer, DrawerBody, DrawerFooter, DrawerHeader,
 } from '.';

--- a/src/Drawer/DrawerHeader.tsx
+++ b/src/Drawer/DrawerHeader.tsx
@@ -5,7 +5,7 @@ import { type IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faTimes, faCompressAlt, faExpandAlt,
-} from 'src/font_awesome/solid';
+} from '../font_awesome/solid';
 
 import './DrawerHeader.scss';
 

--- a/src/Drawer/DrawerHeader.tsx
+++ b/src/Drawer/DrawerHeader.tsx
@@ -5,7 +5,7 @@ import { type IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faTimes, faCompressAlt, faExpandAlt,
-} from '@fortawesome/pro-solid-svg-icons';
+} from 'src/font_awesome/solid';
 
 import './DrawerHeader.scss';
 

--- a/src/Dropdown/Dropdown.stories.tsx
+++ b/src/Dropdown/Dropdown.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {
  faEllipsisV, faFileAlt, faChevronDown, faTag, faEnvelope, faTrashAlt,
-} from '@fortawesome/pro-regular-svg-icons';
+} from 'src/font_awesome/regular';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {

--- a/src/Dropdown/Dropdown.stories.tsx
+++ b/src/Dropdown/Dropdown.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {
  faEllipsisV, faFileAlt, faChevronDown, faTag, faEnvelope, faTrashAlt,
-} from 'src/font_awesome/regular';
+} from '../font_awesome/regular';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {

--- a/src/Dropdown/Dropdown.stories.tsx
+++ b/src/Dropdown/Dropdown.stories.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
  faEllipsisV, faFileAlt, faChevronDown, faTag, faEnvelope, faTrashAlt,
 } from '../font_awesome/regular';
-
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
  Dropdown, DropdownDivider, DropdownToggle, DropdownItem, DropdownMenu,
 } from '.';

--- a/src/EmptyState/EmptyState.stories.tsx
+++ b/src/EmptyState/EmptyState.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
-import { faPlus } from 'src/font_awesome/regular';
+import { faPlus } from '../font_awesome/regular';
 
 import Button from '../Button';
 

--- a/src/EmptyState/EmptyState.stories.tsx
+++ b/src/EmptyState/EmptyState.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
-import { faPlus } from '@fortawesome/pro-regular-svg-icons';
+import { faPlus } from 'src/font_awesome/regular';
 
 import Button from '../Button';
 

--- a/src/Flex/Flex.tsx
+++ b/src/Flex/Flex.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, ElementType, createElement } from 'react';
 import classNames from 'classnames';
 
-import { useDeprecationWarning } from 'src/utils';
+import { useDeprecationWarning } from '../utils';
 
 import styles from './Flex.module.scss';
 

--- a/src/FormGroup/FormGroup.stories.tsx
+++ b/src/FormGroup/FormGroup.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { faSearch } from 'src/font_awesome/solid';
+import { faSearch } from '../font_awesome/solid';
 import { FlexContainer } from 'src/FlexContainer';
 import FormGroup from '.';
 import Input from '../Input';

--- a/src/FormGroup/FormGroup.stories.tsx
+++ b/src/FormGroup/FormGroup.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { faSearch } from '@fortawesome/pro-solid-svg-icons';
 
+import { faSearch } from 'src/font_awesome/solid';
 import { FlexContainer } from 'src/FlexContainer';
 import FormGroup from '.';
 import Input from '../Input';

--- a/src/FormGroup/FormGroup.stories.tsx
+++ b/src/FormGroup/FormGroup.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
-import { faSearch } from '../font_awesome/solid';
 import { FlexContainer } from 'src/FlexContainer';
+import { faSearch } from '../font_awesome/solid';
 import FormGroup from '.';
 import Input from '../Input';
 import FormControlLabel from '../FormControlLabel';

--- a/src/IconButton/IconButton.tsx
+++ b/src/IconButton/IconButton.tsx
@@ -12,7 +12,7 @@ import {
   faPencil,
   faTimes,
   faExpandAlt,
-} from '@fortawesome/pro-regular-svg-icons';
+} from 'src/font_awesome/regular';
 import Button, { type ButtonProps } from '../Button/Button';
 
 export const IconButtonActions = {

--- a/src/IconButton/IconButton.tsx
+++ b/src/IconButton/IconButton.tsx
@@ -12,7 +12,7 @@ import {
   faPencil,
   faTimes,
   faExpandAlt,
-} from 'src/font_awesome/regular';
+} from '../font_awesome/regular';
 import Button, { type ButtonProps } from '../Button/Button';
 
 export const IconButtonActions = {

--- a/src/IconCell/IconCell.stories.tsx
+++ b/src/IconCell/IconCell.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {
  faGlobe, faMailbox, faPaperPlane, faStar, faUser,
-} from '@fortawesome/pro-regular-svg-icons';
+} from 'src/font_awesome/regular';
 
 import IconCell from '.';
 import mdx from './IconCell.mdx';

--- a/src/IconCell/IconCell.stories.tsx
+++ b/src/IconCell/IconCell.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {
  faGlobe, faMailbox, faPaperPlane, faStar, faUser,
-} from 'src/font_awesome/regular';
+} from '../font_awesome/regular';
 
 import IconCell from '.';
 import mdx from './IconCell.mdx';

--- a/src/IconCell/IconCell.tsx
+++ b/src/IconCell/IconCell.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { type IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import { useDeprecationWarning } from 'src/utils';
+import { useDeprecationWarning } from '../utils';
 
 import './IconCell.scss';
 

--- a/src/LoadingOverlay/LoadingOverlay.tsx
+++ b/src/LoadingOverlay/LoadingOverlay.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSpinnerThird } from 'src/font_awesome/solid';
+import { faSpinnerThird } from '../font_awesome/solid';
 
 import './LoadingOverlay.scss';
 

--- a/src/LoadingOverlay/LoadingOverlay.tsx
+++ b/src/LoadingOverlay/LoadingOverlay.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSpinnerThird } from '@fortawesome/pro-solid-svg-icons';
+import { faSpinnerThird } from 'src/font_awesome/solid';
 
 import './LoadingOverlay.scss';
 

--- a/src/Modal/ModalHeader.tsx
+++ b/src/Modal/ModalHeader.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import './ModalHeader.scss';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faExclamationTriangle } from '@fortawesome/pro-solid-svg-icons';
+import { faExclamationTriangle } from 'src/font_awesome/solid';
 
 type ModalHeaderProps = {
   children?: React.ReactNode;

--- a/src/Modal/ModalHeader.tsx
+++ b/src/Modal/ModalHeader.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import './ModalHeader.scss';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faExclamationTriangle } from 'src/font_awesome/solid';
+import { faExclamationTriangle } from '../font_awesome/solid';
 
 type ModalHeaderProps = {
   children?: React.ReactNode;

--- a/src/Pill/Pill.stories.tsx
+++ b/src/Pill/Pill.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import {
  faClock, faGiftCard, faGlobe, faMicrophone, faUsers,
-} from 'src/font_awesome/solid';
+} from '../font_awesome/solid';
 
 import { Pill, Pills, PILL_COLORS } from '.';
 import mdx from './Pill.mdx';

--- a/src/Pill/Pill.stories.tsx
+++ b/src/Pill/Pill.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import {
  faClock, faGiftCard, faGlobe, faMicrophone, faUsers,
-} from '@fortawesome/pro-solid-svg-icons';
+} from 'src/font_awesome/solid';
 
 import { Pill, Pills, PILL_COLORS } from '.';
 import mdx from './Pill.mdx';

--- a/src/Pill/Pill.tsx
+++ b/src/Pill/Pill.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { type IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes } from 'src/font_awesome/solid';
+import { faTimes } from '../font_awesome/solid';
 
 import './Pill.scss';
 

--- a/src/Pill/Pill.tsx
+++ b/src/Pill/Pill.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import classNames from 'classnames';
-import { type IconDefinition } from '@fortawesome/pro-solid-svg-icons';
+import { type IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes } from '@fortawesome/pro-solid-svg-icons';
+import { faTimes } from 'src/font_awesome/solid';
 
 import './Pill.scss';
 

--- a/src/ProfileCell/ProfileCell.stories.tsx
+++ b/src/ProfileCell/ProfileCell.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { faShieldCheck } from '@fortawesome/pro-solid-svg-icons';
+import { faShieldCheck } from 'src/font_awesome/solid';
 import ProfileCell from '.';
 import ProfileCellSkeleton from './ProfileCellSkeleton';
 import mdx from './ProfileCell.mdx';

--- a/src/ProfileCell/ProfileCell.stories.tsx
+++ b/src/ProfileCell/ProfileCell.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { faShieldCheck } from 'src/font_awesome/solid';
+import { faShieldCheck } from '../font_awesome/solid';
 import ProfileCell from '.';
 import ProfileCellSkeleton from './ProfileCellSkeleton';
 import mdx from './ProfileCell.mdx';

--- a/src/RichTextEditor/RichTextEditorMenuBar.tsx
+++ b/src/RichTextEditor/RichTextEditorMenuBar.tsx
@@ -12,7 +12,7 @@ import {
   faListOl,
   faListUl,
   faUnlink,
-} from '@fortawesome/pro-regular-svg-icons';
+} from 'src/font_awesome/regular';
 import IconButton from '../IconButton';
 
 import { RichTextEditorActions } from './richTextEditorActions';

--- a/src/RichTextEditor/RichTextEditorMenuBar.tsx
+++ b/src/RichTextEditor/RichTextEditorMenuBar.tsx
@@ -12,7 +12,7 @@ import {
   faListOl,
   faListUl,
   faUnlink,
-} from 'src/font_awesome/regular';
+} from '../font_awesome/regular';
 import IconButton from '../IconButton';
 
 import { RichTextEditorActions } from './richTextEditorActions';

--- a/src/Table/Table.stories.tsx
+++ b/src/Table/Table.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { faFileAlt, faEllipsisV, faThumbtack } from '@fortawesome/pro-solid-svg-icons';
+import { faFileAlt, faEllipsisV, faThumbtack } from 'src/font_awesome/solid';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import Button from '../Button';

--- a/src/Table/Table.stories.tsx
+++ b/src/Table/Table.stories.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 
-import { faFileAlt, faEllipsisV, faThumbtack } from 'src/font_awesome/solid';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
+import { faFileAlt, faEllipsisV, faThumbtack } from '../font_awesome/solid';
 import Button from '../Button';
 import Card from '../Card';
 import CheckboxButton from '../CheckboxButton';

--- a/src/Table/TableSortLabel.tsx
+++ b/src/Table/TableSortLabel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSort } from '@fortawesome/pro-solid-svg-icons';
+import { faSort } from 'src/font_awesome/solid';
 
 import './TableSortLabel.scss';
 

--- a/src/Table/TableSortLabel.tsx
+++ b/src/Table/TableSortLabel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSort } from 'src/font_awesome/solid';
+import { faSort } from '../font_awesome/solid';
 
 import './TableSortLabel.scss';
 

--- a/src/Tooltip/Tooltip.jsx
+++ b/src/Tooltip/Tooltip.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faQuestionCircle } from '@fortawesome/pro-solid-svg-icons';
+import { faQuestionCircle } from '../font_awesome/solid';
 
 import Popper from '../Popper';
 

--- a/src/Tooltip/Tooltip.stories.jsx
+++ b/src/Tooltip/Tooltip.stories.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 
-import { faExclamationTriangle } from '@fortawesome/pro-solid-svg-icons';
+import { faExclamationTriangle } from '../font_awesome/solid';
 
 import Tooltip from '.';
 import mdx from './Tooltip.mdx';

--- a/src/font_awesome/brands.ts
+++ b/src/font_awesome/brands.ts
@@ -6,17 +6,10 @@
 
 /* eslint-disable no-restricted-imports */
 
-import { library } from '@fortawesome/fontawesome-svg-core';
-
 import { faGoogle } from '@fortawesome/free-brands-svg-icons/faGoogle';
 import { faFacebook } from '@fortawesome/free-brands-svg-icons/faFacebook';
 import { faLinkedin } from '@fortawesome/free-brands-svg-icons/faLinkedin';
 import { faTwitter } from '@fortawesome/free-brands-svg-icons/faTwitter';
-
-library.add(faGoogle);
-library.add(faFacebook);
-library.add(faLinkedin);
-library.add(faTwitter);
 
 export {
   faGoogle,

--- a/src/font_awesome/brands.ts
+++ b/src/font_awesome/brands.ts
@@ -1,0 +1,18 @@
+import { library } from '@fortawesome/fontawesome-svg-core';
+
+import { faGoogle } from '@fortawesome/free-brands-svg-icons/faGoogle';
+import { faFacebook } from '@fortawesome/free-brands-svg-icons/faFacebook';
+import { faLinkedin } from '@fortawesome/free-brands-svg-icons/faLinkedin';
+import { faTwitter } from '@fortawesome/free-brands-svg-icons/faTwitter';
+
+library.add(faGoogle);
+library.add(faFacebook);
+library.add(faLinkedin);
+library.add(faTwitter);
+
+export {
+  faGoogle,
+  faFacebook,
+  faLinkedin,
+  faTwitter,
+};

--- a/src/font_awesome/brands.ts
+++ b/src/font_awesome/brands.ts
@@ -1,3 +1,11 @@
+// Keep this eslint-disable here. FontAwesome imports should only be happening
+// in this file and nowhere else in the codebase.
+//
+// Any direct import from '@fortawesome/free-brands-svg-icons' will create bloat in
+// our overall bundle size.
+
+/* eslint-disable no-restricted-imports */
+
 import { library } from '@fortawesome/fontawesome-svg-core';
 
 import { faGoogle } from '@fortawesome/free-brands-svg-icons/faGoogle';

--- a/src/font_awesome/regular.ts
+++ b/src/font_awesome/regular.ts
@@ -1,3 +1,11 @@
+// Keep this eslint-disable here. FontAwesome imports should only be happening
+// in this file and nowhere else in the codebase.
+//
+// Any direct import from '@fortawesome/pro-regular-svg-icons' will create bloat in
+// our overall bundle size.
+
+/* eslint-disable no-restricted-imports */
+
 import { library } from '@fortawesome/fontawesome-svg-core';
 
 import { faSpinnerThird } from '@fortawesome/pro-regular-svg-icons/faSpinnerThird';

--- a/src/font_awesome/regular.ts
+++ b/src/font_awesome/regular.ts
@@ -1,0 +1,98 @@
+import { library } from '@fortawesome/fontawesome-svg-core';
+
+import { faSpinnerThird } from '@fortawesome/pro-regular-svg-icons/faSpinnerThird';
+import { faCreditCard } from '@fortawesome/pro-regular-svg-icons/faCreditCard';
+import { faFileAlt } from '@fortawesome/pro-regular-svg-icons/faFileAlt';
+import { faCaretDown } from '@fortawesome/pro-regular-svg-icons/faCaretDown';
+import { faPaperPlane } from '@fortawesome/pro-regular-svg-icons/faPaperPlane';
+import { faCopy } from '@fortawesome/pro-regular-svg-icons/faCopy';
+import { faCalendarAlt } from '@fortawesome/pro-regular-svg-icons/faCalendarAlt';
+import { faEllipsisV } from '@fortawesome/pro-regular-svg-icons/faEllipsisV';
+import { faChevronDown } from '@fortawesome/pro-regular-svg-icons/faChevronDown';
+import { faTag } from '@fortawesome/pro-regular-svg-icons/faTag';
+import { faEnvelope } from '@fortawesome/pro-regular-svg-icons/faEnvelope';
+import { faTrashAlt } from '@fortawesome/pro-regular-svg-icons/faTrashAlt';
+import { faPlus } from '@fortawesome/pro-regular-svg-icons/faPlus';
+import { faPlusCircle } from '@fortawesome/pro-regular-svg-icons/faPlusCircle';
+import { faMinusCircle } from '@fortawesome/pro-regular-svg-icons/faMinusCircle';
+import { faChevronLeft } from '@fortawesome/pro-regular-svg-icons/faChevronLeft';
+import { faChevronRight } from '@fortawesome/pro-regular-svg-icons/faChevronRight';
+import { faPencil } from '@fortawesome/pro-regular-svg-icons/faPencil';
+import { faTimes } from '@fortawesome/pro-regular-svg-icons/faTimes';
+import { faExpandAlt } from '@fortawesome/pro-regular-svg-icons/faExpandAlt';
+import { faGlobe } from '@fortawesome/pro-regular-svg-icons/faGlobe';
+import { faMailbox } from '@fortawesome/pro-regular-svg-icons/faMailbox';
+import { faStar } from '@fortawesome/pro-regular-svg-icons/faStar';
+import { faUser } from '@fortawesome/pro-regular-svg-icons/faUser';
+import { faBold } from '@fortawesome/pro-regular-svg-icons/faBold';
+import { faItalic } from '@fortawesome/pro-regular-svg-icons/faItalic';
+import { faLink } from '@fortawesome/pro-regular-svg-icons/faLink';
+import { faListOl } from '@fortawesome/pro-regular-svg-icons/faListOl';
+import { faListUl } from '@fortawesome/pro-regular-svg-icons/faListUl';
+import { faUnlink } from '@fortawesome/pro-regular-svg-icons/faUnlink';
+
+library.add(faSpinnerThird);
+library.add(faCreditCard);
+library.add(faFileAlt);
+library.add(faCaretDown);
+library.add(faPaperPlane);
+library.add(faCopy);
+library.add(faCalendarAlt);
+library.add(faEllipsisV);
+library.add(faChevronDown);
+library.add(faTag);
+library.add(faEnvelope);
+library.add(faTrashAlt);
+library.add(faPlus);
+library.add(faPlusCircle);
+library.add(faMinusCircle);
+library.add(faChevronLeft);
+library.add(faChevronRight);
+library.add(faPencil);
+library.add(faTimes);
+library.add(faExpandAlt);
+library.add(faGlobe);
+library.add(faMailbox);
+library.add(faStar);
+library.add(faUser);
+library.add(faBold);
+library.add(faItalic);
+library.add(faLink);
+library.add(faListOl);
+library.add(faListUl);
+library.add(faUnlink);
+
+
+
+export {
+  faSpinnerThird,
+  faCreditCard,
+  faFileAlt,
+  faCaretDown,
+  faPaperPlane,
+  faCopy,
+  faCalendarAlt,
+  faEllipsisV,
+  faChevronDown,
+  faTag,
+  faEnvelope,
+  faTrashAlt,
+  faPlus,
+  faPlusCircle,
+  faMinusCircle,
+  faChevronLeft,
+  faChevronRight,
+  faPencil,
+  faTimes,
+  faExpandAlt,
+  faGlobe,
+  faMailbox,
+  faStar,
+  faUser,
+  faBold,
+  faItalic,
+  faLink,
+  faListOl,
+  faListUl,
+  faUnlink,
+};

--- a/src/font_awesome/regular.ts
+++ b/src/font_awesome/regular.ts
@@ -62,8 +62,6 @@ library.add(faListOl);
 library.add(faListUl);
 library.add(faUnlink);
 
-
-
 export {
   faSpinnerThird,
   faCreditCard,

--- a/src/font_awesome/regular.ts
+++ b/src/font_awesome/regular.ts
@@ -6,8 +6,6 @@
 
 /* eslint-disable no-restricted-imports */
 
-import { library } from '@fortawesome/fontawesome-svg-core';
-
 import { faSpinnerThird } from '@fortawesome/pro-regular-svg-icons/faSpinnerThird';
 import { faCreditCard } from '@fortawesome/pro-regular-svg-icons/faCreditCard';
 import { faFileAlt } from '@fortawesome/pro-regular-svg-icons/faFileAlt';
@@ -38,37 +36,6 @@ import { faLink } from '@fortawesome/pro-regular-svg-icons/faLink';
 import { faListOl } from '@fortawesome/pro-regular-svg-icons/faListOl';
 import { faListUl } from '@fortawesome/pro-regular-svg-icons/faListUl';
 import { faUnlink } from '@fortawesome/pro-regular-svg-icons/faUnlink';
-
-library.add(faSpinnerThird);
-library.add(faCreditCard);
-library.add(faFileAlt);
-library.add(faCaretDown);
-library.add(faPaperPlane);
-library.add(faCopy);
-library.add(faCalendarAlt);
-library.add(faEllipsisV);
-library.add(faChevronDown);
-library.add(faTag);
-library.add(faEnvelope);
-library.add(faTrashAlt);
-library.add(faPlus);
-library.add(faPlusCircle);
-library.add(faMinusCircle);
-library.add(faChevronLeft);
-library.add(faChevronRight);
-library.add(faPencil);
-library.add(faTimes);
-library.add(faExpandAlt);
-library.add(faGlobe);
-library.add(faMailbox);
-library.add(faStar);
-library.add(faUser);
-library.add(faBold);
-library.add(faItalic);
-library.add(faLink);
-library.add(faListOl);
-library.add(faListUl);
-library.add(faUnlink);
 
 export {
   faSpinnerThird,

--- a/src/font_awesome/solid.ts
+++ b/src/font_awesome/solid.ts
@@ -1,0 +1,84 @@
+import { library } from '@fortawesome/fontawesome-svg-core';
+
+import { faChevronUp } from '@fortawesome/pro-solid-svg-icons/faChevronUp';
+import { faBullhorn } from '@fortawesome/pro-solid-svg-icons/faBullhorn';
+import { faCircle } from '@fortawesome/pro-solid-svg-icons/faCircle';
+import { faCheck } from '@fortawesome/pro-solid-svg-icons/faCheck';
+import { faExclamationTriangle } from '@fortawesome/pro-solid-svg-icons/faExclamationTriangle';
+import { faInfo } from '@fortawesome/pro-solid-svg-icons/faInfo';
+import { faTimes } from '@fortawesome/pro-solid-svg-icons/faTimes';
+import { faEnvelope } from '@fortawesome/pro-solid-svg-icons/faEnvelope';
+import { faChevronLeft } from '@fortawesome/pro-solid-svg-icons/faChevronLeft';
+import { faChevronRight } from '@fortawesome/pro-solid-svg-icons/faChevronRight';
+import { faTrash } from '@fortawesome/pro-solid-svg-icons/faTrash';
+import { faCompressAlt } from '@fortawesome/pro-solid-svg-icons/faCompressAlt';
+import { faExpandAlt } from '@fortawesome/pro-solid-svg-icons/faExpandAlt';
+import { faSearch } from '@fortawesome/pro-solid-svg-icons/faSearch';
+import { faSpinnerThird } from '@fortawesome/pro-solid-svg-icons/faSpinnerThird';
+import { faClock } from '@fortawesome/pro-solid-svg-icons/faClock';
+import { faGiftCard } from '@fortawesome/pro-solid-svg-icons/faGiftCard';
+import { faGlobe } from '@fortawesome/pro-solid-svg-icons/faGlobe';
+import { faMicrophone } from '@fortawesome/pro-solid-svg-icons/faMicrophone';
+import { faUsers } from '@fortawesome/pro-solid-svg-icons/faUsers';
+import { faShieldCheck } from '@fortawesome/pro-solid-svg-icons/faShieldCheck';
+import { faFileAlt } from '@fortawesome/pro-solid-svg-icons/faFileAlt';
+import { faEllipsisV } from '@fortawesome/pro-solid-svg-icons/faEllipsisV';
+import { faThumbtack } from '@fortawesome/pro-solid-svg-icons/faThumbtack';
+import { faSort } from '@fortawesome/pro-solid-svg-icons/faSort';
+import { faQuestionCircle } from '@fortawesome/pro-solid-svg-icons/faQuestionCircle';
+
+library.add(faChevronUp);
+library.add(faBullhorn);
+library.add(faCircle);
+library.add(faCheck);
+library.add(faExclamationTriangle);
+library.add(faInfo);
+library.add(faTimes);
+library.add(faEnvelope);
+library.add(faChevronLeft);
+library.add(faChevronRight);
+library.add(faTrash);
+library.add(faCompressAlt);
+library.add(faExpandAlt);
+library.add(faSearch);
+library.add(faSpinnerThird);
+library.add(faClock);
+library.add(faGiftCard);
+library.add(faGlobe);
+library.add(faMicrophone);
+library.add(faUsers);
+library.add(faShieldCheck);
+library.add(faFileAlt);
+library.add(faEllipsisV);
+library.add(faThumbtack);
+library.add(faSort);
+library.add(faQuestionCircle);
+
+export {
+  faChevronUp,
+  faBullhorn,
+  faCircle,
+  faCheck,
+  faExclamationTriangle,
+  faInfo,
+  faTimes,
+  faEnvelope,
+  faChevronLeft,
+  faChevronRight,
+  faTrash,
+  faCompressAlt,
+  faExpandAlt,
+  faSearch,
+  faSpinnerThird,
+  faClock,
+  faGiftCard,
+  faGlobe,
+  faMicrophone,
+  faUsers,
+  faShieldCheck,
+  faFileAlt,
+  faEllipsisV,
+  faThumbtack,
+  faSort,
+  faQuestionCircle,
+};

--- a/src/font_awesome/solid.ts
+++ b/src/font_awesome/solid.ts
@@ -1,3 +1,11 @@
+// Keep this eslint-disable here. FontAwesome imports should only be happening
+// in this file and nowhere else in the codebase.
+//
+// Any direct import from '@fortawesome/pro-solid-svg-icons' will create bloat in
+// our overall bundle size.
+
+/* eslint-disable no-restricted-imports */
+
 import { library } from '@fortawesome/fontawesome-svg-core';
 
 import { faChevronUp } from '@fortawesome/pro-solid-svg-icons/faChevronUp';

--- a/src/font_awesome/solid.ts
+++ b/src/font_awesome/solid.ts
@@ -6,8 +6,6 @@
 
 /* eslint-disable no-restricted-imports */
 
-import { library } from '@fortawesome/fontawesome-svg-core';
-
 import { faChevronUp } from '@fortawesome/pro-solid-svg-icons/faChevronUp';
 import { faBullhorn } from '@fortawesome/pro-solid-svg-icons/faBullhorn';
 import { faCircle } from '@fortawesome/pro-solid-svg-icons/faCircle';
@@ -34,33 +32,6 @@ import { faEllipsisV } from '@fortawesome/pro-solid-svg-icons/faEllipsisV';
 import { faThumbtack } from '@fortawesome/pro-solid-svg-icons/faThumbtack';
 import { faSort } from '@fortawesome/pro-solid-svg-icons/faSort';
 import { faQuestionCircle } from '@fortawesome/pro-solid-svg-icons/faQuestionCircle';
-
-library.add(faChevronUp);
-library.add(faBullhorn);
-library.add(faCircle);
-library.add(faCheck);
-library.add(faExclamationTriangle);
-library.add(faInfo);
-library.add(faTimes);
-library.add(faEnvelope);
-library.add(faChevronLeft);
-library.add(faChevronRight);
-library.add(faTrash);
-library.add(faCompressAlt);
-library.add(faExpandAlt);
-library.add(faSearch);
-library.add(faSpinnerThird);
-library.add(faClock);
-library.add(faGiftCard);
-library.add(faGlobe);
-library.add(faMicrophone);
-library.add(faUsers);
-library.add(faShieldCheck);
-library.add(faFileAlt);
-library.add(faEllipsisV);
-library.add(faThumbtack);
-library.add(faSort);
-library.add(faQuestionCircle);
 
 export {
   faChevronUp,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15075,7 +15075,7 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.5.4#optional!builtin<compat/typescript>":
   version: 5.5.4
-  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=5adc0c"
+  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=b45daf"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver


### PR DESCRIPTION
I looked at our bundle sizes and I've noticed that our fortawesome is occupying 2 top spots for dependencies 

From prod

![Screenshot 2024-09-24 at 4 55 07 PM](https://github.com/user-attachments/assets/fed3b3c2-e6b1-414e-ae75-ec1e3ae9af17)


We're already guarding against it the rs repo, but looks like we never did that for DS

Locally before changes 
![Screenshot 2024-09-24 at 4 55 52 PM](https://github.com/user-attachments/assets/78e53012-5b8e-4f84-b213-4f499d46d062)

Locally after changes
![Screenshot 2024-09-24 at 4 57 28 PM](https://github.com/user-attachments/assets/b5fe2191-9a91-4d79-acc0-72fb6671083f)


Shedding off about 5.4 MB
