### PR TITLE
Fix stale entities lockfile locator

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,6 +6,7 @@ name: "Chromatic build"
 # Event for the workflow
 on:
   pull_request:
+  merge_group:
   workflow_dispatch:
     inputs:
       dry_run:
@@ -55,4 +56,4 @@ jobs:
       - name: Run Chromatic
         uses: chromaui/action@94713c544284a14195de3b50ef24301579f1877e # v18.0.1
         with:
-          dryRun: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run == true) || (github.event_name != 'workflow_dispatch' && github.ref_name != 'main') }}
+          dryRun: ${{ github.event_name == 'merge_group' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == true) || (github.event_name != 'workflow_dispatch' && github.ref_name != 'main') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/yarn.lock
+++ b/yarn.lock
@@ -7932,7 +7932,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:^4.4.0, entities@npm:^4.5.0":
+"entities@npm:^4.5.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 10c0/5b039739f7621f5d1ad996715e53d964035f75ad3b9a4d38c6b3804bb226e282ffeae2443624d8fdd9c47d8e926ae9ac009c54671243f0c3294c26af7cc85250


### PR DESCRIPTION
## Summary

Remove the stale `entities@^4.4.0` locator reintroduced when several Dependabot lockfile updates merged from overlapping base commits.

## Verification

- `yarn install --immutable --check-cache`
- `git diff --check`