### PR TITLE
Tertiary button style updates

### DIFF
--- a/scss/buttons.scss
+++ b/scss/buttons.scss
@@ -194,7 +194,7 @@ $primary: $ux-emerald-600;
   $btn-tertiary-hover-color: $btn-tertiary-color;
 
   $btn-tertiary-active-background: #DEDEDE;
-  $btn-tertiary-active-border: $synth-hyperlink-color;
+  $btn-tertiary-active-border: #DEDEDE;
   $btn-tertiary-active-color: $btn-tertiary-hover-color;
 
   $btn-tertiary-disabled-background: $btn-tertiary-background;
@@ -221,9 +221,12 @@ $primary: $ux-emerald-600;
 
   border-width: 2px;
 
-  &:active, &.btn-tertiary:focus {
-    box-shadow: none;
-    border-color: var(--synth-hyperlink-color);
+  &:active, &:focus {
+    @include btn-remove-bootstrap-focus-outline;
+  }
+
+  &:focus-visible {
+    @include btn-focus-outline;
   }
 
   &:focus:not(:active):not(:hover) {

--- a/scss/buttons.scss
+++ b/scss/buttons.scss
@@ -187,13 +187,13 @@ $primary: $ux-emerald-600;
 @mixin btn-tertiary {
   $btn-tertiary-background: transparent;
   $btn-tertiary-border: transparent;
-  $btn-tertiary-color: $synth-primary-cta-blue;
+  $btn-tertiary-color: #000000;
 
-  $btn-tertiary-hover-background: $btn-tertiary-background;
+  $btn-tertiary-hover-background: #F4F4F4;
   $btn-tertiary-hover-border: $btn-tertiary-border;
   $btn-tertiary-hover-color: $btn-tertiary-color;
 
-  $btn-tertiary-active-background: $btn-tertiary-background;
+  $btn-tertiary-active-background: #DEDEDE;
   $btn-tertiary-active-border: $synth-hyperlink-color;
   $btn-tertiary-active-color: $btn-tertiary-hover-color;
 
@@ -224,6 +224,10 @@ $primary: $ux-emerald-600;
   &:active, &.btn-tertiary:focus {
     box-shadow: none;
     border-color: var(--synth-hyperlink-color);
+  }
+
+  &:focus:not(:active):not(:hover) {
+    background-color: transparent;
   }
 }
 


### PR DESCRIPTION
[//]: # (
See https://www.notion.so/Expectations-for-Code-Reviews-4c261233caf64f12ab459ba090be2c50 for more best practices around how we do Code Review.
This is a default pull request template that teams can use as a starting point.
You can edit this here: docs/pull_request_template.md
)
### Related Issue(s)

Closes [ENG-227](https://linear.app/user-interviews/issue/ENG-227/tertiary-button-updates)

### Description
[//]: # (
Provide a brief description of the intent of this pull request.
Example: Allow users to search for a specific product by name.
)
Update styling on tertiary button to match [new design](https://www.figma.com/design/dmmTbSjuPXqt9m82YaewXO/Synthesis-Design-System?node-id=1637-10978&node-type=canvas&t=0A1KSHA2k434BsvO-0).

### Reviewers
[//]: # (
Indicate who your primary and secondary reviewers are, and make sure they know.
Do this AFTER you have done your own self-review.
)

Primary: Jason

Secondary: Torrence

### Manual Test plan
[//]: # (
How did you test this manually? How can your reviewer test the workflow?
If this is a bug, how can you reproduce the bug?
)

Note the tertiary button is used in the following location in rails-server:

## New Hub filters popover:

https://github.com/user-attachments/assets/f0bfb34c-ab49-48e7-a7c3-b4b0a855c508

## Domain settings:

https://github.com/user-attachments/assets/c20c081a-a376-4b23-ac8b-8ec1db6f168f

## Pre-workspace form:

https://github.com/user-attachments/assets/d00e096c-2e3d-4f09-b3e9-ed41dbcceae2

## Project collaborators modal:

https://github.com/user-attachments/assets/ac9990d1-ba9e-4dca-a314-4c8e9698aebb

