### PR TITLE
Validate merge queue entries in required workflows

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,6 +6,7 @@ name: "Chromatic build"
 # Event for the workflow
 on:
   pull_request:
+  merge_group:
   workflow_dispatch:
     inputs:
       dry_run:
@@ -55,4 +56,4 @@ jobs:
       - name: Run Chromatic
         uses: chromaui/action@94713c544284a14195de3b50ef24301579f1877e # v18.0.1
         with:
-          dryRun: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run == true) || (github.event_name != 'workflow_dispatch' && github.ref_name != 'main') }}
+          dryRun: ${{ github.event_name == 'merge_group' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == true) || (github.event_name != 'workflow_dispatch' && github.ref_name != 'main') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- run each required GitHub Actions workflow for `merge_group` events
- keep Chromatic dry-run-only for synthetic queue commits

This is temporarily stacked on #1651 so the broken lockfile is repaired before merge-queue support lands. It will target `main` after #1651 merges.

## Verification

- `actionlint -config-file .github/actionlint.yaml`
- `zizmor --offline --min-severity high --no-progress .github`