### PR TITLE
Storybook housekeeping - Stories and add TSdocs

### DIFF
--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -5,30 +5,18 @@ import RBAccordion from 'react-bootstrap/Accordion';
 
 type AccordionProps = {
   children: React.ReactNode;
-  /**
-    The current active key that corresponds to the currently expanded accordion
-  */
+  /** Controlled open panel(s); values must match each `AccordionItem` `eventKey`. Use `string[]` when `alwaysOpen`. Forwarded to React Bootstrap `Accordion`. */
   activeKey?: string | string[];
-  /**
-    Allow accordion items to stay open when another item is opened
-  */
+  /** Multiple panels may stay open; pair with `activeKey` / `defaultActiveKey` as arrays when needed. Forwarded to React Bootstrap `Accordion`. */
   alwaysOpen?: boolean;
-  /**
-    Sets a custom element for this component
-  */
+  /** Root element type. Forwarded to React Bootstrap `Accordion`. */
   as?: React.ElementType;
-  /**
-    The default active key that is expanded on start
-  */
+  /** Initial open key(s) when uncontrolled; ignored if `activeKey` is set. */
   defaultActiveKey?: string | string[];
-  /**
-    Renders accordion edge-to-edge with its parent container
-  */
+  /** Edge-to-edge (flush) styling. Forwarded to React Bootstrap `Accordion`. */
   flush?: boolean;
   UNSAFE_className?: string;
-  /**
-    Callback fired when the active item changes
-  */
+  /** Fires when the expanded item changes. Forwarded to React Bootstrap `Accordion`. */
   onSelect?: () => void;
 };
 

--- a/src/Accordion/AccordionCollapse.tsx
+++ b/src/Accordion/AccordionCollapse.tsx
@@ -8,9 +8,7 @@ import './AccordionCollapse.scss';
 type AccordionCollapseProps = {
   variant?: string;
   children: React.ReactNode;
-  /**
-   A unique key used to control this item's collapse/expand.
-   */
+  /** Must match this item’s `AccordionItem` and `AccordionToggle` `eventKey`. Forwarded to React Bootstrap `AccordionCollapse`. */
   eventKey: string;
   UNSAFE_className?: string;
 };

--- a/src/Accordion/AccordionItem.tsx
+++ b/src/Accordion/AccordionItem.tsx
@@ -6,16 +6,13 @@ import RBAccordionItem from 'react-bootstrap/AccordionItem';
 import './AccordionItem.scss';
 
 type AccordionItemProps = {
-  /**
-    Sets a custom element for this component
-  */
+  /** Wrapper element type. Forwarded to React Bootstrap `AccordionItem`. */
   as?: React.ElementType;
-  /**
-    Removes border from accordion item
-  */
+  /** Removes the item border. */
   borderless?: boolean;
   UNSAFE_className?: string;
   children: React.ReactNode;
+  /** Must match this item’s `AccordionToggle` and `AccordionCollapse` `eventKey`. Forwarded to React Bootstrap `AccordionItem`. */
   eventKey: string;
   variant?: string;
 };

--- a/src/Accordion/AccordionToggle.tsx
+++ b/src/Accordion/AccordionToggle.tsx
@@ -12,28 +12,26 @@ import { isEventKeyActive } from './utils';
 import './AccordionToggle.scss';
 
 type AccordionToggleProps = {
+  /** Bottom border on the header inner container. */
   borderBottom?: boolean;
-  /**
-   Set Chevron icon to open/close quarter turn from lateral
-  */
+  /** Chevron at 90° at rest; open/close rotation differs from default. */
   chevronLateral?: boolean;
-  /**
-   Aligns the Chevron icon to the left
-  */
+  /** Chevron before content; hides the trailing chevron. */
   chevronLeft?: boolean;
-  /**
-   Aligns the Chevron icon to the right (default)
-  */
+  /** Trailing chevron (default `true`). */
   chevronRight?: boolean;
   children?: React.ReactNode;
+  /** Shown only while this panel is collapsed. */
   collapsedText?: string;
-  /**
-   A unique key used to control this item's collapse/expand.
-   */
+  /** Disables the header button and mutes appearance. */
   disabled?: boolean;
+  /** Must match this item’s `AccordionItem` and `AccordionCollapse` `eventKey`. */
   eventKey: string;
+  /** Tighter horizontal padding on the header. */
   flush?: boolean;
+  /** Parenthetical text after the title. */
   helperText?: string;
+  /** Font Awesome icon definition rendered before the title. */
   leadingIcon?: object;
   title?: string;
   UNSAFE_className?: string;

--- a/src/Alert/Alert.tsx
+++ b/src/Alert/Alert.tsx
@@ -91,31 +91,26 @@ const getAlertClassName = (type: MessageType) => {
 };
 
 type AlertProps = {
-  /**
-   Creates a CTA button on the Alert
-  */
+  /** `{ url, content }` renders a styled anchor; any other `ReactNode` is rendered in the action area as-is. */
   action?:
     | {
         url: string;
         content: React.ReactNode;
       }
     | React.ReactNode;
-  /**
-    Specifies where to open the linked document
-  */
+  /** `target` on the action anchor when `action` is `{ url, content }` (e.g. `_blank`). */
   actionTarget?: string;
-  /**
-   Determines whether the Alert will disappear automatically
-  */
+  /** When true and `onDismiss` is set, calls `onDismiss` after a delay.*/
   autoDismiss?: boolean;
+  /** Passed into `onDismiss` from the close button and from auto-dismiss. */
   id?: string;
   message: string | React.ReactNode;
+  /** Removes the type-colored left border (`borderLeft: none`). */
   removeBorderLeft?: boolean;
   title?: string;
-  /**
-   One of the MessageTypes
-  */
+  /** Variant and icon (`MessageTypes`) */
   type: MessageType;
+  /** Renders the close control; combined with `autoDismiss`, also invoked after the timeout. */
   onDismiss?: (arg0?: string) => void;
 };
 

--- a/src/Avatar/Avatar.tsx
+++ b/src/Avatar/Avatar.tsx
@@ -7,13 +7,21 @@ import { uiModClassName } from '../Styles/classNames';
 import './Avatar.scss';
 
 type AvatarProps = {
+  /** Sets `aria-hidden` on the root (default `false`). */
   ariaHidden?: boolean;
+  /** When set, adds a `ui-mod` class derived from `id` for alternate circle colors. */
   colorId?: string | number;
+  /** Image URL; on load error, shows `initials` instead. */
   image?: string;
+  /** Initials shown when there is no `image` or the image fails to load. */
   initials: string;
+  /** Larger circle and alert dot (`Avatar--large`; default `false`). */
   large?: boolean;
+  /** `alt` text for the image when `image` is used (default `''`). */
   name?: string;
+  /** Renders the red corner badge (default `false`). */
   showAlert?: boolean;
+  /** Wraps the avatar content in a new-tab link when set. */
   url?: string;
 };
 

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -32,9 +32,13 @@ export enum ButtonVariants {
 }
 
 export type ButtonProps = RBButtonProps & {
+  /** Spinner replaces `children`; also forces `disabled` and `aria-disabled`. */
   isLoading?: boolean;
+  /** Renders before `children` when not `isLoading`. */
   leadingIcon?: IconDefinition;
+  /** Shown beside the spinner while `isLoading` (default `Loading...`). */
   loadingText?: string;
+  /** Renders after `children` when not `isLoading`. */
   trailingIcon?: IconDefinition;
 };
 

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -20,18 +20,29 @@ export const CardSizes = {
 
 type ElementProps = DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
 
+/** Root node is `elementType`; standard HTML attributes spread onto it via `ElementProps`. */
 type CardProps = {
   children?: ReactNode;
   className?: string;
+  /** Inserts an `hr` before `subTitle`/`children` and `Card--divided` (pulls title bottom margin when `title` is present). */
   divided?: boolean;
+  /** Outer element tag name for `createElement` (default `'section'`). */
   elementType?: string;
+  /** Shown beside `title` in the header row. */
   helperText?: ReactNode;
+  /** Swaps the body for `loadingSkeleton` or the default skeleton (default `false`). */
   isLoading?: boolean;
+  /** Custom loading UI; used only when `isLoading`. */
   loadingSkeleton?: ReactNode;
+  /** Paragraph skeleton groups in the default loading layout (default `1`). */
   loadingSkeletonParagraphCount?: number;
+  /** Removes outer padding (`Card--no-padding`; default `false`). */
   noPadding?: boolean;
+  /** Responsive max width via `Card--{size}` (`CardSizes` / `'xs' | 'sm' | 'md' | 'lg'`). */
   size?: 'xs' | 'sm' | 'md' | 'lg';
+  /** Optional `h3` after the optional divider, before `children`. */
   subTitle?: ReactNode;
+  /** Optional `h2` header row; enables `helperText` in that row. */
   title?: ReactNode;
 } & ElementProps;
 

--- a/src/ControlButtonGroup/ControlButtonGroup.tsx
+++ b/src/ControlButtonGroup/ControlButtonGroup.tsx
@@ -6,10 +6,15 @@ export const ORIENTATIONS = {
 } as const;
 
 type ControlButtonGroupProps = {
+  /** Receives each child’s `value` and returns whether that option should appear selected. */
   childChecked: (...args: unknown[]) => boolean;
+  /** Inputs (or similar) with a `value` prop; the group may `cloneElement` to inject `checked` / `onChange` / `bordered`. */
   children: React.ReactNode;
+  /** Becomes each child’s `onChange` when `onChange` is set; should handle the change event from the control. */
   handleChangeValue: React.ChangeEventHandler<HTMLInputElement>;
+  /** `'row'` vs `'column'` (`ORIENTATIONS`, default `column`); in `'row'`, sets `bordered` on composite children if unset. */
   orientation?: (typeof ORIENTATIONS)[keyof typeof ORIENTATIONS];
+  /** When defined, controlled mode: clones pass `checked` from `childChecked` and `onChange` from `handleChangeValue`. When omitted, children are not augmented. */
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
 };
 

--- a/src/DateTimePicker/DateTimePicker.tsx
+++ b/src/DateTimePicker/DateTimePicker.tsx
@@ -35,23 +35,39 @@ const popperContainerDocumentBody = ({
   children?: React.ReactNode;
 }) => createPortal(children, document.body);
 
+/** String-driven `react-datepicker` wrapper; values round-trip via date-fns using `dateFormat` / `timeFormat`. */
 export type DateTimePickerProps = {
+  /** Shows clear UI; when cleared, calls `onChangeDate({ startDate: null, startTime: null })` if `onChangeDate` is set (default `false`). */
   isClearable?: boolean;
+  /** Current date string; kept in sync when this prop changes (`''` default). */
   date?: string;
+  /** date-fns format for the date segment (defaults to `ISO_DATE_FORMAT_FNS` in this file: `yyyy-MM-dd`). */
   dateFormat?: string;
+  /** Disables opening/editing the picker. */
   disabled?: boolean;
   id?: string;
+  /** Class on `PickerEnforcedInput` when `showPickerEnforcedInput` (`form-control` default). */
   inputClassName?: string;
+  /** Upper bound forwarded to `react-datepicker`. */
   maxDate?: Date;
+  /** Lower bound forwarded to `react-datepicker`. */
   minDate?: Date;
   name?: string;
+  /** Month/year dropdowns on the calendar (`showMonthDropdown` / `showYearDropdown`). */
   showMonthAndYearSelects?: boolean;
+  /** Uses `PickerEnforcedInput` and a localized pattern token (`P`) for `dateFormat` instead of free typing. */
   showPickerEnforcedInput?: boolean;
+  /** Enables time UI and parses `date` + `time` together. */
   showTimeSelect?: boolean;
+  /** Time string when `showTimeSelect`; synced when this prop changes (`''` default). */
   time?: string;
+  /** date-fns format for the time segment when `showTimeSelect` (default `hh:mm aa`). */
   timeFormat?: string;
+  /** Portals the calendar popper to `document.body` with modal stacking styles. */
   isWithinModal?: boolean;
+  /** On calendar close, valid picks yield `{ startDate, startTime }` strings; with `isClearable`, clear/invalid paths can pass `null` fields. */
   onChangeDate?: (...args: unknown[]) => unknown;
+  /** Called with an `Error` if parsing fails when the calendar closes. */
   onDateParseError?: (...args: unknown[]) => unknown;
 };
 

--- a/src/Drawer/Drawer.tsx
+++ b/src/Drawer/Drawer.tsx
@@ -31,16 +31,26 @@ export const DrawerSizes = {
 } as const;
 
 type DrawerProps = {
+  /** Top padding for fixed nav clearance (`Drawer--behind-nav`; default `true`). */
   behindNav?: boolean;
+  /** Typically `DrawerHeader`, `DrawerBody`, and `DrawerFooter`. */
   children?: React.ReactNode;
   className?: string;
+  /** When true, clicking the dimmed overlay calls `onRequestClose` (default `true`). */
   closeOnOverlayClick?: boolean;
+  /** Initial expanded width when `expandable` (`false` default). */
   defaultExpanded?: boolean;
+  /** Enables expand/collapse control via `ExpandContext` (`false` default). */
   expandable?: boolean;
+  /** Renders the backdrop and toggles body scroll lock (`Drawer--open`; default `true`). */
   hasBackgroundOverlay?: boolean;
+  /** Slide edge (`ORIENTATION_LEFT` / `ORIENTATION_RIGHT`; default `right`). */
   orientation?: typeof ORIENTATION_LEFT | typeof ORIENTATION_RIGHT;
+  /** Width preset from `DrawerSizes` (default `sm`). */
   size?: (typeof DrawerSizes)[keyof typeof DrawerSizes];
+  /** Drives open/closed presentation and escape key handling while true. */
   visible: boolean;
+  /** Escape (when open), overlay (when `closeOnOverlayClick`), and header close should call this. */
   onRequestClose: (...args: unknown[]) => unknown;
 };
 

--- a/src/Drawer/DrawerFooter.tsx
+++ b/src/Drawer/DrawerFooter.tsx
@@ -8,17 +8,29 @@ import './DrawerFooter.scss';
 
 type DrawerFooterProps = {
   children?: React.ReactNode;
+  /** Primary `Button` `isLoading`. */
   isPrimaryActionLoading?: boolean;
+  /** Secondary `Button` `isLoading`. */
   isSecondaryActionLoading?: boolean;
+  /** Primary `Button` `disabled`. */
   primaryActionDisabled?: boolean;
+  /** Primary `Button` `leadingIcon`. */
   primaryActionIcon?: IconDefinition;
+  /** Primary `Button` `loadingText` while loading. */
   primaryActionLoadingText?: string;
+  /** Primary `Button` label. */
   primaryActionText?: string;
+  /** Primary `Button` `variant`. */
   primaryActionVariant?: string;
+  /** Secondary transparent `Button` `disabled`. */
   secondaryActionDisabled?: boolean;
+  /** Secondary `Button` `loadingText` while loading. */
   secondaryActionLoadingText?: string;
+  /** Secondary `Button` label. */
   secondaryActionText?: string;
+  /** Renders the primary button only when set. */
   onPrimaryAction?: () => void;
+  /** Renders the secondary button only when set. */
   onSecondaryAction?: () => void;
 };
 

--- a/src/Drawer/DrawerHeader.tsx
+++ b/src/Drawer/DrawerHeader.tsx
@@ -10,8 +10,10 @@ import { ExpandContext } from './Drawer';
 import './DrawerHeader.scss';
 
 type DrawerHeaderProps = {
+  /** Bottom border on the header row (`true` default). */
   bordered?: boolean;
   title?: ReactNode;
+  /** Close icon; usually the same callback passed to `Drawer`. */
   onRequestClose: (...args: unknown[]) => unknown;
 };
 

--- a/src/EmptyState/EmptyState.tsx
+++ b/src/EmptyState/EmptyState.tsx
@@ -9,11 +9,17 @@ import './EmptyState.scss';
 
 export interface EmptyStateProps {
   className?: string;
+  /** Lets inner content span wider than the default `max-width` (`false` default). */
   fullWidth?: boolean;
+  /** Illustration URL; `<img>` uses `alt=""`. */
   image?: string;
+  /** Top spacing preset on the outer wrapper (`sm` default). */
   marginTop?: 'sm' | 'md' | 'lg' | 'none';
+  /** CTA area below the subtitle (e.g. a `Button`). */
   primaryAction?: ReactNode;
+  /** Centered `Text` body under the title. */
   subtitle?: string | ReactNode;
+  /** Centered `Heading` (level 4, small) when provided. */
   title?: ReactNode;
 }
 

--- a/src/Form/Form.tsx
+++ b/src/Form/Form.tsx
@@ -8,9 +8,13 @@ export type FormProps = {
   action?: string;
   children?: React.ReactNode;
   className?: string;
+  /** Hidden input `name` for CSRF; paired with `CSRFToken`, omitted when `method` is `GET`. */
   CSRFParam?: string;
+  /** Hidden input `value` for CSRF; paired with `CSRFParam`, omitted when `method` is `GET`. */
   CSRFToken?: string;
+  /** Required `id` on the `<form>`. */
   id: string;
+  /** `GET` submits as GET and skips CSRF/`_method` fields; other values render `<form method="POST">` and, when this prop is set, a hidden `_method` carrying the verb. */
   method?: string;
   name?: string;
   onSubmit?: React.FormEventHandler<HTMLFormElement>;

--- a/src/FormGroup/FormGroup.tsx
+++ b/src/FormGroup/FormGroup.tsx
@@ -38,26 +38,38 @@ function buildErrorMessage(errors, label) {
 }
 
 export type FormGroupProps = {
+  /** Bordered container styling (`FormGroup--bordered`). */
   bordered?: boolean;
   children?: React.ReactNode;
   className?: string;
+  /** Shows the invalid feedback region when `errors` resolves to a message (`true` default). */
   displayErrorText?: boolean;
-  // For accessibility purposes, FormGroups with radio or checkbox groups
-  // should be rendered as a <fieldset> element.
-  // All other FormGroups will be rendered as a normal <div> by default.
+  /** `fieldset` + `InputLegend` for grouped radios/checkboxes; `div` + `InputLabel` otherwise (`div` default). */
   elementType?: 'div' | 'fieldset';
+  /** RHF `FieldErrors` map, a single `FieldError`, or keyed messages; resolved with `inputKey` (default `''`). */
   // oxlint-disable-next-line typescript/no-explicit-any
   errors?: { [key: string]: React.ReactNode } | FieldErrors<any> | FieldError;
+  /** Helper line under the label and above the controls. */
   helperText?: React.ReactNode;
+  /** Root wrapper `id`. */
   id?: string;
+  /** Horizontal label/control layout (`FormGroup--inline`). */
   inline?: boolean;
+  /** Selects `errors[inputKey]` (falls back to `''`) for `buildErrorMessage` / `id="form-errors-…"`. */
   inputKey?: string;
+  /** Label or legend text when paired with `elementType`. */
   label?: React.ReactNode;
+  /** Class forwarded to `InputLabel` / `InputLegend`. */
   labelClassName?: string;
+  /** Secondary line on the label component. */
   labelHelperText?: string;
+  /** `htmlFor` on `InputLabel` when `elementType` is `div`. */
   labelHtmlFor?: string;
+  /** Tooltip content on the label component. */
   labelTooltip?: React.ReactNode;
+  /** Drops default vertical margin (`FormGroup--no-margin`). */
   noMargin?: boolean;
+  /** Marks the label/legend as required. */
   required?: boolean;
 };
 

--- a/src/IconButton/IconButton.tsx
+++ b/src/IconButton/IconButton.tsx
@@ -58,16 +58,19 @@ export const IconButtonActions = {
 
 export type IconButtonProps = (
   | {
+      /** Preset icon + default `aria-label` (override label with `ariaLabel`). */
       action: keyof typeof IconButtonActions;
       ariaLabel?: string;
       icon?: never;
     }
   | {
       action?: never;
+      /** Required when not using `action`. */
       ariaLabel: string;
       icon: IconDefinition;
     }
 ) & {
+  /** `sm` (default) or `lg` icon button sizing. */
   size?: 'sm' | 'lg';
 } & ButtonProps;
 

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -13,14 +13,22 @@ type InputElementProps = React.DetailedHTMLProps<
 
 export type InputProps = InputElementProps & {
   disabled?: boolean;
+  /** Required `id` on the native `<input>`. */
   id: string;
+  /** Icon in the leading `input-group-text`. */
   leadingIcon?: IconDefinition;
+  /** Required `name` on the native `<input>`. */
   name: string;
   placeholder?: string;
+  /** Icon after the field; pair with `trailingIconOnClick` for a button, otherwise decorative. */
   trailingIcon?: IconDefinition;
+  /** `aria-label` on the trailing icon button when `trailingIconOnClick` is set. */
   trailingIconLabel?: string;
+  /** When set with `trailingIcon`, wraps the icon in a clickable trailing control. */
   trailingIconOnClick?: (...args: unknown[]) => unknown;
+  /** `type` on that trailing control (`button` vs `submit`; default `button`). */
   trailingIconOnClickSubmit?: boolean;
+  /** Static suffix text after the input (layout class adjusts for `type="number"`). */
   trailingText?: string;
   type?: string;
   value?: string;

--- a/src/InputLabel/InputLabel.tsx
+++ b/src/InputLabel/InputLabel.tsx
@@ -13,10 +13,15 @@ type LabelProps = React.DetailedHTMLProps<
 
 export type InputLabelProps = {
   className?: string;
+  /** Shown in parentheses after the label text. */
   labelHelperText?: React.ReactNode;
+  /** Passed to `htmlFor` to associate with an input `id`. */
   labelHtmlFor?: string;
+  /** Appends “(Required)” helper copy. */
   required?: boolean;
+  /** Primary label text. */
   text: React.ReactNode;
+  /** Renders a trailing `Tooltip` with right placement. */
   tooltipText?: React.ReactNode;
 } & LabelProps;
 

--- a/src/InputLegend/InputLegend.tsx
+++ b/src/InputLegend/InputLegend.tsx
@@ -13,9 +13,13 @@ type LegendProps = React.DetailedHTMLProps<
 
 export type InputLegendProps = {
   className?: string;
+  /** Shown in parentheses after the legend text. */
   labelHelperText?: React.ReactNode;
+  /** Appends “(Required)” helper copy. */
   required?: boolean;
+  /** Primary legend text. */
   text: React.ReactNode;
+  /** Renders a trailing `Tooltip` with right placement. */
   tooltipText?: React.ReactNode;
 } & LegendProps;
 

--- a/src/LoadingOverlay/LoadingOverlay.tsx
+++ b/src/LoadingOverlay/LoadingOverlay.tsx
@@ -8,12 +8,18 @@ import { faSpinnerThird } from '../font_awesome/solid';
 import './LoadingOverlay.scss';
 
 type LoadingOverlayProps = {
+  /** Modifier for vertically centering content with overflow handling. */
   contentCenterOverflow?: boolean;
+  /** Aligns overlay content toward the top. */
   contentTop?: boolean;
+  /** `data-testid` on the root (`LoadingOverlay` default). */
   dataTestid?: string;
   header?: string;
+  /** Secondary line with `overlay--text` styling. */
   text?: string;
+  /** Class on the `text` paragraph. */
   textClassName?: string;
+  /** When false, root uses `display: none` instead of relying on CSS alone (`true` default). */
   visible?: boolean;
 };
 

--- a/src/LoadingSkeleton/LoadingSkeleton.tsx
+++ b/src/LoadingSkeleton/LoadingSkeleton.tsx
@@ -11,41 +11,20 @@ import colors from '../Styles/colors/palette';
 import './LoadingSkeleton.scss';
 
 export type LoadingSkeletonProps = SkeletonProps & {
-  /**
-  The border radius of the skeleton.
-  */
+  /** Corner radius on each bar (`4px` default). */
   borderRadius?: number | string;
-  /**
-  Makes the skeleton circular by setting border-radius to 50%.
-  */
+  /** Forces a circular skeleton (`border-radius: 50%`). */
   circle?: boolean;
   className?: string;
-  /**
-  A custom class name for the `<span>` that wraps the individual skeleton elements.
-  */
+  /** Extra class merged onto the library’s skeleton container span. */
   containerClassName?: string;
-  /**
-  A string that is added to the container element as a data-testid attribute.
-  Use it with screen.getByTestId('...') from React Testing Library.
-  */
+  /** `data-testid` on the skeleton container for RTL queries. */
   containerTestId?: string;
-  /**
-  The number of lines of skeletons to render. If count is a decimal number like 3.5,
-  three full skeletons and one half-width skeleton will be rendered.
-  */
+  /** Number of skeleton rows; */
   count?: number;
-  /**
-  The height of the skeleton.
-  */
   height?: number | string;
-  /**
-  By default, a `<br />` is inserted after each skeleton so that each skeleton gets its own line.
-  When inline is true, no line breaks are inserted.
-  */
+  /** Skips `<br />` between repeated skeletons (`false` default). */
   inline?: boolean;
-  /**
-  The width of the skeleton.
-  */
   width?: number | string;
 };
 

--- a/src/Main/Main.tsx
+++ b/src/Main/Main.tsx
@@ -13,9 +13,11 @@ type ElementProps = React.DetailedHTMLProps<
 >;
 
 type MainProps = ElementProps & {
+  /** Root element type (`main` default). */
   as?: React.ElementType;
   children?: React.ReactNode;
   className?: string;
+  /** Forwarded to React Bootstrap `Container` (`true` default). */
   fluid?: ReactBootstrapContainerProps['fluid'];
   id?: string;
 };

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -13,6 +13,7 @@ export const MODAL_SIZES = {
 
 type ModalProps = {
   className?: string;
+  /** Adds `ReactModal--medium` / `ReactModal--large` class names. */
   size?: (typeof MODAL_SIZES)[keyof typeof MODAL_SIZES];
 } & ReactModalProps;
 

--- a/src/Modal/ModalFooter.tsx
+++ b/src/Modal/ModalFooter.tsx
@@ -8,9 +8,13 @@ import './ModalFooter.scss';
 
 type ModalFooterProps = {
   children?: React.ReactNode;
+  /** Disables the dismiss control when `onRequestClose` is set. */
   closingIsDisabled?: boolean;
+  /** Cancel button label (`Cancel` default). */
   dismissButtonText?: string;
+  /** Sticky footer positioning class (`false` default). */
   isSticky?: boolean;
+  /** Invoked with no arguments on dismiss click (not an event handler). */
   onRequestClose?: (...args: unknown[]) => unknown;
 };
 

--- a/src/Modal/ModalHeader.tsx
+++ b/src/Modal/ModalHeader.tsx
@@ -8,14 +8,23 @@ import { faExclamationTriangle } from '../font_awesome/solid';
 import './ModalHeader.scss';
 
 type ModalHeaderProps = {
+  /** When set, replaces the built-in `h1` / subtitle layout entirely. */
   children?: React.ReactNode;
+  /** Disables the close button when `onRequestClose` is set. */
   closingIsDisabled?: boolean;
+  /** Secondary heading under `title` when not using `children`. */
   subtitle?: string;
+  /** Primary heading when not using `children`. */
   title?: React.ReactNode;
+  /** Extra classes merged onto the default `h1`. */
   titleClass?: string;
+  /** `id` on the default `h1` for `aria-labelledby`. */
   titleId?: string;
+  /** When truthy, shows a warning icon with this string as its `className`. */
   variant?: string;
+  /** Sticky header positioning (`false` default). */
   isSticky?: boolean;
+  /** Invoked with no arguments on close click (not an event handler). */
   onRequestClose?: (...args: unknown[]) => unknown;
 };
 

--- a/src/Pill/Pill.tsx
+++ b/src/Pill/Pill.tsx
@@ -20,10 +20,15 @@ export const PILL_COLORS = {
 
 type PillProps = {
   children?: React.ReactNode;
+  /** Palette token from `PILL_COLORS` (`blue` default). */
   color?: (typeof PILL_COLORS)[keyof typeof PILL_COLORS];
+  /** Leading FA icon. */
   icon?: IconDefinition;
+  /** Passed to `onClose` for keyed removal. */
   id?: string;
+  /** Primary label content (also used in close `aria-label`). */
   text?: React.ReactNode;
+  /** Renders a close button; receives `id` when clicked. */
   onClose?: (...args: unknown[]) => unknown;
 };
 

--- a/src/ProfileCell/ProfileCell.tsx
+++ b/src/ProfileCell/ProfileCell.tsx
@@ -10,13 +10,21 @@ import ProfileCellSkeleton from './ProfileCellSkeleton';
 import './ProfileCell.scss';
 
 type ProfileCellProps = {
+  /** Forwarded to `Avatar` for background hue. */
   colorId?: string | number;
+  /** Swaps the cell for `ProfileCellSkeleton`. */
   isLoading?: boolean;
+  /** Larger avatar + typography (`ProfileCell--large`). */
   large?: boolean;
+  /** Inline `max-width` on the text column (`none` when unset). */
   maxWidth?: string;
+  /** Forwarded to `Avatar` alert dot. */
   showAlert?: boolean;
+  /** Secondary line under the name (falls back to a blank placeholder). */
   subtitle?: React.ReactNode;
+  /** Icon beside the name heading. */
   trailingIcon?: IconDefinition;
+  /** Participant display data; `imageUrl` or `profilePictureUrl` feeds the avatar photo. */
   user: {
     facebookProfileUrl?: string;
     imageUrl?: string;

--- a/src/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/src/RadioButtonGroup/RadioButtonGroup.tsx
@@ -7,10 +7,15 @@ import ControlButtonGroup, { ORIENTATIONS } from '../ControlButtonGroup';
 import './RadioButtonGroup.scss';
 
 type RadioButtonGroupProps = {
+  /** Each child should expose a `value` prop for selection state. */
   children: React.ReactNode;
+  /** Stretches row layout when `orientation` is `row`. */
   fullWidth?: boolean;
+  /** Column vs row grouping (`ORIENTATIONS`, default `column`). */
   orientation?: (typeof ORIENTATIONS)[keyof typeof ORIENTATIONS];
+  /** Selected option’s `value` for `checked` state. */
   value?: number | string | boolean;
+  /** Receives `event.target.value` from the active radio. */
   onChange?: (...args: unknown[]) => unknown;
 };
 

--- a/src/RichTextEditor/RichTextEditorMenuBar.tsx
+++ b/src/RichTextEditor/RichTextEditorMenuBar.tsx
@@ -19,8 +19,11 @@ import type { Editor } from '@tiptap/core';
 import './RichTextEditorMenuBar.scss';
 
 type RichTextEditorMenuBarProps = {
+  /** Subset of `RichTextEditorActions` to render (must align with parent editor extensions). */
   availableActions: (typeof RichTextEditorActions)[keyof typeof RichTextEditorActions][];
+  /** Live TipTap instance for command handlers. */
   editor: Editor;
+  /** Disables every control when false (`true` default). */
   editable?: boolean;
 };
 

--- a/src/Steps/Step.tsx
+++ b/src/Steps/Step.tsx
@@ -10,8 +10,10 @@ type DivProps = React.DetailedHTMLProps<
 >;
 
 type StepProps = DivProps & {
+  /** Marker inside the circle; when a string, also used in `Step--{circleText}` modifier classes. */
   circleText?: string | React.ReactNode;
   className?: string;
+  /** Label beside the circle. */
   text?: string | React.ReactNode;
 };
 

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -12,8 +12,11 @@ type TableElementProps = React.DetailedHTMLProps<
 export type TableProps = TableElementProps & {
   children?: React.ReactNode;
   className?: string;
+  /** Swaps children for `TableLoadingSkeleton`. */
   isLoading?: boolean;
+  /** Pixel widths for each skeleton column (see `TableLoadingSkeleton` default). */
   loadingColumns?: number[];
+  /** Skeleton row count (`7` default on the skeleton). */
   loadingRows?: number;
 };
 

--- a/src/Table/TableCell.tsx
+++ b/src/Table/TableCell.tsx
@@ -10,18 +10,29 @@ type TableCellElementProps = React.DetailedHTMLProps<
 >;
 
 type TableCellProps = TableCellElementProps & {
+  /** Right-aligns cell content. */
   alignRight?: boolean;
   children?: React.ReactNode;
   className?: string;
+  /** Tighter padding preset. */
   compact?: boolean;
+  /** Renders `<th>` instead of `<td>` and adjusts sticky corner styling. */
   header?: boolean;
+  /** Pixel `max-width` style on `<td>` rows. */
   maxWidth?: number;
+  /** Pixel `min-width` style on `<td>` rows. */
   minWidth?: number;
+  /** Drops bottom border on the cell. */
   removeBorderBottom?: boolean;
+  /** Enables sticky column classes (pair with `stickyLeft` / `stickyRight`). */
   stickyColumn?: boolean;
+  /** Pixel offset for left/right sticky positioning. */
   stickyColumnOffsetX?: number;
+  /** Sticky column anchored left. */
   stickyLeft?: boolean;
+  /** Sticky column anchored right. */
   stickyRight?: boolean;
+  /** Sticky row styling (also injected into child cells from `TableRow`). */
   stickyRow?: boolean;
 };
 

--- a/src/Table/TableLoadingSkeleton.tsx
+++ b/src/Table/TableLoadingSkeleton.tsx
@@ -6,7 +6,9 @@ import { LoadingSkeleton } from '../LoadingSkeleton';
 import './TableLoadingSkeleton.scss';
 
 type TableLoadingSkeletonProps = {
+  /** Skeleton bar widths in px per column (built-in default array when unset). */
   columns?: number[];
+  /** Number of skeleton rows (`7` default). */
   rows?: number;
 };
 

--- a/src/Table/TableRow.tsx
+++ b/src/Table/TableRow.tsx
@@ -12,9 +12,13 @@ type TableElementProps = React.DetailedHTMLProps<
 type TableRowProps = TableElementProps & {
   children?: React.ReactNode;
   className?: string;
+  /** Pointer/hover affordance for interactive rows. */
   clickable?: boolean;
+  /** Suppresses hover styling. */
   removeHover?: boolean;
+  /** Selected row highlight. */
   selected?: boolean;
+  /** When true, each child receives `stickyRow` via `cloneElement`. */
   stickyRow?: boolean;
 };
 

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -8,7 +8,9 @@ import type { TabsProps as BootstrapTabProps } from 'react-bootstrap/Tabs';
 import * as styles from './tabs.module.scss';
 
 export interface TabsProps extends BootstrapTabProps {
+  /** Module class to allow tab labels to wrap (`flex-wrap: unset`). */
   flexWrapUnset?: boolean;
+  /** Module class so nav buttons fill tab height. */
   navItemButtonFullHeight?: boolean;
 }
 

--- a/src/Text/Text.tsx
+++ b/src/Text/Text.tsx
@@ -12,11 +12,15 @@ type ElementProps = React.DetailedHTMLProps<
 >;
 
 type TextProps = ElementProps & {
+  /** Element type to render (`p` default). */
   as?: React.ElementType;
   className?: string;
   children?: React.ReactNode;
+  /** Maps to `Text--{size}` (`md` default). */
   size?: (typeof TEXT_PROPS)['size'][keyof (typeof TEXT_PROPS)['size']];
+  /** Applied as inline `text-align` style. */
   textAlign?: (typeof TEXT_PROPS)['textAlign'][keyof (typeof TEXT_PROPS)['textAlign']];
+  /** Maps to `Text--{weight}` (`regular` default). */
   weight?: (typeof TEXT_PROPS)['weight'][keyof (typeof TEXT_PROPS)['weight']];
 };
 

--- a/src/Toast/Toast.tsx
+++ b/src/Toast/Toast.tsx
@@ -10,9 +10,13 @@ import { type Message } from './useToast';
 import './Toast.scss';
 
 type ToastProps = {
+  /** Forwarded to each `Alert` `autoDismiss`. */
   autoDismiss?: boolean;
+  /** Toggles header styling on the toast group (`true` default). */
   header?: boolean;
+  /** Active toast payloads from `useToast`. */
   messages: Message[];
+  /** Passed to each `Alert` `onDismiss` (typically `dismissMessage`). */
   onToastClosed?: (...args: unknown[]) => unknown;
 };
 


### PR DESCRIPTION
closes: REC-2169

I went through a bunch of our components and had an agent add short TSDocs on the props that could use some explaining. I didn’t touch component code or defaults. Basically better docs so you (or agents) don’t have to read the whole file and hopefully should raise the quality of the context they already use. 

Essentially, the hope is that if you have the Storybook MCP server running (which you can see at `http://localhost:9009/manifests/components.html`), you can point an agent to it and it'll have more context to read from and how to use things. Can read more on [Storybook component manifests here](https://storybook.js.org/docs/ai/manifests#components-manifest)

> "While the types themselves provide a basic level of information, JSDoc comments in your component source code can provide additional metadata for the manifest, which can be helpful for AI agents. We highly recommend adding JSDoc comments to your components and their props to provide as much context as possible for the agents."

<img width="1191" height="935" alt="Screenshot 2026-05-11 at 2 16 55 PM" src="https://github.com/user-attachments/assets/45c4c4db-23f6-475a-b08d-8d082e17e1c8" />


We probably could improve these comments over time, but didn't wanna spend too much time on them but it's def better than an agent making things up on the fly on how something is used. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to adding/updating TypeScript prop comments with no behavioral or styling modifications.
> 
> **Overview**
> Adds/refreshes **TSDoc prop documentation** across a wide set of UI components (e.g. `Accordion*`, `Alert`, `Button`, `Card`, `Drawer*`, `Form*`, `Input*`, `Modal*`, `Table*`, `Tabs`, `Toast`).
> 
> The updates clarify controlled vs uncontrolled usage, default behaviors, and how props are forwarded to underlying libraries (notably React Bootstrap / `react-modal` / `react-datepicker`), without changing runtime logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a2f933423be94fc18f52c5b09964f46717b1a2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->