### PR TITLE
Remove copy to clipboard button default props

### DIFF
--- a/src/CopyToClipboardButton/CopyToClipboardButton.tsx
+++ b/src/CopyToClipboardButton/CopyToClipboardButton.tsx
@@ -69,10 +69,4 @@ function CopyToClipboardButton({
   );
 }
 
-CopyToClipboardButton.defaultProps = {
-  copyText: '',
-  displayText: undefined,
-  variant: ButtonVariants.NEUTRAL,
-};
-
 export default CopyToClipboardButton;


### PR DESCRIPTION
Noticed this warning in rails server so removing here.