### PR TITLE
Add zizmor

### DIFF
--- a/.github/actions/ensure_env/action.yml
+++ b/.github/actions/ensure_env/action.yml
@@ -10,9 +10,11 @@ runs:
   using: 'composite'
   steps:
     - name: Confirm ENV
+      env:
+        ENV_KEY: ${{ inputs.env-key }}
       run: |
-        if [[ ! -v ${{ inputs.env-key }} ]]; then
-          echo Did not find ${{ inputs.env-key }} in the ENV
+        if [[ ! -v "$ENV_KEY" ]]; then
+          echo "Did not find $ENV_KEY in the ENV"
           exit 1
         fi
       shell: bash

--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -10,7 +10,7 @@ runs:
         env-key: FONTAWESOME_NPM_AUTH_TOKEN
 
     - name: Install Yarn
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
       with:
         timeout_minutes: 5
         max_attempts: 3

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -29,6 +29,6 @@ jobs:
         uses: ./.github/actions/setup_environment
 
       - name: Publish to Chromatic
-        uses: chromaui/action@v13
+        uses: chromaui/action@30047ab459164cf99ae8f097f6aa5c7ef4fcc869 # v13
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -35,7 +35,14 @@ jobs:
         uses: ./.github/actions/setup_environment
 
       - name: Bump version in package.json
-        run: yarn version ${{ github.event.inputs.version }}
+        env:
+          # Surface workflow_dispatch input as an env var so this `run:` block
+          # references "$BUMP_TYPE" instead of templating user input directly
+          # into the shell command (zizmor: template-injection). The input is
+          # already constrained by the `choice` list above, but pinning to an
+          # env var keeps the audit clean and removes the implicit trust.
+          BUMP_TYPE: ${{ github.event.inputs.version }}
+        run: yarn version "$BUMP_TYPE"
 
       - name: Extract version from package.json
         id: extract_version
@@ -48,7 +55,7 @@ jobs:
         run: git checkout -b release/v${{ steps.extract_version.outputs.version }}
 
       - name: Initialize mandatory git config
-        uses: fregante/setup-git-user@v2
+        uses: fregante/setup-git-user@024bc0b8e177d7e77203b48dab6fb45666854b35 # v2
 
       - name: Commit manifest files
         id: make-commit
@@ -62,7 +69,7 @@ jobs:
         run: git push origin release/v${{ steps.extract_version.outputs.version }}
 
       - name: Merge version update into main branch
-        uses: thomaseizinger/create-pull-request@master
+        uses: thomaseizinger/create-pull-request@955adb4634198898bc24dca0468514c63a8fc98d # 1.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -81,6 +88,10 @@ jobs:
       - name: Pack bundle tarball
         run: npm pack
 
+      # TODO(deprecated-action): actions/create-release was archived by
+      # GitHub in 2021 and receives no security or runner-version updates.
+      # Migrate to softprops/action-gh-release (hash-pinned per zizmor policy)
+      # or `gh release create` via a `run:` block. Tracking item to be filed.
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -93,7 +104,10 @@ jobs:
           draft: false
           prerelease: false
 
-      # Upload assets to the release
+      # TODO(deprecated-action): actions/upload-release-asset was archived
+      # alongside actions/create-release in 2021. softprops/action-gh-release
+      # uploads assets in the same step that creates the release, so the
+      # migration collapses these two steps into one.
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -31,11 +31,11 @@ jobs:
         run: yarn build-storybook
 
       - name: Upload
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "storybook-static"
 
       - name: Deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
         with:
           token: ${{ github.token }}

--- a/.github/workflows/prepare-hotfix.yml
+++ b/.github/workflows/prepare-hotfix.yml
@@ -12,6 +12,10 @@ on:
 
 env:
   FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
+  # Surface workflow_dispatch input as an env var so `run:` blocks can
+  # reference "$HOTFIX_VERSION" instead of templating user input directly
+  # into shell commands (zizmor: template-injection).
+  HOTFIX_VERSION: ${{ github.event.inputs.version }}
 
 jobs:
   prepare-hotfix:
@@ -30,27 +34,27 @@ jobs:
         uses: ./.github/actions/setup_environment
 
       - name: Create hotfix branch
-        run: git checkout -b hotfix/${{ github.event.inputs.version }}
+        run: git checkout -b "hotfix/$HOTFIX_VERSION"
 
       - name: Initialize mandatory git config
-        uses: fregante/setup-git-user@v2
+        uses: fregante/setup-git-user@024bc0b8e177d7e77203b48dab6fb45666854b35 # v2
 
       - name: Bump version in package.json
-        run: yarn version --new-version ${{ github.event.inputs.version }} --no-git-tag-version
+        run: yarn version --new-version "$HOTFIX_VERSION" --no-git-tag-version
 
       - name: Commit manifest files
         id: make-commit
         run: |
           git add package.json
-          git commit --message "Prepare hotfix ${{ github.event.inputs.version }}"
+          git commit --message "Prepare hotfix $HOTFIX_VERSION"
 
-          echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Publish hotfix branch
-        run: git push origin hotfix/${{ github.event.inputs.version }}
+        run: git push origin "hotfix/$HOTFIX_VERSION"
 
       - name: Merge hotfix into main branch
-        uses: thomaseizinger/create-pull-request@master
+        uses: thomaseizinger/create-pull-request@955adb4634198898bc24dca0468514c63a8fc98d # 1.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -59,7 +63,7 @@ jobs:
           title: Merge hotfix/${{ github.event.inputs.version }} into main branch
 
       - name: Merge hotfix into develop branch
-        uses: thomaseizinger/create-pull-request@master
+        uses: thomaseizinger/create-pull-request@955adb4634198898bc24dca0468514c63a8fc98d # 1.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,20 +26,23 @@ jobs:
         run: yarn test
 
       - name: Upload coverage to OtterWise
+        # NOTE: do not wrap in ${{ ... }} — `if:` is already an expression
+        # context, and an extra wrap turns the result into a non-empty string
+        # ("false") that is always truthy (zizmor: unsound-condition).
         if: >
-          ${{ vars.OTTERWISE_ENABLED == 'true' && 
-              steps.test.outcome != 'skipped' && 
-              steps.test.outcome != 'cancelled' }}
-        uses: getOtterWise/github-action@v1
+          vars.OTTERWISE_ENABLED == 'true' &&
+          steps.test.outcome != 'skipped' &&
+          steps.test.outcome != 'cancelled'
+        uses: getOtterWise/github-action@739d7617d927fde5c1694f4c18b08a902948bc71 # v1
         with:
           token: ${{ secrets.OTTERWISE_TOKEN }}
 
       - name: Upload coverage to Coveralls
         if: >
-          ${{ vars.COVERALLS_ENABLED == 'true' &&  
-              steps.test.outcome != 'skipped' && 
-              steps.test.outcome != 'cancelled' }}
-        uses: coverallsapp/github-action@v2
+          vars.COVERALLS_ENABLED == 'true' &&
+          steps.test.outcome != 'skipped' &&
+          steps.test.outcome != 'cancelled'
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2
         with:
           # github-token: ${{ secrets.GITHUB_TOKEN }}
           format: lcov
@@ -47,18 +50,18 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: >
-          ${{ vars.CODECOV_ENABLED == 'true' &&
-              steps.test.outcome != 'skipped' && 
-              steps.test.outcome != 'cancelled' }}
-        uses: codecov/codecov-action@v5
+          vars.CODECOV_ENABLED == 'true' &&
+          steps.test.outcome != 'skipped' &&
+          steps.test.outcome != 'cancelled'
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov
         if: >
-          ${{ vars.CODECOV_ENABLED == 'true' && 
-              steps.test.outcome != 'skipped' && 
-              steps.test.outcome != 'cancelled' }}
-        uses: codecov/test-results-action@v1
+          vars.CODECOV_ENABLED == 'true' &&
+          steps.test.outcome != 'skipped' &&
+          steps.test.outcome != 'cancelled'
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,68 @@
+name: Zizmor (GitHub Actions audit)
+
+# Audits .github/workflows and .github/actions for known-dangerous patterns
+# (template injection, excessive permissions, dangerous triggers, unpinned
+# uses, cache poisoning, etc.) and uploads results to the Security tab.
+#
+# See https://github.com/zizmorcore/zizmor and the audit reference at
+# https://docs.zizmor.sh/audits/ for what each finding means.
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+      - .github/zizmor.yml
+  push:
+    branches: [main]
+  schedule:
+    # Weekly catch-up so new audits added by zizmor releases surface even
+    # on workflows that aren't being actively edited.
+    - cron: '17 9 * * 1'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: zizmor-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Audit GitHub Actions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      # Pass 1: advisory run. Audits at every severity, uploads results to the
+      # Security tab, and never fails the workflow. This is how medium/low
+      # findings (e.g. `artipacked` / persist-credentials, unpinned-uses on
+      # internal actions) stay visible without blocking PRs.
+      - name: Run zizmor (advisory — all severities → Security tab)
+        continue-on-error: true
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          # Online audits (impostor-commit, ref-confusion) call the GitHub API
+          # against each `uses:` repo. The default workflow `GITHUB_TOKEN` is
+          # repo-scoped and can't read our private same-org actions, which
+          # makes those audits crash fatally with a 404/401 instead of soft-
+          # skipping. Run them locally with `GH_TOKEN=$(gh auth token) zizmor
+          # .github/`. Follow-up: provision a GitHub App / fine-grained PAT
+          # with `Contents: Read` on user-interviews/* and re-enable.
+          online-audits: false
+
+      # Pass 2: enforcement run. Only high-severity findings are reported, and
+      # this step IS allowed to fail the workflow. `advanced-security: false`
+      # avoids a duplicate SARIF upload (pass 1 already uploaded the full set).
+      - name: Run zizmor (gate — fail the workflow on high-severity findings)
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          online-audits: false
+          min-severity: high
+          advanced-security: false

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "actions/*": ref-pin
+        "user-interviews/*": ref-pin
+        "*": hash-pin # prefer hash-pin for security with 3rd party actions


### PR DESCRIPTION

Same setup as rails-server. See first CI run to see how the build would fail without the changes
https://github.com/user-interviews/ui-design-system/actions/runs/25330264746/job/74261864130

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/user-interviews/codesmith/ui-design-system/pr/1444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes multiple CI/release workflows (version bump, hotfix, coverage uploads) and pins third-party actions by SHA; failures would impact automation but not runtime code.
> 
> **Overview**
> Adds a new `zizmor` workflow that audits `.github/workflows` and `.github/actions` (advisory SARIF upload plus a high-severity enforcement pass) and introduces `.github/zizmor.yml` to enforce pinning policies.
> 
> Hardens existing workflows to satisfy the audit: pins third-party `uses:` to commit SHAs, fixes unsafe `if:` expression wrapping, and reduces template-injection risk by routing `workflow_dispatch` inputs through env vars (plus a small fix to `ensure_env` to check a quoted env key).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0e9b2b336772b64e752729514d1bcad13d9792e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->