### PR TITLE
Update DS Alert to match /design_system_components

### DIFF
--- a/src/Alert/Alert.mdx
+++ b/src/Alert/Alert.mdx
@@ -52,6 +52,13 @@ performing an action.
 
 <Canvas of={ComponentStories.Warning} />
 
+### No Margin
+
+- Pass `noMargin` to drop the default bottom margin. Useful when the alert is rendered inside a
+flex/grid layout that already controls spacing, or when stacking alerts flush against one another.
+
+<Canvas of={ComponentStories.NoMargin} />
+
 ### With Dismiss
 
 - Used in cases where a user would want to dismiss or remove an alert from view.

--- a/src/Alert/Alert.scss
+++ b/src/Alert/Alert.scss
@@ -91,6 +91,10 @@
 
     margin-bottom: 0;
   }
+
+  &--no-margin {
+    margin-bottom: 0;
+  }
 }
 
 .Alert-success {

--- a/src/Alert/Alert.scss
+++ b/src/Alert/Alert.scss
@@ -81,14 +81,15 @@
   }
 
   &__title {
-    @include synth-font-type-30--bold;
-
+    font-size: 0.875rem;
+    font-weight: 700;
+    line-height: 1.25rem;
     margin-bottom: 4px;
   }
 
   &__message {
-    @include synth-font-type-30;
-
+    font-size: 0.875rem;
+    line-height: 1.25rem;
     margin-bottom: 0;
   }
 
@@ -138,7 +139,7 @@
 }
 
 .Alert-feature {
-  border: 2px solid var(--synth-accent-green);
+  border: 1px solid var(--synth-accent-green);
 
   .close {
     @include close-action;

--- a/src/Alert/Alert.stories.tsx
+++ b/src/Alert/Alert.stories.tsx
@@ -180,3 +180,4 @@ export function WithCallToAction() {
     </>
   );
 }
+

--- a/src/Alert/Alert.stories.tsx
+++ b/src/Alert/Alert.stories.tsx
@@ -75,6 +75,27 @@ export function Warning() {
   );
 }
 
+export function NoMargin() {
+  return (
+    <>
+      <Alert
+        id="no-margin-1"
+        message="This alert drops its default bottom margin."
+        noMargin
+        title="No margin"
+        type={MessageTypes.INFO}
+      />
+      <Alert
+        id="no-margin-2"
+        message="The next alert sits flush against this one because both pass `noMargin`."
+        noMargin
+        title="Stacked without spacing"
+        type={MessageTypes.INFO}
+      />
+    </>
+  );
+}
+
 const onDismiss = (id) => {
   action('alert dismissed')(id);
 };

--- a/src/Alert/Alert.stories.tsx
+++ b/src/Alert/Alert.stories.tsx
@@ -180,4 +180,3 @@ export function WithCallToAction() {
     </>
   );
 }
-

--- a/src/Alert/Alert.test.tsx
+++ b/src/Alert/Alert.test.tsx
@@ -1,0 +1,208 @@
+import React from 'react';
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Alert, MessageTypes } from './index';
+
+type AlertType = (typeof MessageTypes)[keyof typeof MessageTypes];
+
+const elements = {
+  alert: {
+    get: () => screen.getByText('message').closest('.Alert') as HTMLElement,
+  },
+  closeButton: {
+    get: (type: AlertType) =>
+      screen.getByRole('button', { name: `close ${type}` }),
+  },
+  actionLink: {
+    get: (name: string) => screen.getByRole('link', { name }),
+  },
+};
+
+describe('Alert', () => {
+  describe('when given a valid type', () => {
+    describe('with type success', () => {
+      it('renders the title and message', () => {
+        render(
+          <Alert
+            message="message"
+            title="Success title"
+            type={MessageTypes.SUCCESS}
+          />,
+        );
+
+        expect(screen.getByText('Success title')).toBeInTheDocument();
+        expect(screen.getByText('message')).toBeInTheDocument();
+        expect(elements.alert.get().classList).toContain('Alert-success');
+      });
+    });
+
+    describe('with type info', () => {
+      it('renders the title and message', () => {
+        render(
+          <Alert
+            message="message"
+            title="Info title"
+            type={MessageTypes.INFO}
+          />,
+        );
+
+        expect(screen.getByText('Info title')).toBeInTheDocument();
+        expect(elements.alert.get().classList).toContain('Alert-info');
+      });
+    });
+
+    describe('with type feature', () => {
+      it('renders the title and message', () => {
+        render(
+          <Alert
+            message="message"
+            title="Feature title"
+            type={MessageTypes.FEATURE}
+          />,
+        );
+
+        expect(screen.getByText('Feature title')).toBeInTheDocument();
+        expect(elements.alert.get().classList).toContain('Alert-feature');
+      });
+    });
+
+    describe('with type warning', () => {
+      it('renders the title and message', () => {
+        render(
+          <Alert
+            message="message"
+            title="Warning title"
+            type={MessageTypes.WARNING}
+          />,
+        );
+
+        expect(screen.getByText('Warning title')).toBeInTheDocument();
+        expect(elements.alert.get().classList).toContain('Alert-warning');
+      });
+    });
+
+    describe('with type error', () => {
+      it('renders the title and message', () => {
+        render(
+          <Alert
+            message="message"
+            title="Error title"
+            type={MessageTypes.ERROR}
+          />,
+        );
+
+        expect(screen.getByText('Error title')).toBeInTheDocument();
+        expect(elements.alert.get().classList).toContain('Alert-error');
+      });
+    });
+  });
+
+  describe('when given an unsupported type', () => {
+    it('throws a TypeError', () => {
+      expect(() =>
+        render(
+          <Alert message="message" type={'not-a-real-type' as AlertType} />,
+        ),
+      ).toThrow(TypeError);
+    });
+  });
+
+  describe('when noMargin is true', () => {
+    it('adds the Alert--no-margin modifier class', () => {
+      render(<Alert message="message" noMargin type={MessageTypes.INFO} />);
+
+      expect(elements.alert.get().classList).toContain('Alert--no-margin');
+    });
+  });
+
+  describe('when noMargin is not set', () => {
+    it('does not add the Alert--no-margin modifier class', () => {
+      render(<Alert message="message" type={MessageTypes.INFO} />);
+
+      expect(elements.alert.get().classList).not.toContain('Alert--no-margin');
+    });
+  });
+
+  describe('when removeBorderLeft is true', () => {
+    describe('and type is not feature', () => {
+      it('removes the colored left border', () => {
+        render(
+          <Alert
+            message="message"
+            removeBorderLeft
+            type={MessageTypes.WARNING}
+          />,
+        );
+
+        expect(elements.alert.get()).toHaveStyle({ borderLeft: 'none' });
+      });
+    });
+
+    describe('and type is feature', () => {
+      it('keeps the colored left border', () => {
+        render(
+          <Alert
+            message="message"
+            removeBorderLeft
+            type={MessageTypes.FEATURE}
+          />,
+        );
+
+        expect(elements.alert.get()).not.toHaveAttribute('style');
+      });
+    });
+  });
+
+  describe('when an onDismiss handler is provided', () => {
+    it('renders a close button', () => {
+      render(
+        <Alert
+          id="alert-id"
+          message="message"
+          type={MessageTypes.INFO}
+          onDismiss={jest.fn()}
+        />,
+      );
+
+      expect(elements.closeButton.get(MessageTypes.INFO)).toBeInTheDocument();
+    });
+
+    it('calls onDismiss with the id when the close button is clicked', async () => {
+      const onDismiss = jest.fn();
+
+      render(
+        <Alert
+          id="alert-id"
+          message="message"
+          type={MessageTypes.INFO}
+          onDismiss={onDismiss}
+        />,
+      );
+
+      userEvent.click(elements.closeButton.get(MessageTypes.INFO));
+
+      await waitFor(() => {
+        expect(onDismiss).toHaveBeenCalledWith('alert-id');
+      });
+    });
+  });
+
+  describe('when given an action with a url', () => {
+    it('renders a styled anchor with the action target', () => {
+      render(
+        <Alert
+          action={{ content: 'Take action', url: 'https://example.com' }}
+          actionTarget="_blank"
+          message="message"
+          type={MessageTypes.INFO}
+        />,
+      );
+
+      const link = elements.actionLink.get('Take action');
+      expect(link).toHaveAttribute('href', 'https://example.com');
+      expect(link).toHaveAttribute('target', '_blank');
+    });
+  });
+});

--- a/src/Alert/Alert.tsx
+++ b/src/Alert/Alert.tsx
@@ -82,12 +82,12 @@ const getAlertIcon = (type: MessageType) => {
 const AUTO_DISMISS_TIMEOUT_SUCCESS = 3000;
 const AUTO_DISMISS_TIMEOUT_DEFAULT = 5000;
 
-const getAlertClassName = (type: MessageType) => {
+const getAlertClassName = (type: MessageType, noMargin?: boolean) => {
   if (!Object.values(MessageTypes).includes(type)) {
     throw new TypeError(`Unexpected type ${type} used for an alert.`);
   }
 
-  return `Alert Alert-${type}`;
+  return classNames(`Alert Alert-${type}`, { 'Alert--no-margin': noMargin });
 };
 
 type AlertProps = {
@@ -105,6 +105,8 @@ type AlertProps = {
   /** Passed into `onDismiss` from the close button and from auto-dismiss. */
   id?: string;
   message: string | React.ReactNode;
+  /** Drops the default bottom margin. Useful when the alert is rendered inside a flex/grid layout that controls spacing. */
+  noMargin?: boolean;
   /** Removes the type-colored left border (`borderLeft: none`). */
   removeBorderLeft?: boolean;
   title?: string;
@@ -134,7 +136,7 @@ function Alert(props: AlertProps) {
 
   return (
     <div
-      className={getAlertClassName(props.type)}
+      className={getAlertClassName(props.type, props.noMargin)}
       style={props.removeBorderLeft ? { borderLeft: 'none' } : undefined}
     >
       <div className="Alert__icon">{getAlertIcon(props.type)}</div>

--- a/src/Alert/Alert.tsx
+++ b/src/Alert/Alert.tsx
@@ -87,7 +87,9 @@ const getAlertClassName = (type: MessageType, noMargin?: boolean) => {
     throw new TypeError(`Unexpected type ${type} used for an alert.`);
   }
 
-  return classNames(`Alert Alert-${type}`, { 'Alert--no-margin': noMargin });
+  return classNames(`Alert Alert-${type}`, {
+    'Alert--no-margin': noMargin,
+  });
 };
 
 type AlertProps = {
@@ -99,7 +101,7 @@ type AlertProps = {
       }
     | React.ReactNode;
   /** `target` on the action anchor when `action` is `{ url, content }` (e.g. `_blank`). */
-  actionTarget?: string;
+  actionTarget?: '_self' | '_blank' | '_parent' | '_top';
   /** When true and `onDismiss` is set, calls `onDismiss` after a delay.*/
   autoDismiss?: boolean;
   /** Passed into `onDismiss` from the close button and from auto-dismiss. */
@@ -107,13 +109,13 @@ type AlertProps = {
   message: string | React.ReactNode;
   /** Drops the default bottom margin. Useful when the alert is rendered inside a flex/grid layout that controls spacing. */
   noMargin?: boolean;
-  /** Removes the type-colored left border (`borderLeft: none`). */
+  /** Drop the colored left accent (use when nested in a card/drawer). No effect on `feature`. */
   removeBorderLeft?: boolean;
-  title?: string;
+  title?: string | React.ReactNode;
   /** Variant and icon (`MessageTypes`) */
   type: MessageType;
   /** Renders the close control; combined with `autoDismiss`, also invoked after the timeout. */
-  onDismiss?: (arg0?: string) => void;
+  onDismiss?: (id?: string) => void;
 };
 
 function Alert(props: AlertProps) {
@@ -137,7 +139,11 @@ function Alert(props: AlertProps) {
   return (
     <div
       className={getAlertClassName(props.type, props.noMargin)}
-      style={props.removeBorderLeft ? { borderLeft: 'none' } : undefined}
+      style={
+        props.removeBorderLeft && props.type !== MessageTypes.FEATURE
+          ? { borderLeft: 'none' }
+          : undefined
+      }
     >
       <div className="Alert__icon">{getAlertIcon(props.type)}</div>
       <div className="Alert__content">


### PR DESCRIPTION
I checked and the DS `<Alert>` is currently not used in the rails-server codebase. 
This updates the DS version so it has parity with the version currently being used so that we can easily integrate it and get rid of the `design_system_components` version

To test: spin up storybook and confirm the changes look good and new `noMargin` prop is intact

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/user-interviews/codesmith/ui-design-system/pr/1481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes `Alert`’s public prop types/behavior (`noMargin`, `title` type, `actionTarget` union, `removeBorderLeft` exception for `feature`) and adjusts styling, which could cause minor UI regressions or TypeScript breakage for existing consumers.
> 
> **Overview**
> Updates the `Alert` component to better match `design_system_components` by refining typography styles, tweaking the `feature` border weight, and preventing `removeBorderLeft` from removing the accent on `feature` alerts.
> 
> Adds a new `noMargin` prop that applies an `Alert--no-margin` modifier to drop the default bottom spacing, with corresponding Storybook docs/story updates.
> 
> Tightens and expands the public API by restricting `actionTarget` to standard target values and allowing `title` to be a `ReactNode`, and introduces a comprehensive `Alert.test.tsx` covering type validation, dismiss behavior, border removal rules, action link rendering, and the new `noMargin` modifier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb29aac24a2faa9e6589958bd91f51c9219516c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->