### PR TITLE
Prevent link creation in unlink-only rich text editors

### DIFF
--- a/src/RichTextEditor/RichTextEditor.stories.tsx
+++ b/src/RichTextEditor/RichTextEditor.stories.tsx
@@ -56,6 +56,17 @@ export function LinkOnlyActions() {
   );
 }
 
+export function UnlinkOnlyActions() {
+  return (
+    <RichTextEditor
+      availableActions={[RichTextEditorActions.UNLINK]}
+      id="unlink-only-editor"
+      initialValue="<p><a href='https://example.com'>Existing linked text</a> followed by plain text. Select the link to unlink it, type at its boundary, paste a URL, or drag it to test unlink-only behavior.</p>"
+      onChange={() => null}
+    />
+  );
+}
+
 export function NoActions() {
   return (
     <RichTextEditor

--- a/src/RichTextEditor/RichTextEditor.test.tsx
+++ b/src/RichTextEditor/RichTextEditor.test.tsx
@@ -1,6 +1,12 @@
 import React, { createRef, useEffect, useRef } from 'react';
 
-import { act, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Extension, Mark, type Editor } from '@tiptap/core';
 
@@ -351,6 +357,25 @@ describe('<RichTextEditor />', () => {
     await user.paste('https://example.com');
 
     expect(textbox).toHaveTextContent('https://example.com');
+    expect(textbox.querySelector('a')).not.toBeInTheDocument();
+  });
+
+  it('does not preserve links from rich-text pastes for unlink-only action subsets', async () => {
+    render(<Setup availableActions={[RichTextEditorActions.UNLINK]} />);
+
+    const textbox = await elements.textbox.find();
+    if (!textbox) throw new Error('RichTextEditor textbox was not rendered');
+
+    fireEvent.paste(textbox, {
+      clipboardData: {
+        getData: (type: string) =>
+          type === 'text/html'
+            ? '<p><a href="https://example.com">hello</a></p>'
+            : 'hello',
+      },
+    });
+
+    expect(textbox).toHaveTextContent('hello');
     expect(textbox.querySelector('a')).not.toBeInTheDocument();
   });
 

--- a/src/RichTextEditor/RichTextEditor.test.tsx
+++ b/src/RichTextEditor/RichTextEditor.test.tsx
@@ -9,6 +9,7 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Extension, Mark, type Editor } from '@tiptap/core';
+import { Plugin } from '@tiptap/pm/state';
 
 import RichTextEditor, {
   type RichTextEditorProps,
@@ -445,6 +446,43 @@ describe('<RichTextEditor />', () => {
     expect(onPaste.mock.calls[0][0].slice.content.firstChild?.marks).toEqual(
       [],
     );
+  });
+
+  it('allows custom extensions to handle pastes in unlink-only editors', async () => {
+    const handlePaste = jest.fn((view) => {
+      view.dispatch(view.state.tr.insertText('custom paste'));
+
+      return true;
+    });
+    const CustomPaste = Extension.create({
+      name: 'customPaste',
+      addProseMirrorPlugins() {
+        return [new Plugin({ props: { handlePaste } })];
+      },
+    });
+
+    render(
+      <Setup
+        availableActions={[RichTextEditorActions.UNLINK]}
+        customExtensions={[CustomPaste]}
+      />,
+    );
+
+    const textbox = await elements.textbox.find();
+    if (!textbox) throw new Error('RichTextEditor textbox was not rendered');
+
+    fireEvent.paste(textbox, {
+      clipboardData: {
+        getData: (type: string) =>
+          type === 'text/html'
+            ? '<p><a href="https://example.com">hello</a></p>'
+            : 'hello',
+      },
+    });
+
+    expect(handlePaste).toHaveBeenCalledTimes(1);
+    expect(textbox).toHaveTextContent('custom paste');
+    expect(textbox.querySelector('a')).not.toBeInTheDocument();
   });
 
   it('preserves links in dragged content for unlink-only action subsets', async () => {

--- a/src/RichTextEditor/RichTextEditor.test.tsx
+++ b/src/RichTextEditor/RichTextEditor.test.tsx
@@ -19,6 +19,8 @@ import {
   RichTextEditorDefaultActionsArray,
 } from './richTextEditorActions';
 
+import type { Slice } from '@tiptap/pm/model';
+
 describe('<RichTextEditor />', () => {
   const emptyRect = {
     bottom: 0,
@@ -409,7 +411,9 @@ describe('<RichTextEditor />', () => {
   });
 
   it('notifies paste observers in unlink-only editors', async () => {
-    const onPaste = jest.fn();
+    const onPaste = jest.fn(({ editor }: { editor: Editor; slice: Slice }) => {
+      editor.commands.insertContent('before ');
+    });
     const ObservePaste = Extension.create({
       name: 'observePaste',
       onCreate() {
@@ -437,6 +441,7 @@ describe('<RichTextEditor />', () => {
     });
 
     expect(onPaste).toHaveBeenCalledTimes(1);
+    expect(textbox).toHaveTextContent('before hello');
     expect(onPaste.mock.calls[0][0].slice.content.firstChild?.marks).toEqual(
       [],
     );

--- a/src/RichTextEditor/RichTextEditor.test.tsx
+++ b/src/RichTextEditor/RichTextEditor.test.tsx
@@ -379,6 +379,42 @@ describe('<RichTextEditor />', () => {
     expect(textbox.querySelector('a')).not.toBeInTheDocument();
   });
 
+  it('preserves links in dragged content for unlink-only action subsets', async () => {
+    let editor: Editor | undefined;
+    const CaptureEditor = Extension.create({
+      name: 'captureEditor',
+      onCreate() {
+        const { editor: capturedEditor } = this;
+        editor = capturedEditor;
+      },
+    });
+
+    render(
+      <Setup
+        availableActions={[RichTextEditorActions.UNLINK]}
+        customExtensions={[CaptureEditor]}
+        initialValue='<p><a href="https://example.com">hello</a></p>'
+      />,
+    );
+
+    await screen.findByRole('link', { name: 'hello' });
+    const tiptapEditor = editor;
+    if (!tiptapEditor) throw new Error('RichTextEditor was not created');
+
+    const draggedSlice = tiptapEditor.state.doc.slice(1, 6);
+    let transformedSlice = draggedSlice;
+
+    tiptapEditor.view.someProp('transformPasted', (transform) => {
+      transformedSlice = transform(transformedSlice, tiptapEditor.view, false);
+    });
+
+    expect(
+      transformedSlice.content.firstChild?.marks.some(
+        (mark) => mark.type.name === 'link',
+      ),
+    ).toBe(true);
+  });
+
   it('does not extend existing links for unlink-only action subsets', async () => {
     let editor: Editor | undefined;
     const CaptureEditor = Extension.create({

--- a/src/RichTextEditor/RichTextEditor.test.tsx
+++ b/src/RichTextEditor/RichTextEditor.test.tsx
@@ -379,6 +379,69 @@ describe('<RichTextEditor />', () => {
     expect(textbox.querySelector('a')).not.toBeInTheDocument();
   });
 
+  it('does not delete selected content when an empty clipboard is pasted in an unlink-only editor', async () => {
+    let editor: Editor | undefined;
+    const CaptureEditor = Extension.create({
+      name: 'captureEditor',
+      onCreate() {
+        const { editor: capturedEditor } = this;
+        editor = capturedEditor;
+      },
+    });
+
+    render(
+      <Setup
+        availableActions={[RichTextEditorActions.UNLINK]}
+        customExtensions={[CaptureEditor]}
+        initialValue="<p>hello</p>"
+      />,
+    );
+
+    const textbox = await elements.textbox.find();
+    if (!textbox) throw new Error('RichTextEditor textbox was not rendered');
+
+    act(() => editor?.commands.setTextSelection({ from: 1, to: 6 }));
+    fireEvent.paste(textbox, {
+      clipboardData: { getData: () => '' },
+    });
+
+    expect(textbox).toHaveTextContent('hello');
+  });
+
+  it('notifies paste observers in unlink-only editors', async () => {
+    const onPaste = jest.fn();
+    const ObservePaste = Extension.create({
+      name: 'observePaste',
+      onCreate() {
+        this.editor.on('paste', onPaste);
+      },
+    });
+
+    render(
+      <Setup
+        availableActions={[RichTextEditorActions.UNLINK]}
+        customExtensions={[ObservePaste]}
+      />,
+    );
+
+    const textbox = await elements.textbox.find();
+    if (!textbox) throw new Error('RichTextEditor textbox was not rendered');
+
+    fireEvent.paste(textbox, {
+      clipboardData: {
+        getData: (type: string) =>
+          type === 'text/html'
+            ? '<p><a href="https://example.com">hello</a></p>'
+            : 'hello',
+      },
+    });
+
+    expect(onPaste).toHaveBeenCalledTimes(1);
+    expect(onPaste.mock.calls[0][0].slice.content.firstChild?.marks).toEqual(
+      [],
+    );
+  });
+
   it('preserves links in dragged content for unlink-only action subsets', async () => {
     let editor: Editor | undefined;
     const CaptureEditor = Extension.create({

--- a/src/RichTextEditor/RichTextEditor.test.tsx
+++ b/src/RichTextEditor/RichTextEditor.test.tsx
@@ -2,7 +2,7 @@ import React, { createRef, useEffect, useRef } from 'react';
 
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Mark } from '@tiptap/core';
+import { Extension, Mark, type Editor } from '@tiptap/core';
 
 import RichTextEditor, {
   type RichTextEditorProps,
@@ -284,10 +284,19 @@ describe('<RichTextEditor />', () => {
   it('supports unlink-only action subsets', async () => {
     const onChange = jest.fn();
     const user = userEvent.setup();
+    let editor: Editor | undefined;
+    const CaptureEditor = Extension.create({
+      name: 'captureEditor',
+      onCreate() {
+        const { editor: capturedEditor } = this;
+        editor = capturedEditor;
+      },
+    });
 
     render(
       <Setup
         availableActions={[RichTextEditorActions.UNLINK]}
+        customExtensions={[CaptureEditor]}
         initialValue='<p><a href="https://example.com">hello</a></p>'
         onChange={onChange}
       />,
@@ -297,6 +306,8 @@ describe('<RichTextEditor />', () => {
     expect(
       screen.queryByRole('button', { name: /^link$/i }),
     ).not.toBeInTheDocument();
+
+    act(() => editor?.commands.setTextSelection({ from: 1, to: 6 }));
 
     const unlinkButton = await screen.findByRole('button', {
       name: /unlink/i,
@@ -326,6 +337,52 @@ describe('<RichTextEditor />', () => {
     expect(textbox.querySelector('a')).not.toBeInTheDocument();
 
     prompt.mockRestore();
+  });
+
+  it('does not link pasted URLs for unlink-only action subsets', async () => {
+    const user = userEvent.setup();
+
+    render(<Setup availableActions={[RichTextEditorActions.UNLINK]} />);
+
+    const textbox = await elements.textbox.find();
+    if (!textbox) throw new Error('RichTextEditor textbox was not rendered');
+
+    await user.click(textbox);
+    await user.paste('https://example.com');
+
+    expect(textbox).toHaveTextContent('https://example.com');
+    expect(textbox.querySelector('a')).not.toBeInTheDocument();
+  });
+
+  it('does not extend existing links for unlink-only action subsets', async () => {
+    let editor: Editor | undefined;
+    const CaptureEditor = Extension.create({
+      name: 'captureEditor',
+      onCreate() {
+        const { editor: capturedEditor } = this;
+        editor = capturedEditor;
+      },
+    });
+
+    render(
+      <Setup
+        availableActions={[RichTextEditorActions.UNLINK]}
+        customExtensions={[CaptureEditor]}
+        initialValue='<p><a href="https://example.com">hello</a></p>'
+      />,
+    );
+
+    await screen.findByRole('link', { name: 'hello' });
+
+    act(() => {
+      editor?.commands.setTextSelection(6);
+      editor?.commands.insertContent(' world');
+    });
+
+    expect(
+      await screen.findByRole('link', { name: 'hello' }),
+    ).toHaveTextContent('hello');
+    expect(await elements.textbox.find()).toHaveTextContent('hello world');
   });
 
   it('updates toolbar and character count state after transactions', async () => {

--- a/src/RichTextEditor/RichTextEditor.tsx
+++ b/src/RichTextEditor/RichTextEditor.tsx
@@ -16,6 +16,13 @@ import { BulletList, ListItem, OrderedList } from '@tiptap/extension-list';
 import Paragraph from '@tiptap/extension-paragraph';
 import Text from '@tiptap/extension-text';
 import { CharacterCount, Placeholder, UndoRedo } from '@tiptap/extensions';
+import {
+  Fragment,
+  Slice,
+  type MarkType,
+  type Node as ProseMirrorNode,
+} from '@tiptap/pm/model';
+import { Plugin } from '@tiptap/pm/state';
 import { EditorContent, useEditor, useEditorState } from '@tiptap/react';
 import classNames from 'classnames';
 import sanitizeHtml from 'sanitize-html';
@@ -44,12 +51,45 @@ const ExtendedLink = Link.extend({
   },
 });
 
+function stripLinkMarks(fragment: Fragment, linkType: MarkType) {
+  const nodes: ProseMirrorNode[] = [];
+
+  fragment.forEach((node) => {
+    const content = node.content.size
+      ? stripLinkMarks(node.content, linkType)
+      : node.content;
+
+    nodes.push(
+      node
+        .copy(content)
+        .mark(node.marks.filter((mark) => mark.type !== linkType)),
+    );
+  });
+
+  return Fragment.fromArray(nodes);
+}
+
 const UnlinkOnlyLink = Link.configure({
   autolink: false,
   linkOnPaste: false,
 }).extend({
   addPasteRules() {
     return [];
+  },
+  addProseMirrorPlugins() {
+    return [
+      ...(this.parent?.() ?? []),
+      new Plugin({
+        props: {
+          transformPasted: (slice) =>
+            new Slice(
+              stripLinkMarks(slice.content, this.type),
+              slice.openStart,
+              slice.openEnd,
+            ),
+        },
+      }),
+    ];
   },
 });
 

--- a/src/RichTextEditor/RichTextEditor.tsx
+++ b/src/RichTextEditor/RichTextEditor.tsx
@@ -81,12 +81,31 @@ const UnlinkOnlyLink = Link.configure({
       ...(this.parent?.() ?? []),
       new Plugin({
         props: {
-          transformPasted: (slice) =>
-            new Slice(
+          handlePaste: (view, _event, slice) => {
+            const linkFreeSlice = new Slice(
               stripLinkMarks(slice.content, this.type),
               slice.openStart,
               slice.openEnd,
-            ),
+            );
+            const singleNode =
+              linkFreeSlice.openStart === 0 &&
+              linkFreeSlice.openEnd === 0 &&
+              linkFreeSlice.content.childCount === 1
+                ? linkFreeSlice.content.firstChild
+                : null;
+            const transaction = singleNode
+              ? view.state.tr.replaceSelectionWith(singleNode, false)
+              : view.state.tr.replaceSelection(linkFreeSlice);
+
+            view.dispatch(
+              transaction
+                .scrollIntoView()
+                .setMeta('paste', true)
+                .setMeta('uiEvent', 'paste'),
+            );
+
+            return true;
+          },
         },
       }),
     ];

--- a/src/RichTextEditor/RichTextEditor.tsx
+++ b/src/RichTextEditor/RichTextEditor.tsx
@@ -95,15 +95,16 @@ const UnlinkOnlyLink = Link.configure({
               linkFreeSlice.content.childCount === 1
                 ? linkFreeSlice.content.firstChild
                 : null;
-            const transaction = singleNode
-              ? view.state.tr.replaceSelectionWith(singleNode, false)
-              : view.state.tr.replaceSelection(linkFreeSlice);
 
             this.editor.emit('paste', {
               editor: this.editor,
               event,
               slice: linkFreeSlice,
             });
+            const transaction = singleNode
+              ? view.state.tr.replaceSelectionWith(singleNode, false)
+              : view.state.tr.replaceSelection(linkFreeSlice);
+
             view.dispatch(
               transaction
                 .scrollIntoView()

--- a/src/RichTextEditor/RichTextEditor.tsx
+++ b/src/RichTextEditor/RichTextEditor.tsx
@@ -81,7 +81,9 @@ const UnlinkOnlyLink = Link.configure({
       ...(this.parent?.() ?? []),
       new Plugin({
         props: {
-          handlePaste: (view, _event, slice) => {
+          handlePaste: (view, event, slice) => {
+            if (slice.content.size === 0) return false;
+
             const linkFreeSlice = new Slice(
               stripLinkMarks(slice.content, this.type),
               slice.openStart,
@@ -97,6 +99,11 @@ const UnlinkOnlyLink = Link.configure({
               ? view.state.tr.replaceSelectionWith(singleNode, false)
               : view.state.tr.replaceSelection(linkFreeSlice);
 
+            this.editor.emit('paste', {
+              editor: this.editor,
+              event,
+              slice: linkFreeSlice,
+            });
             view.dispatch(
               transaction
                 .scrollIntoView()

--- a/src/RichTextEditor/RichTextEditor.tsx
+++ b/src/RichTextEditor/RichTextEditor.tsx
@@ -7,6 +7,12 @@ import React, {
   useRef,
 } from 'react';
 
+import {
+  Extension,
+  type Editor,
+  type Node as TipTapNode,
+  type Mark,
+} from '@tiptap/core';
 import Bold from '@tiptap/extension-bold';
 import Document from '@tiptap/extension-document';
 import HardBreak from '@tiptap/extension-hard-break';
@@ -36,7 +42,6 @@ import {
 } from './richTextEditorActions';
 import RichTextEditorMenuBar from './RichTextEditorMenuBar';
 
-import type { Editor, Extension, Node as TipTapNode, Mark } from '@tiptap/core';
 import type { IOptions } from 'sanitize-html';
 
 import './RichTextEditor.scss';
@@ -76,16 +81,22 @@ const UnlinkOnlyLink = Link.configure({
   addPasteRules() {
     return [];
   },
+});
+
+const UnlinkOnlyPaste = Extension.create({
+  name: 'unlinkOnlyPaste',
   addProseMirrorPlugins() {
     return [
-      ...(this.parent?.() ?? []),
       new Plugin({
         props: {
           handlePaste: (view, event, slice) => {
             if (slice.content.size === 0) return false;
 
             const linkFreeSlice = new Slice(
-              stripLinkMarks(slice.content, this.type),
+              stripLinkMarks(
+                slice.content,
+                this.editor.schema.marks[RichTextEditorActions.LINK],
+              ),
               slice.openStart,
               slice.openEnd,
             );
@@ -237,6 +248,11 @@ const RichTextEditor = forwardRef(
     ref: ForwardedRef<RichTextEditorRef>,
   ) => {
     const oneLineExtension = isOneLine ? [OneLineLimit] : [];
+    const unlinkOnlyExtension =
+      availableActions.includes(RichTextEditorActions.UNLINK) &&
+      !availableActions.includes(RichTextEditorActions.LINK)
+        ? [UnlinkOnlyPaste]
+        : [];
 
     const requiredExtensions = [
       Document,
@@ -290,6 +306,7 @@ const RichTextEditor = forwardRef(
       ...requiredExtensions,
       ...optionalExtensions,
       ...oneLineExtension,
+      ...unlinkOnlyExtension,
       ...customExtensions,
     ];
 

--- a/src/RichTextEditor/RichTextEditor.tsx
+++ b/src/RichTextEditor/RichTextEditor.tsx
@@ -48,8 +48,9 @@ const UnlinkOnlyLink = Link.configure({
   autolink: false,
   linkOnPaste: false,
 }).extend({
-  // Link derives inclusivity from autolink; retain it so existing links can be removed.
-  inclusive: () => true,
+  addPasteRules() {
+    return [];
+  },
 });
 
 export type RichTextEditorProps = {


### PR DESCRIPTION
~It's not clear to me if this is a regression vs. Codex going overboard in finding bugs, but figured I'd throw it up anyway~

There is an actual regression with the Tiptap 3 merge earlier, although its an edge case, would like to get this in before deploying.

---

  #### What was the actual regression?

  The paste interception added for unlink-only mode initially consumed every non-empty paste before custom extensions could process it. This silently bypassed supported custom handlePaste handlers.

  Earlier iterations of the interceptor also exposed related regressions around drag-and-drop, empty clipboard pastes, Tiptap paste notifications, and observers that synchronously changed editor state.

  The final implementation separates paste sanitization from the high-priority Link mark. Custom paste handlers now get first refusal; unhandled pastes fall through to unlink-only link stripping. Paste transactions are built after notifying observers so synchronous state changes do not produce mismatched transactions.

  #### What was the enhancement?

  Unlink-only mode was not previously a functional configuration: the Link extension was installed only when LINK was present. This PR makes [UNLINK] a supported configuration where existing links remain removable, but users cannot create new links through:

  - The toolbar or Mod-K
  - Typed URL autolinking
  - Plain-text URL pastes
  - Rich HTML pastes
  - Typing at an existing link boundary

  It also adds an UnlinkOnlyActions Storybook story for manual regression testing.

  #### Testing

  Coverage includes:

  - Removing existing links
  - Blocking Mod-K and typed autolinks
  - Plain-text and rich HTML pastes
  - Non-inclusive link boundaries
  - Link-preserving drag-and-drop
  - Empty clipboard behavior
  - Paste notifications
  - Synchronous paste-observer mutations
  - Custom handlePaste extensions

  All 66 unit tests, formatting, lint/type checks, production build, and Storybook browser tests pass.

  Rails currently does not configure an unlink-only editor, so no Rails-specific behavior or test changes are required.