### PR TITLE
Update instructions for obtaining .npmrc file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Synthesis is the official design system of [User Interviews](https://www.userint
 
 ### Initial Setup
 
-After cloning the repo, obtain a `.npmrc` file from another developer. This file contains authorization tokens for any private
+After cloning the repo, obtain a `.npmrc` file from 1password. This file contains authorization tokens for any private
 node packages.
 
 ### Available Scripts


### PR DESCRIPTION
Matching our security setup now, this secret is already in place but ensures we all access the secrets in a uniform and compliant way

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/user-interviews/codesmith/ui-design-system/pr/1443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime or build behavior is modified.
> 
> **Overview**
> Updates `README.md` initial setup instructions to direct developers to obtain the `.npmrc` from **1Password** instead of another developer, aligning onboarding with the current secrets management process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 590153bbb0c0c24d0f7c7c6fbcee7bef923a0063. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->