### PR TITLE
Fix code scanning: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
 

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -16,6 +16,10 @@ on:
           - prepatch
           - prerelease
 
+permissions:
+  contents: write
+  pull-requests: write
+
 env:
   FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: push
 
+permissions:
+  contents: read
+
 env:
   FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
 

--- a/.github/workflows/prepare-hotfix.yml
+++ b/.github/workflows/prepare-hotfix.yml
@@ -1,5 +1,8 @@
 name: "Prepare hotfix"
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/prepare-hotfix.yml
+++ b/.github/workflows/prepare-hotfix.yml
@@ -14,6 +14,9 @@ jobs:
   prepare-hotfix:
     name: Prepare hotfix
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout branch
         uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test javascript
 
 on: push
 
+permissions:
+  contents: read
+
 env:
   FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
 

--- a/src/Table/Table.stories.tsx
+++ b/src/Table/Table.stories.tsx
@@ -506,7 +506,7 @@ export function TableOnCard() {
       title="Email Template Sets"
     >
       <div
-        id="Some table container"
+        id="some-table-container"
         style={{
           display: 'block',
           maxWidth: 'fit-content',
@@ -550,7 +550,7 @@ export function TableOnCardNoPadding() {
   return (
     <Card noPadding size="sm">
       <div
-        id="Some table container"
+        id="some-table-container"
         style={{
           display: 'block',
           maxWidth: 'fit-content',


### PR DESCRIPTION
Fixes lack of permissions in project workflows:
* https://github.com/user-interviews/ui-design-system/security/code-scanning/13
* https://github.com/user-interviews/ui-design-system/security/code-scanning/14
* https://github.com/user-interviews/ui-design-system/security/code-scanning/15
* https://github.com/user-interviews/ui-design-system/security/code-scanning/16
* https://github.com/user-interviews/ui-design-system/security/code-scanning/17

Fixes malformed ID code quality report:
* https://github.com/user-interviews/ui-design-system/security/quality/rules/js%2Fmalformed-html-id

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow permission scoping changes should be low impact but could break release/hotfix automation if required write scopes are missing; the Storybook `id` tweak is cosmetic/documentation-only.
> 
> **Overview**
> Adds explicit GitHub Actions `permissions` to workflows to satisfy code-scanning requirements: read-only `contents` for `lint`, `test`, and `chromatic`, and `contents`/`pull-requests` write access for `create-new-release` and the `prepare-hotfix` job.
> 
> Fixes a malformed HTML `id` in `Table.stories.tsx` by replacing `"Some table container"` with `"some-table-container"` in the card table examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d4bbd4cc48c67b579c3b4835b2f50e888d3c15b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->