### PR TITLE
ControlButtonGroup do not set bordered if child is a DOM element

### DIFF
--- a/src/ControlButtonGroup/ControlButtonGroup.tsx
+++ b/src/ControlButtonGroup/ControlButtonGroup.tsx
@@ -36,7 +36,9 @@ function ControlButtonGroup({
       onChange: handleChangeValue,
     } : {};
 
-    if (row && child.props.bordered === undefined) {
+    const isDOMElement = typeof child.type === 'string';
+
+    if (!isDOMElement && child.props.bordered === undefined) {
       childProps.bordered = true;
     }
 

--- a/src/ControlButtonGroup/ControlButtonGroup.tsx
+++ b/src/ControlButtonGroup/ControlButtonGroup.tsx
@@ -38,7 +38,7 @@ function ControlButtonGroup({
 
     const isDOMElement = typeof child.type === 'string';
 
-    if (!isDOMElement && child.props.bordered === undefined) {
+    if (!isDOMElement && row && child.props.bordered === undefined) {
       childProps.bordered = true;
     }
 


### PR DESCRIPTION
Fixing console warning that prevented us from adding more frontend specs (since warnings make specs fail)

before
![Screenshot 2024-10-31 at 2 48 30 PM](https://github.com/user-attachments/assets/b176a188-70a2-4205-903f-01571f68e0d3)


After
![Screenshot 2024-10-31 at 2 43 10 PM](https://github.com/user-attachments/assets/f1481d15-3d5f-4751-a5e4-5d3d0ab55c1b)
