### PR TITLE
remove `.Synthesized` class gating on remaining components

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,12 +5,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 
 const preview = {
   decorators: [
-    (Story) => (
-      <div className="Synthesized">
-        {/* 👇 Decorators in Storybook also accept a function. Replace <Story/> with Story() to enable it  */}
-        <Story />
-      </div>
-    ),
+    (Story) => Story(),
   ],
 
   parameters: {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -4,10 +4,6 @@ import '../scss/global.scss';
 import 'bootstrap/dist/css/bootstrap.min.css';
 
 const preview = {
-  decorators: [
-    (Story) => Story(),
-  ],
-
   parameters: {
     backgrounds: {
       options: {

--- a/scss/buttons.scss
+++ b/scss/buttons.scss
@@ -18,8 +18,7 @@
   }
 }
 
-$synthesis-primary: $synth-primary-cta-blue;
-$primary: $ux-emerald-600;
+$primary: $synth-primary-cta-blue;
 
 @mixin btn-focus-outline {
   box-shadow: none !important;
@@ -34,39 +33,6 @@ $primary: $ux-emerald-600;
 @mixin btn-primary {
   $btn-primary-background: $primary;
   $btn-primary-border: $primary;
-  $btn-primary-color: $ux-white;
-  $btn-primary-hover-background: $ux-emerald-700;
-  $btn-primary-hover-border: $ux-emerald-700;
-  $btn-primary-hover-color: $ux-white;
-  $btn-primary-active-background: $ux-emerald-800;
-  $btn-primary-active-border: $ux-emerald-800;
-  $btn-primary-active-color: $ux-white;
-
-  @include button-variant(
-    $btn-primary-background,
-    $btn-primary-border,
-    $btn-primary-color,
-    $btn-primary-hover-background,
-    $btn-primary-hover-border,
-    $btn-primary-hover-color,
-    $btn-primary-active-background,
-    $btn-primary-active-border,
-    $btn-primary-active-color
-  );
-
-  &:focus-visible {
-    @include btn-focus-outline;
-  }
-
-  &:active,
-  &:focus {
-    @include btn-remove-bootstrap-focus-outline;
-  }
-}
-
-@mixin synthesis-btn-primary {
-  $btn-primary-background: $synthesis-primary;
-  $btn-primary-border: $synthesis-primary;
   $btn-primary-color: $ux-white;
   $btn-primary-hover-background: $synth-dark-background-selected-blue;
   $btn-primary-hover-border: $synth-dark-background-selected-blue;
@@ -100,45 +66,10 @@ $primary: $ux-emerald-600;
 @mixin btn-outline-primary {
   $btn-outline-primary-color: $primary;
   $btn-outline-primary-color-hover: $ux-white;
-  $btn-outline-primary-hover-background: $ux-emerald-700;
-  $btn-outline-primary-hover-border: $ux-emerald-700;
-  $btn-outline-primary-hover-color: $ux-white;
-  $btn-outline-primary-border: $primary;
-  $btn-outline-primary-active-background: $ux-emerald-800;
-  $btn-outline-primary-active-border-color: $ux-emerald-800;
-
-  @include button-outline-variant(
-    $btn-outline-primary-color,
-    $btn-outline-primary-color-hover,
-    $btn-outline-primary-hover-background,
-    $btn-outline-primary-hover-border,
-    $btn-outline-primary-hover-color
-  );
-
-  border-color: $btn-outline-primary-border;
-
-  &:active {
-    background-color: $btn-outline-primary-active-background;
-    border-color: $btn-outline-primary-active-border-color;
-  }
-
-  &:focus-visible {
-    @include btn-focus-outline;
-  }
-
-  &:active,
-  &:focus {
-    @include btn-remove-bootstrap-focus-outline;
-  }
-}
-
-@mixin synthesis-btn-outline-primary {
-  $btn-outline-primary-color: $synthesis-primary;
-  $btn-outline-primary-color-hover: $ux-white;
   $btn-outline-primary-hover-background: $synth-dark-background-selected-blue;
   $btn-outline-primary-hover-border: $synth-dark-background-selected-blue;
   $btn-outline-primary-hover-color: $ux-white;
-  $btn-outline-primary-border: $synthesis-primary;
+  $btn-outline-primary-border: $primary;
   $btn-outline-primary-active-background: $synth-dark-background-pressed-blue;
   $btn-outline-primary-active-border-color: $synth-dark-background-pressed-blue;
 

--- a/src/Alert/Alert.scss
+++ b/src/Alert/Alert.scss
@@ -32,157 +32,6 @@
   }
 }
 
-.Synthesized {
-  .Alert {
-    display: grid;
-    grid-template-columns: 32px auto auto 32px;
-    grid-template-rows: auto auto;
-    grid-template-areas:
-      'icon content content close'
-      'icon action action close';
-
-    @media (width >= 450px) {
-      grid-template-areas:
-        'icon content action close'
-        'icon content action close';
-    }
-
-    background-color: var(--synth-gray-300);
-    border-radius: var(--ux-border-radius);
-    color: var(--synth-gray-600);
-    margin-bottom: var(--synth-spacing-4);
-    padding: var(--synth-spacing-4);
-    position: relative;
-
-    &__icon {
-      grid-area: icon;
-    }
-
-    &__content {
-      grid-area: content;
-      margin-right: var(--synth-spacing-4);
-    }
-
-    &__action {
-      grid-area: action;
-      display: flex;
-      align-items: center;
-      justify-content: flex-start;
-
-      @media (width >= 450px) {
-        justify-content: flex-end;
-      }
-    }
-
-    &__close {
-      grid-area: close;
-      display: flex;
-      align-items: flex-start;
-      justify-content: flex-end;
-    }
-
-    &__title {
-      @include synth-font-type-30--bold;
-
-      margin-bottom: 4px;
-    }
-
-    &__message {
-      @include synth-font-type-30;
-
-      margin-bottom: 0;
-    }
-  }
-
-  .Alert-success {
-    border-left: 8px solid var(--synth-emerald-400);
-
-    .close {
-      @include close-action;
-    }
-
-    .primary-action {
-      @include primary-action;
-    }
-
-    .Alert__icon {
-      color: var(--synth-emerald-400);
-
-      .fa-check {
-        color: var(--ux-gray-100);
-      }
-    }
-  }
-
-  .Alert-info {
-    border-left: 8px solid var(--synth-blue-300);
-
-    .close {
-      @include close-action;
-    }
-
-    .primary-action {
-      @include primary-action;
-    }
-
-    .Alert__icon {
-      color: var(--ux-blue-300);
-
-      .fa-info {
-        color: var(--ux-blue-600);
-      }
-    }
-  }
-
-  .Alert-feature {
-    border: 2px solid var(--ux-teal-600);
-
-    .close {
-      @include close-action;
-    }
-
-    .primary-action {
-      @include primary-action;
-    }
-
-    .Alert__icon {
-      color: var(--ux-teal-600);
-    }
-  }
-
-  .Alert-warning {
-    border-left: 8px solid var(--synth-orange-100);
-
-    .close {
-      @include close-action;
-    }
-
-    .primary-action {
-      @include primary-action;
-    }
-
-    .Alert__icon {
-      color: var(--synth-orange-100);
-    }
-  }
-
-  .Alert-error {
-    border-left: 8px solid var(--ux-red-400);
-
-    .close {
-      @include close-action;
-    }
-
-    .primary-action {
-      @include primary-action;
-    }
-
-    .Alert__icon {
-      color: var(--synth-red-200);
-    }
-  }
-}
-
 .Alert {
   display: grid;
   grid-template-columns: 32px auto auto 32px;
@@ -197,8 +46,9 @@
       'icon content action close';
   }
 
-  font-weight: 500;
+  background-color: var(--synth-gray-300);
   border-radius: var(--ux-border-radius);
+  color: var(--synth-gray-600);
   margin-bottom: var(--synth-spacing-4);
   padding: var(--synth-spacing-4);
   position: relative;
@@ -244,9 +94,7 @@
 }
 
 .Alert-success {
-  background-color: var(--ux-green-100);
-  color: var(--synth-green-300);
-  border-left: 8px solid var(--ux-green-400);
+  border-left: 8px solid var(--synth-emerald-400);
 
   .close {
     @include close-action;
@@ -257,21 +105,19 @@
   }
 
   .Alert__icon {
-    color: var(--ux-green-400);
+    color: var(--synth-emerald-400);
 
     .fa-check {
-      color: var(--synth-green-300);
+      color: var(--ux-gray-100);
     }
   }
 }
 
 .Alert-info {
-  background-color: var(--ux-blue-100);
-  color: var(--synth-blue-400);
-  border-left: 8px solid var(--ux-blue-300);
+  border-left: 8px solid var(--synth-blue-300);
 
   .close {
-    @include close-action($ux-blue-600, $ux-blue-800);
+    @include close-action;
   }
 
   .primary-action {
@@ -288,22 +134,6 @@
 }
 
 .Alert-feature {
-  background-color: var(--ux-teal-100);
-  color: var(--ux-teal-800);
-  border: 2px solid var(--ux-teal-600);
-
-  .close {
-    @include close-action;
-  }
-
-  .primary-action {
-    @include primary-action;
-  }
-}
-
-.Alert-feature {
-  background-color: var(--ux-teal-100);
-  color: var(--ux-teal-800);
   border: 2px solid var(--ux-teal-600);
 
   .close {
@@ -313,12 +143,14 @@
   .primary-action {
     @include primary-action($ux-teal-600, $ux-teal-700, $ux-white);
   }
+
+  .Alert__icon {
+    color: var(--ux-teal-600);
+  }
 }
 
 .Alert-warning {
-  background-color: var(--ux-yellow-100);
-  color: var(--ux-yellow-900);
-  border-left: 8px solid var(--ux-yellow-600);
+  border-left: 8px solid var(--synth-orange-100);
 
   .close {
     @include close-action;
@@ -329,13 +161,11 @@
   }
 
   .Alert__icon {
-    color: var(--ux-yellow-700);
+    color: var(--synth-orange-100);
   }
 }
 
 .Alert-error {
-  background-color: var(--ux-red-100);
-  color: var(--ux-red-800);
   border-left: 8px solid var(--ux-red-400);
 
   .close {

--- a/src/Alert/Alert.scss
+++ b/src/Alert/Alert.scss
@@ -134,18 +134,18 @@
 }
 
 .Alert-feature {
-  border: 2px solid var(--ux-teal-600);
+  border: 2px solid var(--synth-accent-green);
 
   .close {
-    @include close-action($ux-teal-600, $ux-teal-800);
+    @include close-action;
   }
 
   .primary-action {
-    @include primary-action($ux-teal-600, $ux-teal-700, $ux-white);
+    @include primary-action;
   }
 
   .Alert__icon {
-    color: var(--ux-teal-600);
+    color: var(--synth-accent-green);
   }
 }
 

--- a/src/Button/Button.scss
+++ b/src/Button/Button.scss
@@ -1,17 +1,5 @@
 @import '../../scss/theme';
 
-.Synthesized {
-  .Button {
-    &.btn-primary {
-      @include synthesis-btn-primary;
-    }
-
-    &.btn-outline-primary {
-      @include synthesis-btn-outline-primary;
-    }
-  }
-}
-
 .Button {
   @include synth-font-type-30--bold;
 

--- a/src/Card/Card.scss
+++ b/src/Card/Card.scss
@@ -1,17 +1,10 @@
 @import '../../scss/theme';
 
-.Synthesized {
-  .Card {
-    border: 1px solid var(--ux-gray-400);
-    box-shadow: none;
-  }
-}
-
 .Card {
   background-color: var(--ux-white);
-  border: none;
+  border: 1px solid var(--ux-gray-400);
   border-radius: var(--ux-border-radius);
-  box-shadow: var(--ux-elevations-20);
+  box-shadow: none;
   outline-color: var(--ux-green-500);
   padding: $card-spacing;
   max-width: 100%;

--- a/src/Dropdown/DropdownToggle.scss
+++ b/src/Dropdown/DropdownToggle.scss
@@ -1,7 +1,5 @@
 @import '../../scss/theme';
 
-$primary: $ux-emerald-600;
-
 .DropdownToggle {
   @include synth-font-type-30--bold;
 
@@ -22,14 +20,6 @@ $primary: $ux-emerald-600;
 
   &.btn-primary {
     @include btn-primary;
-
-    &:focus {
-      background: var(--ux-emerald-600);
-    }
-
-    &.show:focus {
-      background: var(--ux-emerald-700);
-    }
   }
 
   &.btn-outline-primary {
@@ -50,17 +40,5 @@ $primary: $ux-emerald-600;
 
   &.btn-outline-transparent {
     @include btn-outline-transparent;
-  }
-}
-
-.Synthesized {
-  .DropdownToggle {
-    &.btn-primary {
-      @include synthesis-btn-primary;
-    }
-
-    &.btn-outline-primary {
-      @include synthesis-btn-outline-primary;
-    }
   }
 }

--- a/src/Select/select.scss
+++ b/src/Select/select.scss
@@ -1,10 +1,8 @@
 @import '../../scss/theme';
 
 // Note: react-select is largely styled via css-in-js, not SCSS.
-// However, we need to only provide the styles below when the "Synthesized"
-// class is present on the body in rails server
 
-.Synthesized .Select__menu {
+.Select__menu {
   .Select__option:hover,
   .Select__option--is-focused {
     background-color: var(--synth-hover-state);

--- a/src/Tabs/tabs.module.scss
+++ b/src/Tabs/tabs.module.scss
@@ -1,52 +1,22 @@
 @import '../../scss/theme';
 
 .tabs {
-  --border-width: 2px;
-
-  border-bottom: var(--border-width) solid var(--ux-gray-400);
-
-  :global(.nav-link) {
-    color: var(--ux-gray-800);
-    font:
-      400 0.875rem/1.25rem Inter,
-      sans-serif;
-    text-decoration: none;
-    border: none;
-    border-radius: 0;
-    border-bottom: var(--border-width) solid var(--ux-gray-400);
-    margin-bottom: calc(0px - var(--border-width));
-    padding: 6px 12px;
-  }
-
-  :global(.nav-link.active),
-  :global(.nav-link:hover),
-  :global(.nav-link:active),
-  :global(.nav-link:focus) {
-    color: var(--ux-blue-500);
-    border-bottom: var(--border-width) solid var(--ux-blue-500);
-  }
-
-  .flexWrapUnset {
-    flex-wrap: nowrap;
-  }
-
-  .navItemButtonFullHeight {
-    :global(.nav-item .button) {
-      height: calc(100% + 2px);
-    }
-  }
-}
-
-:global(.Synthesized) .tabs {
   border-bottom: 1px solid var(--synth-div-stroke-neutral);
   align-items: flex-end;
 
   :global(.nav-link),
   :global(.nav-link.disabled) {
     color: var(--synth-unselected-tab);
+    font:
+      400 0.875rem/1.25rem Inter,
+      sans-serif;
+    text-decoration: none;
+    border: none;
+    border-radius: 0;
     border-bottom: 1px solid var(--synth-div-stroke-neutral);
     position: relative;
     margin-bottom: -1px;
+    padding: 6px 12px;
   }
 
   :global(.nav-link.active) {
@@ -59,6 +29,10 @@
   :global(.nav-link:focus) {
     color: var(--synth-gray-600);
     border-bottom: 3px solid var(--synth-indicator-stroke-green);
+  }
+
+  .flexWrapUnset {
+    flex-wrap: nowrap;
   }
 
   .navItemButtonFullHeight {


### PR DESCRIPTION
closes: REC-2173

Removed `.Synthesized` class gating on the remaining components that had it. The components should look the same. Removed the older styles that were being supported outside of the gating. 

Can do a release and then we should be able to remove those Synthesized erb templates in RS and do some spot checking. 

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/user-interviews/codesmith/ui-design-system/pr/1463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes default styling globally (removing `.Synthesized` scoping) for multiple shared components, which can cause visual regressions in consuming apps.
> 
> **Overview**
> Removes `.Synthesized`-scoped styling so core component styles apply globally by default (Alert, Button, Card, DropdownToggle, Select, Tabs), including deleting the Storybook decorator that injected the wrapper.
> 
> Unifies theming toward Synth tokens: `buttons.scss` drops legacy emerald primary variants/mixins and makes the primary/outline-primary variants use Synth blue tokens, and several components update borders/shadows/colors (notably `Card` and `Alert` variants) to match the new defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 938ddfeaf3f81db020a709c01e15c218688c3bfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->