### PR TITLE
Upgrade Chromatic and Codecov to Node24

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,10 +1,17 @@
 # .github/workflows/chromatic.yml
 
 # Workflow name
-name: "Chromatic build on main"
+name: "Chromatic build"
 
 # Event for the workflow
 on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run without publishing to Chromatic"
+        required: true
+        type: boolean
+        default: true
   push:
     branches:
       - main
@@ -20,6 +27,12 @@ jobs:
   chromatic-deployment:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
+      - name: Validate Chromatic run mode
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == false && github.ref_name != 'main' }}
+        run: |
+          echo "::error::Chromatic uploads are only allowed from main. Re-run with dry_run=true for $GITHUB_REF_NAME."
+          exit 1
+
       - name: Checkout branch
         uses: actions/checkout@v6
         with:
@@ -29,7 +42,8 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup_environment
 
-      - name: Publish to Chromatic
+      - name: Run Chromatic
         uses: chromaui/action@0b8c883861c1663076150cf1f4592b19d1ff6a54 # v17.0.1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          dryRun: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run == true) || (github.event_name != 'workflow_dispatch' && github.ref_name != 'main') }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -30,6 +30,6 @@ jobs:
         uses: ./.github/actions/setup_environment
 
       - name: Publish to Chromatic
-        uses: chromaui/action@30047ab459164cf99ae8f097f6aa5c7ef4fcc869 # v13
+        uses: chromaui/action@0b8c883861c1663076150cf1f4592b19d1ff6a54 # v17.0.1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,8 @@
 name: Lint
 
-on: push
+on:
+  push:
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
           vars.CODECOV_ENABLED == 'true' &&
           steps.test.outcome != 'skipped' &&
           steps.test.outcome != 'cancelled'
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Test javascript
 
-on: push
+on:
+  push:
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
Noticed warnings in the actions output -- still a few node20 ones left, but don't think they will break when GH forces 24 and will wait for further upgrades rather than replace with CLI scripts.

There didn't seem to be anything in the Chromatic Changelog that stood out. Updates the chromatic action to allow for doing a dry run on non-main branches, and it passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/user-interviews/codesmith/ui-design-system/pr/1521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782485876&installation_id=127447467&pr_number=1521&repository=user-interviews%2Fui-design-system&return_to=https%3A%2F%2Fgithub.com%2Fuser-interviews%2Fui-design-system%2Fpull%2F1521&signature=e142723994db6c9681cf19fbf9cbb18d47668c4547702fb79d9ec87ddffc3b6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->