### PR TITLE
Fix create new release Action

### DIFF
--- a/.github/workflows/block-prerelease-prs.yml
+++ b/.github/workflows/block-prerelease-prs.yml
@@ -1,0 +1,37 @@
+name: Block prerelease PRs to main
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  block-prerelease-prs:
+    name: Block prerelease PRs to main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject prerelease branches
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [[ "$HEAD_REF" == prerelease/* ]]; then
+            echo "::error::Do not open PRs from prerelease/... branches to main. Merge the clean feature branch instead."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Reject prerelease package versions
+        run: |
+          version=$(node -p "require('./package.json').version")
+
+          if [[ "$version" == *-* ]]; then
+            echo "::error::package.json version '$version' is a prerelease. Do not merge prerelease versions to main."
+            exit 1
+          fi

--- a/.github/workflows/block-prerelease-prs.yml
+++ b/.github/workflows/block-prerelease-prs.yml
@@ -14,13 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Reject prerelease branches
-        env:
-          HEAD_REF: ${{ github.head_ref }}
+        if: startsWith(github.head_ref, 'prerelease/')
         run: |
-          if [[ "$HEAD_REF" == prerelease/* ]]; then
-            echo "::error::Do not open PRs from prerelease/... branches to main. Merge the clean feature branch instead."
-            exit 1
-          fi
+          echo "::error::Do not open PRs from prerelease/... branches to main. Merge the clean feature branch instead."
+          exit 1
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -1,10 +1,23 @@
+# Release workflow model:
+# - Stable releases are normally dispatched from main. They create a
+#   release/vX.Y.Z branch, tag/build from that version-bump commit, and open a
+#   PR back to main so package.json records the stable version.
+# - Prereleases should be dispatched from disposable prerelease/... branches.
+#   The workflow commits the prerelease version bump back to that branch so
+#   later prerelease runs can increment from the previous prerelease version.
+# - Do not merge prerelease/... branches back to main. Merge the clean feature
+#   branch when the feature is ready, then cut the final stable release.
+
 name: "Create new release"
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Select the version increment. Use premajor/preminor/prepatch to start a prerelease line; use prerelease to increment an existing prerelease."
+        description: >-
+          Select the version increment. Use premajor/preminor/prepatch to start
+          a prerelease line; use prerelease to increment an existing
+          prerelease.
         required: true
         type: choice
         options:
@@ -57,7 +70,19 @@ jobs:
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Create version bump branch
+      - name: Validate prerelease branch
+        if: ${{ steps.extract_version.outputs.prerelease == 'true' }}
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          if [[ "$REF_TYPE" != "branch" || "$REF_NAME" != prerelease/* ]]; then
+            echo "Prereleases must be dispatched from a disposable prerelease/... branch."
+            exit 1
+          fi
+
+      - name: Create stable release branch
+        if: ${{ steps.extract_version.outputs.prerelease == 'false' }}
         run: git checkout -b "release/v${{ steps.extract_version.outputs.version }}"
 
       - name: Initialize mandatory git config
@@ -71,8 +96,15 @@ jobs:
 
           echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Publish release branch
+      - name: Publish stable release branch
+        if: ${{ steps.extract_version.outputs.prerelease == 'false' }}
         run: git push origin "release/v${{ steps.extract_version.outputs.version }}"
+
+      - name: Publish prerelease branch
+        if: ${{ steps.extract_version.outputs.prerelease == 'true' }}
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: git push origin "HEAD:refs/heads/$REF_NAME"
 
       - name: Merge version update into main branch
         if: ${{ steps.extract_version.outputs.prerelease == 'false' }}

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Select the version increment"
+        description: "Select the version increment. Use premajor/preminor/prepatch to start a prerelease line; use prerelease to increment an existing prerelease."
         required: true
         type: choice
         options:
@@ -75,6 +75,7 @@ jobs:
         run: git push origin "release/v${{ steps.extract_version.outputs.version }}"
 
       - name: Merge version update into main branch
+        if: ${{ steps.extract_version.outputs.prerelease == 'false' }}
         uses: thomaseizinger/create-pull-request@955adb4634198898bc24dca0468514c63a8fc98d # 1.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup environment
         uses: ./.github/actions/setup_environment
@@ -55,7 +57,7 @@ jobs:
           # already constrained by the `choice` list above, but pinning to an
           # env var keeps the audit clean and removes the implicit trust.
           BUMP_TYPE: ${{ github.event.inputs.version }}
-        run: yarn version "$BUMP_TYPE"
+        run: yarn version "$BUMP_TYPE" --immediate
 
       - name: Extract release metadata from package.json
         id: extract_version

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -65,6 +65,7 @@ jobs:
           version=$(node -p "require('./package.json').version")
           echo "Extracted version: $version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "RELEASE_VERSION=$version" >> "$GITHUB_ENV"
 
           if [[ "$version" == *-* ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
@@ -73,19 +74,16 @@ jobs:
           fi
 
       - name: Validate prerelease branch
-        if: ${{ steps.extract_version.outputs.prerelease == 'true' }}
-        env:
-          REF_NAME: ${{ github.ref_name }}
-          REF_TYPE: ${{ github.ref_type }}
+        if: steps.extract_version.outputs.prerelease == 'true'
         run: |
-          if [[ "$REF_TYPE" != "branch" || "$REF_NAME" != prerelease/* ]]; then
+          if [[ "$GITHUB_REF_TYPE" != "branch" || "$GITHUB_REF_NAME" != prerelease/* ]]; then
             echo "Prereleases must be dispatched from a disposable prerelease/... branch."
             exit 1
           fi
 
       - name: Create stable release branch
-        if: ${{ steps.extract_version.outputs.prerelease == 'false' }}
-        run: git checkout -b "release/v${{ steps.extract_version.outputs.version }}"
+        if: steps.extract_version.outputs.prerelease == 'false'
+        run: git checkout -b "release/v$RELEASE_VERSION"
 
       - name: Initialize mandatory git config
         uses: fregante/setup-git-user@024bc0b8e177d7e77203b48dab6fb45666854b35 # v2
@@ -94,22 +92,20 @@ jobs:
         id: make-commit
         run: |
           git add package.json
-          git commit --message "Update package.json v${{ steps.extract_version.outputs.version }}"
+          git commit --message "Update package.json v$RELEASE_VERSION"
 
           echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Publish stable release branch
-        if: ${{ steps.extract_version.outputs.prerelease == 'false' }}
-        run: git push origin "release/v${{ steps.extract_version.outputs.version }}"
+        if: steps.extract_version.outputs.prerelease == 'false'
+        run: git push origin "release/v$RELEASE_VERSION"
 
       - name: Publish prerelease branch
-        if: ${{ steps.extract_version.outputs.prerelease == 'true' }}
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        run: git push origin "HEAD:refs/heads/$REF_NAME"
+        if: steps.extract_version.outputs.prerelease == 'true'
+        run: git push origin "HEAD:refs/heads/$GITHUB_REF_NAME"
 
       - name: Merge version update into main branch
-        if: ${{ steps.extract_version.outputs.prerelease == 'false' }}
+        if: steps.extract_version.outputs.prerelease == 'false'
         uses: thomaseizinger/create-pull-request@955adb4634198898bc24dca0468514c63a8fc98d # 1.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -44,15 +44,21 @@ jobs:
           BUMP_TYPE: ${{ github.event.inputs.version }}
         run: yarn version "$BUMP_TYPE"
 
-      - name: Extract version from package.json
+      - name: Extract release metadata from package.json
         id: extract_version
         run: |
-          version=$(grep '"version"' package.json | sed -E 's/.*"version": "([^"]+)".*/\1/')
+          version=$(node -p "require('./package.json').version")
           echo "Extracted version: $version"
-          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          if [[ "$version" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create version bump branch
-        run: git checkout -b release/v${{ steps.extract_version.outputs.version }}
+        run: git checkout -b "release/v${{ steps.extract_version.outputs.version }}"
 
       - name: Initialize mandatory git config
         uses: fregante/setup-git-user@024bc0b8e177d7e77203b48dab6fb45666854b35 # v2
@@ -63,10 +69,10 @@ jobs:
           git add package.json
           git commit --message "Update package.json v${{ steps.extract_version.outputs.version }}"
 
-          echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Publish release branch
-        run: git push origin release/v${{ steps.extract_version.outputs.version }}
+        run: git push origin "release/v${{ steps.extract_version.outputs.version }}"
 
       - name: Merge version update into main branch
         uses: thomaseizinger/create-pull-request@955adb4634198898bc24dca0468514c63a8fc98d # 1.4.0
@@ -88,33 +94,14 @@ jobs:
       - name: Pack bundle tarball
         run: npm pack
 
-      # TODO(deprecated-action): actions/create-release was archived by
-      # GitHub in 2021 and receives no security or runner-version updates.
-      # Migrate to softprops/action-gh-release (hash-pinned per zizmor policy)
-      # or `gh release create` via a `run:` block. Tracking item to be filed.
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ steps.extract_version.outputs.version }}
-          release_name: Release v${{ steps.extract_version.outputs.version }}
-          body_path:
+          name: Release v${{ steps.extract_version.outputs.version }}
+          target_commitish: ${{ steps.make-commit.outputs.commit }}
+          files: user-interviews-ui-design-system-${{ steps.extract_version.outputs.version }}.tgz
           draft: false
-          prerelease: false
-
-      # TODO(deprecated-action): actions/upload-release-asset was archived
-      # alongside actions/create-release in 2021. softprops/action-gh-release
-      # uploads assets in the same step that creates the release, so the
-      # migration collapses these two steps into one.
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./user-interviews-ui-design-system-${{ steps.extract_version.outputs.version }}.tgz
-          asset_name: user-interviews-ui-design-system-${{ steps.extract_version.outputs.version }}.tgz
-          asset_content_type: application/tar+gzip
+          prerelease: ${{ steps.extract_version.outputs.prerelease }}


### PR DESCRIPTION
Fixes the "Create new release" GH action, which was always busted and leaving the version behind what it ultimately packaged up (as well as totally broke with any pre-release stuff, like I wanted to do with #1506 when testing against the rails server.

Old flow problems:
>   - The workflow bumped package.json, created a release branch/PR, but the GitHub Release tag was created against the original workflow commit instead of the version-bump commit. That’s
>     why tags like v8.4.0 pointed at code where package.json still said the previous version.
>   - Prereleases were treated like stable releases. They opened PRs back to main, which would put versions like 8.5.0-0 on main if merged.
>   - Prerelease bumps lived only on temporary release/v... branches, so rerunning prerelease from the same feature branch would not increment correctly.
>   - yarn version failed on feature/prerelease branch dispatches because Actions used a shallow checkout without enough history for Yarn to find an ancestor with main.
>   - The release used deprecated archived GitHub release/upload actions.

  How we addressed it:
> 
>   - Swapped deprecated release/upload actions for pinned softprops/action-gh-release@v3.
>   - Capture the version-bump commit SHA and pass it as target_commitish, so the tag, release, and tarball all line up with the bumped package.json.
>   - Detect prereleases by checking whether the resolved version contains -.
>   - Stable releases still create release/v..., push it, and open the PR to main.
>   - Prereleases must run from disposable prerelease/... branches. The workflow commits the prerelease version bump back to that branch and skips the PR to main.
>   - Added top-of-file comments documenting the stable vs prerelease branch model.
>   - Added fetch-depth: 0 and yarn version ... --immediate so Yarn can resolve branch ancestry and perform the intended direct manifest bump.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/user-interviews/codesmith/ui-design-system/pr/1508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782415086&installation_id=127447467&pr_number=1508&repository=user-interviews%2Fui-design-system&return_to=https%3A%2F%2Fgithub.com%2Fuser-interviews%2Fui-design-system%2Fpull%2F1508&signature=9f645c768eec46317e540f5ceb4e9ef546cd01f1ac960bb2d103eaf0455bc510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->