### PR TITLE
Upgrade Storybook MCP addon to 10.6

### DIFF
--- a/.storybook/main.mjs
+++ b/.storybook/main.mjs
@@ -19,8 +19,8 @@ const config = {
         toolsets: {
           dev: true,
           docs: true,
+          test: false,
         },
-        experimentalFormat: 'markdown',
       },
     },
     '@storybook/addon-webpack5-compiler-babel',
@@ -48,7 +48,7 @@ const config = {
     defaultName: 'Docs',
   },
   features: {
-    experimentalComponentsManifest: true,
+    componentsManifest: true,
   },
   stories: [
     '../src/**/*.stories.@(js|jsx|ts|tsx)',

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@storybook/addon-a11y": "10.6.0",
     "@storybook/addon-docs": "10.6.0",
     "@storybook/addon-links": "10.6.0",
-    "@storybook/addon-mcp": "0.7.0",
+    "@storybook/addon-mcp": "10.6.0",
     "@storybook/addon-styling-webpack": "^3.0.2",
     "@storybook/addon-webpack5-compiler-babel": "^4.0.1",
     "@storybook/react-webpack5": "10.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4000,23 +4000,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-mcp@npm:0.7.0":
-  version: 0.7.0
-  resolution: "@storybook/addon-mcp@npm:0.7.0"
+"@storybook/addon-mcp@npm:10.6.0":
+  version: 10.6.0
+  resolution: "@storybook/addon-mcp@npm:10.6.0"
   dependencies:
-    "@storybook/mcp": "npm:0.8.0"
     "@tmcp/adapter-valibot": "npm:^0.1.5"
     "@tmcp/transport-http": "npm:^0.8.5"
-    picoquery: "npm:^2.5.0"
     tmcp: "npm:^1.19.4"
-    valibot: "npm:1.2.0"
+    valibot: "npm:^1.4.0"
   peerDependencies:
-    "@storybook/addon-vitest": ^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0
-    storybook: ^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0
+    "@storybook/addon-vitest": ^10.6.0
+    storybook: ^10.6.0
   peerDependenciesMeta:
     "@storybook/addon-vitest":
       optional: true
-  checksum: 10c0/c33c506062eeec37d47cfa2dcd0d3076bdc43229b88dae27336af4a33d65c408e3e7de036c36bc99db81a9b3f194fb750de7b1fae98b309433cf03376dd04d18
+  checksum: 10c0/0ff6051f9758ed005419ded68524d4bdf3e4ce0d10aeb563ffa91c213019c62554763f3f749aac77f9d3a05f169c4411421687eaf0ca3650c1af3fafb0421afb
   languageName: node
   linkType: hard
 
@@ -4093,18 +4091,6 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: 10c0/73614dbb3e9c4756a6838525a6c78f85b24a5a09782512a39f24fe5a435992d6af92591ce18ac7a9a08c14aec10c08b158f68126aa29125058e01169c827bed6
-  languageName: node
-  linkType: hard
-
-"@storybook/mcp@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@storybook/mcp@npm:0.8.0"
-  dependencies:
-    "@tmcp/adapter-valibot": "npm:^0.1.5"
-    "@tmcp/transport-http": "npm:^0.8.5"
-    tmcp: "npm:^1.19.4"
-    valibot: "npm:1.2.0"
-  checksum: 10c0/774c6f67c62c7ce6438df46f83ed2a4a75066a2d7003d2db5569ee1d77c174ac6ddb4f7ea0240deb284b614cbe0a8f4bf128dbb4d5484c8d4d84cee29c21605f
   languageName: node
   linkType: hard
 
@@ -5367,7 +5353,7 @@ __metadata:
     "@storybook/addon-a11y": "npm:10.6.0"
     "@storybook/addon-docs": "npm:10.6.0"
     "@storybook/addon-links": "npm:10.6.0"
-    "@storybook/addon-mcp": "npm:0.7.0"
+    "@storybook/addon-mcp": "npm:10.6.0"
     "@storybook/addon-styling-webpack": "npm:^3.0.2"
     "@storybook/addon-webpack5-compiler-babel": "npm:^4.0.1"
     "@storybook/react-webpack5": "npm:10.6.0"
@@ -12873,13 +12859,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picoquery@npm:^2.5.0":
-  version: 2.5.0
-  resolution: "picoquery@npm:2.5.0"
-  checksum: 10c0/ac22a7622ecf6f6c0d2657b04d2ca346f814ff4d343827e6ca53d2d5cecfebee18d80b1290b916d11db6f62866bec26e92bb0a0d7939bd15971e60320db8d265
-  languageName: node
-  linkType: hard
-
 "pify@npm:^4.0.1":
   version: 4.0.1
   resolution: "pify@npm:4.0.1"
@@ -15850,7 +15829,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"valibot@npm:1.2.0, valibot@npm:^1.1.0":
+"valibot@npm:^1.1.0":
   version: 1.2.0
   resolution: "valibot@npm:1.2.0"
   peerDependencies:
@@ -15859,6 +15838,18 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/e6897ed2008fc900380a6ce39b62bc5fca45fd5e070f70571c6380ede3ba026d0b7016230215d87f7f3d672a28dbde5a0522d39830b493fdc3dccd1a59ef4ee6
+  languageName: node
+  linkType: hard
+
+"valibot@npm:^1.4.0":
+  version: 1.5.0
+  resolution: "valibot@npm:1.5.0"
+  peerDependencies:
+    typescript: ">=5"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/d49dab2b2fcbb477c894def73466de598b602859a47ab92b26d387c4d2a472cbfd4ef57b49eea91aeeff143c38f5a9523914dc5a73469ec93c7cfd4326eb5fbf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary

  Upgrades @storybook/addon-mcp from 0.7.0 to 10.6.0, aligning it with the rest of the Storybook 10.6 packages.

### Changes

  - Upgrade @storybook/addon-mcp to 10.6.0.
  - Replace experimentalComponentsManifest with componentsManifest.
  - Remove the obsolete experimentalFormat option.
  - Explicitly disable the unavailable MCP test toolset while retaining the dev and docs toolsets.
  - Refresh the Yarn lockfile and remove obsolete transitive dependencies.